### PR TITLE
[FE] App Homepage & BusyBuddy Homepage Refinements

### DIFF
--- a/demo/issue-28-demo.html
+++ b/demo/issue-28-demo.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BusyBuddy - Issue #28 Demo: Homepage & App Refinements</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css" rel="stylesheet">
+    <style>
+        :root {
+            --primary-dark: #303030;
+            --secondary-gray: #616161;
+            --bg-light: #f1f2f4;
+            --border-color: #e3e3e3;
+        }
+        
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+            background-color: #fafafa;
+        }
+        
+        .demo-section {
+            background: white;
+            border-radius: 16px;
+            padding: 32px;
+            margin-bottom: 32px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+        }
+        
+        .demo-header {
+            border-bottom: 2px solid var(--primary-dark);
+            padding-bottom: 16px;
+            margin-bottom: 24px;
+        }
+        
+        .demo-header h2 {
+            color: var(--primary-dark);
+            font-weight: 700;
+            margin: 0;
+        }
+        
+        .demo-note {
+            background: #f8f9fa;
+            border-left: 4px solid #007bff;
+            padding: 12px 16px;
+            margin: 16px 0;
+            font-size: 14px;
+            color: var(--secondary-gray);
+        }
+        
+        .plan-banner {
+            background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
+            border: 1px solid #90caf9;
+            border-radius: 12px;
+            padding: 16px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        
+        .toggle-switch {
+            width: 132px;
+            height: 48px;
+            border-radius: 15px;
+            position: relative;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+        
+        .toggle-switch.active { background-color: #198754; }
+        .toggle-switch.inactive { background-color: #dc3545; }
+        .toggle-switch.loading { background-color: #6c757d; }
+        
+        .toggle-slider {
+            width: 50px;
+            height: 40px;
+            background: white;
+            border-radius: 11px;
+            position: absolute;
+            top: 4px;
+            transition: left 0.3s ease;
+        }
+        
+        .toggle-switch.active .toggle-slider { left: 78px; }
+        .toggle-switch.inactive .toggle-slider { left: 5px; }
+        .toggle-switch.loading .toggle-slider { left: 41px; }
+        
+        .toggle-label {
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            color: white;
+            font-weight: 500;
+            font-size: 14px;
+        }
+        
+        .toggle-label.left { left: 16px; }
+        .toggle-label.right { right: 16px; }
+        
+        .video-container {
+            background: #1a1a1a;
+            border-radius: 15px;
+            aspect-ratio: 16/9;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+        }
+        
+        .video-list-item {
+            border: 1px solid var(--border-color);
+            border-radius: 12px;
+            padding: 16px;
+            margin-bottom: 8px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+        
+        .video-list-item:hover { border-color: var(--primary-dark); background: #f8f9fa; }
+        .video-list-item.active { border: 2px solid var(--primary-dark); background: #f8f9fa; }
+        
+        .video-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        
+        .video-icon.active { background: var(--primary-dark); color: white; }
+        .video-icon.inactive { background: var(--bg-light); color: var(--secondary-gray); }
+        
+        .app-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 20px 0;
+            border-bottom: 1px solid var(--border-color);
+            margin-bottom: 24px;
+        }
+        
+        .app-title-section {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+        
+        .app-title {
+            font-size: 24px;
+            font-weight: 600;
+            color: var(--primary-dark);
+            margin: 0;
+        }
+        
+        .create-btn {
+            background: var(--primary-dark);
+            color: white;
+            border: none;
+            border-radius: 12px;
+            padding: 12px 24px;
+            font-weight: 600;
+            font-size: 14px;
+            min-width: 180px;
+        }
+        
+        .app-tabs {
+            display: flex;
+            gap: 8px;
+            background: var(--bg-light);
+            padding: 4px;
+            border-radius: 15px;
+        }
+        
+        .app-tab {
+            padding: 12px 24px;
+            border-radius: 12px;
+            border: none;
+            font-weight: 600;
+            font-size: 13px;
+            background: transparent;
+            color: #4A4A4A;
+        }
+        
+        .app-tab.active { background: var(--primary-dark); color: white; }
+        
+        .comparison-row { display: flex; gap: 24px; margin-bottom: 24px; }
+        .comparison-col { flex: 1; padding: 20px; border-radius: 12px; }
+        .before { background: #ffebee; border: 2px solid #ef5350; }
+        .after { background: #e8f5e9; border: 2px solid #66bb6a; }
+        
+        .comparison-label {
+            font-weight: 700;
+            font-size: 14px;
+            margin-bottom: 12px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .before .comparison-label { color: #c62828; }
+        .after .comparison-label { color: #2e7d32; }
+        
+        .checklist { list-style: none; padding: 0; margin: 0; }
+        .checklist li {
+            padding: 12px 0;
+            border-bottom: 1px solid var(--border-color);
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+        .checklist li:last-child { border-bottom: none; }
+        
+        .check-icon {
+            width: 24px;
+            height: 24px;
+            border-radius: 50%;
+            background: #e8f5e9;
+            color: #2e7d32;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        
+        .loading-spinner {
+            width: 16px;
+            height: 16px;
+            border: 2px solid #007bff;
+            border-top-color: transparent;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        
+        @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
+</head>
+<body>
+    <div class="container py-5">
+        <div class="text-center mb-5">
+            <h1 class="fw-bold">Issue #28 Implementation Demo</h1>
+            <p class="lead text-muted">[FE] App Homepage & BusyBuddy Homepage Refinements</p>
+            <a href="https://github.com/11thandOrange/BusyBuddy_v2/issues/28" target="_blank" class="btn btn-outline-dark">
+                <i class="bi bi-github"></i> View Issue on GitHub
+            </a>
+        </div>
+
+        <!-- Acceptance Criteria -->
+        <div class="demo-section">
+            <div class="demo-header">
+                <h2><i class="bi bi-check2-square"></i> Acceptance Criteria</h2>
+            </div>
+            <ul class="checklist">
+                <li><span class="check-icon"><i class="bi bi-check"></i></span><div><strong>Subtask #37:</strong> Hide Plan Banner When User Is On the Highest Plan</div></li>
+                <li><span class="check-icon"><i class="bi bi-check"></i></span><div><strong>Subtask #38:</strong> App Overview Tabs Render A List Of Videos</div></li>
+                <li><span class="check-icon"><i class="bi bi-check"></i></span><div><strong>Subtask #39:</strong> Re-Order App Header Buttons</div></li>
+                <li><span class="check-icon"><i class="bi bi-check"></i></span><div><strong>Subtask #40:</strong> Fix Active/Inactive Toggle Flash On Load</div></li>
+            </ul>
+        </div>
+
+        <!-- Subtask #37 -->
+        <div class="demo-section">
+            <div class="demo-header d-flex justify-content-between align-items-center">
+                <h2><i class="bi bi-eye-slash"></i> Subtask #37: Hide Plan Banner</h2>
+                <span class="badge bg-success">Completed</span>
+            </div>
+            <div class="demo-note">When a merchant is on the Advanced plan (highest tier), the plan upgrade banner is hidden.</div>
+            <div class="comparison-row">
+                <div class="comparison-col before">
+                    <div class="comparison-label"><i class="bi bi-x-circle"></i> BEFORE (Advanced Plan)</div>
+                    <div class="plan-banner">
+                        <div><strong>Current Plan: Advanced</strong><p class="mb-0 small text-muted">You have full access.</p></div>
+                        <button class="btn btn-primary btn-sm">View Plans</button>
+                    </div>
+                </div>
+                <div class="comparison-col after">
+                    <div class="comparison-label"><i class="bi bi-check-circle"></i> AFTER (Advanced Plan)</div>
+                    <div class="text-center py-4 text-muted">
+                        <i class="bi bi-eye-slash" style="font-size: 32px;"></i>
+                        <p class="mb-0 mt-2">Banner Hidden</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Subtask #38 -->
+        <div class="demo-section">
+            <div class="demo-header d-flex justify-content-between align-items-center">
+                <h2><i class="bi bi-play-circle"></i> Subtask #38: Video List in Overview</h2>
+                <span class="badge bg-success">Completed</span>
+            </div>
+            <div class="demo-note">Each app's Overview tab now renders a clickable list of videos. Video on left, list on right.</div>
+            <div class="comparison-row">
+                <div class="comparison-col before">
+                    <div class="comparison-label"><i class="bi bi-x-circle"></i> BEFORE</div>
+                    <div class="video-container" style="height: 150px;">
+                        <div class="text-center"><i class="bi bi-play-circle" style="font-size: 48px;"></i><p class="mb-0 mt-2">Single video</p></div>
+                    </div>
+                </div>
+                <div class="comparison-col after">
+                    <div class="comparison-label"><i class="bi bi-check-circle"></i> AFTER</div>
+                    <div class="row g-2">
+                        <div class="col-7">
+                            <div class="video-container" style="height: 120px;"><i class="bi bi-play-circle" style="font-size: 32px;"></i></div>
+                        </div>
+                        <div class="col-5">
+                            <div class="video-list-item active p-2">
+                                <div class="d-flex align-items-center gap-2">
+                                    <div class="video-icon active" style="width:30px;height:30px;"><i class="bi bi-play-fill"></i></div>
+                                    <small><strong>Getting Started</strong></small>
+                                </div>
+                            </div>
+                            <div class="video-list-item p-2">
+                                <div class="d-flex align-items-center gap-2">
+                                    <div class="video-icon inactive" style="width:30px;height:30px;"><i class="bi bi-play-fill"></i></div>
+                                    <small><strong>Customization</strong></small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Subtask #39 -->
+        <div class="demo-section">
+            <div class="demo-header d-flex justify-content-between align-items-center">
+                <h2><i class="bi bi-arrows-move"></i> Subtask #39: Re-Order Header Buttons</h2>
+                <span class="badge bg-success">Completed</span>
+            </div>
+            <div class="demo-note">Create button now in top right. Active/Inactive toggle inline with app title.</div>
+            <div class="comparison-row">
+                <div class="comparison-col before">
+                    <div class="comparison-label"><i class="bi bi-x-circle"></i> BEFORE</div>
+                    <div style="background: var(--bg-light); padding: 12px; border-radius: 12px;">
+                        <div class="d-flex justify-content-between mb-2">
+                            <div class="app-tabs"><button class="app-tab active">Overview</button></div>
+                            <button class="create-btn btn-sm" style="padding:8px 16px;">Create</button>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <strong>Bundle Discount</strong>
+                            <div class="toggle-switch inactive" style="transform: scale(0.6);"><div class="toggle-slider"></div></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="comparison-col after">
+                    <div class="comparison-label"><i class="bi bi-check-circle"></i> AFTER</div>
+                    <div style="background: var(--bg-light); padding: 12px; border-radius: 12px;">
+                        <div class="d-flex justify-content-between align-items-center mb-2 pb-2" style="border-bottom: 1px solid var(--border-color);">
+                            <div class="d-flex align-items-center gap-2">
+                                <strong>Bundle Discount</strong>
+                                <div class="toggle-switch active" style="transform: scale(0.5);"><div class="toggle-slider"></div></div>
+                            </div>
+                            <button class="create-btn btn-sm" style="padding:6px 12px;font-size:12px;">Create Bundle</button>
+                        </div>
+                        <div class="app-tabs"><button class="app-tab active" style="padding:8px 16px;">Overview</button></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Subtask #40 -->
+        <div class="demo-section">
+            <div class="demo-header d-flex justify-content-between align-items-center">
+                <h2><i class="bi bi-lightning"></i> Subtask #40: Toggle Flash Fix</h2>
+                <span class="badge bg-success">Completed</span>
+            </div>
+            <div class="demo-note">Toggle no longer flashes red/inactive on load. Shows neutral gray loading state.</div>
+            <div class="comparison-row">
+                <div class="comparison-col before">
+                    <div class="comparison-label"><i class="bi bi-x-circle"></i> BEFORE</div>
+                    <div class="text-center">
+                        <div class="toggle-switch inactive mx-auto mb-2"><div class="toggle-slider"></div><span class="toggle-label right">Inactive</span></div>
+                        <i class="bi bi-arrow-down"></i>
+                        <div class="toggle-switch active mx-auto mt-2"><div class="toggle-slider"></div><span class="toggle-label left">Active</span></div>
+                        <small class="text-muted d-block mt-2">Flashes red first</small>
+                    </div>
+                </div>
+                <div class="comparison-col after">
+                    <div class="comparison-label"><i class="bi bi-check-circle"></i> AFTER</div>
+                    <div class="text-center">
+                        <div class="toggle-switch loading mx-auto mb-2"><div class="toggle-slider"></div><div class="position-absolute w-100 h-100 d-flex align-items-center justify-content-center" style="top:0;left:0;"><div class="loading-spinner"></div></div></div>
+                        <i class="bi bi-arrow-down"></i>
+                        <div class="toggle-switch active mx-auto mt-2"><div class="toggle-slider"></div><span class="toggle-label left">Active</span></div>
+                        <small class="text-success d-block mt-2">Neutral gray loading</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Files Changed -->
+        <div class="demo-section">
+            <div class="demo-header"><h2><i class="bi bi-file-earmark-code"></i> Files Changed</h2></div>
+            <table class="table table-hover">
+                <thead><tr><th>File</th><th>Change</th><th>Subtask</th></tr></thead>
+                <tbody>
+                    <tr><td><code>web/frontend/pages/index.jsx</code></td><td>Hide plan banner for Advanced plan</td><td><span class="badge bg-primary">#37</span></td></tr>
+                    <tr><td><code>web/frontend/components/VideoList.jsx</code></td><td>New video list component</td><td><span class="badge bg-primary">#38</span></td></tr>
+                    <tr><td><code>web/frontend/apps/*/DiscountList.jsx</code></td><td>Updated 7 files with VideoList</td><td><span class="badge bg-primary">#38</span></td></tr>
+                    <tr><td><code>web/frontend/components/AppHeader.jsx</code></td><td>New header component</td><td><span class="badge bg-primary">#39</span></td></tr>
+                    <tr><td><code>web/frontend/components/ToggelSwitch.jsx</code></td><td>Fixed flash issue</td><td><span class="badge bg-primary">#40</span></td></tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="text-center text-muted py-4">
+            <p class="mb-1">BusyBuddy v2 - Issue #28 Implementation</p>
+            <small>Demo page showcasing UI changes - Shopify app not required</small>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/demo/issue-28-demo.html
+++ b/demo/issue-28-demo.html
@@ -327,34 +327,39 @@
                 <h2><i class="bi bi-arrows-move"></i> Subtask #39: Re-Order Header Buttons</h2>
                 <span class="badge bg-success">Completed</span>
             </div>
-            <div class="demo-note">Create button now in top right. Active/Inactive toggle inline with app title.</div>
-            <div class="comparison-row">
-                <div class="comparison-col before">
-                    <div class="comparison-label"><i class="bi bi-x-circle"></i> BEFORE</div>
-                    <div style="background: var(--bg-light); padding: 12px; border-radius: 12px;">
-                        <div class="d-flex justify-content-between mb-2">
-                            <div class="app-tabs"><button class="app-tab active">Overview</button></div>
-                            <button class="create-btn btn-sm" style="padding:8px 16px;">Create</button>
-                        </div>
-                        <div class="d-flex justify-content-between align-items-center">
-                            <strong>Bundle Discount</strong>
-                            <div class="toggle-switch inactive" style="transform: scale(0.6);"><div class="toggle-slider"></div></div>
-                        </div>
+            <div class="demo-note">
+                <strong>Header Layout:</strong><br>
+                • Left Column: Title (left) + Toggle (right)<br>
+                • Right Column: Create button (regular apps) OR "Create Another Discount" + "Create" (bundle apps)
+            </div>
+            
+            <!-- Regular App Example -->
+            <h5 class="mt-4 mb-3">Regular App (e.g., Announcement Bar)</h5>
+            <div style="background: var(--bg-light); padding: 16px; border-radius: 12px; margin-bottom: 20px;">
+                <div class="d-flex justify-content-between align-items-center pb-3 mb-3" style="border-bottom: 1px solid var(--border-color);">
+                    <div class="d-flex justify-content-between align-items-center" style="flex: 1; max-width: 50%;">
+                        <strong style="font-size: 18px;">Announcement Bar</strong>
+                        <div class="toggle-switch active" style="transform: scale(0.6);"><div class="toggle-slider"></div></div>
+                    </div>
+                    <button class="create-btn" style="padding:10px 20px;">Create Announcement</button>
+                </div>
+                <div class="app-tabs"><button class="app-tab active" style="padding:8px 16px;">Overview</button><button class="app-tab" style="padding:8px 16px;">Settings</button></div>
+            </div>
+            
+            <!-- Bundle App Example -->
+            <h5 class="mb-3">Bundle App (e.g., Bundle Discount)</h5>
+            <div style="background: var(--bg-light); padding: 16px; border-radius: 12px;">
+                <div class="d-flex justify-content-between align-items-center pb-3 mb-3" style="border-bottom: 1px solid var(--border-color);">
+                    <div class="d-flex justify-content-between align-items-center" style="flex: 1; max-width: 50%;">
+                        <strong style="font-size: 18px;">Bundle Discount</strong>
+                        <div class="toggle-switch active" style="transform: scale(0.6);"><div class="toggle-slider"></div></div>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <button style="background: white; border: 1px solid #e3e3e3; border-radius: 12px; padding: 10px 16px; font-weight: 600; font-size: 13px;">Create Another Discount</button>
+                        <button class="create-btn" style="padding:10px 20px;">Create Bundle</button>
                     </div>
                 </div>
-                <div class="comparison-col after">
-                    <div class="comparison-label"><i class="bi bi-check-circle"></i> AFTER</div>
-                    <div style="background: var(--bg-light); padding: 12px; border-radius: 12px;">
-                        <div class="d-flex justify-content-between align-items-center mb-2 pb-2" style="border-bottom: 1px solid var(--border-color);">
-                            <div class="d-flex align-items-center gap-2">
-                                <strong>Bundle Discount</strong>
-                                <div class="toggle-switch active" style="transform: scale(0.5);"><div class="toggle-slider"></div></div>
-                            </div>
-                            <button class="create-btn btn-sm" style="padding:6px 12px;font-size:12px;">Create Bundle</button>
-                        </div>
-                        <div class="app-tabs"><button class="app-tab active" style="padding:8px 16px;">Overview</button></div>
-                    </div>
-                </div>
+                <div class="app-tabs"><button class="app-tab active" style="padding:8px 16px;">Overview</button><button class="app-tab" style="padding:8px 16px;">Discounts</button></div>
             </div>
         </div>
 

--- a/demo/issue-28-demo.html
+++ b/demo/issue-28-demo.html
@@ -328,38 +328,44 @@
                 <span class="badge bg-success">Completed</span>
             </div>
             <div class="demo-note">
-                <strong>Header Layout:</strong><br>
-                • Left Column: Title (left) + Toggle (right)<br>
-                • Right Column: Create button (regular apps) OR "Create Another Discount" + "Create" (bundle apps)
+                <strong>Page Structure:</strong><br>
+                • ONE header at the top (in parent component, e.g., BundleForm.jsx)<br>
+                • Header: [Title | Toggle] on left, [Create Another Discount (bundle only) | Toggle] on right<br>
+                • Body: Just tabs (Overview, Discounts, Settings, Analytics) - NO buttons in tab row<br>
+                • DiscountList.jsx only contains tabs + content (no header)
             </div>
             
-            <!-- Regular App Example -->
-            <h5 class="mt-4 mb-3">Regular App (e.g., Announcement Bar)</h5>
-            <div style="background: var(--bg-light); padding: 16px; border-radius: 12px; margin-bottom: 20px;">
-                <div class="d-flex justify-content-between align-items-center pb-3 mb-3" style="border-bottom: 1px solid var(--border-color);">
-                    <div class="d-flex justify-content-between align-items-center" style="flex: 1; max-width: 50%;">
-                        <strong style="font-size: 18px;">Announcement Bar</strong>
-                        <div class="toggle-switch active" style="transform: scale(0.6);"><div class="toggle-slider"></div></div>
-                    </div>
-                    <button class="create-btn" style="padding:10px 20px;">Create Announcement</button>
-                </div>
-                <div class="app-tabs"><button class="app-tab active" style="padding:8px 16px;">Overview</button><button class="app-tab" style="padding:8px 16px;">Settings</button></div>
-            </div>
-            
-            <!-- Bundle App Example -->
-            <h5 class="mb-3">Bundle App (e.g., Bundle Discount)</h5>
-            <div style="background: var(--bg-light); padding: 16px; border-radius: 12px;">
-                <div class="d-flex justify-content-between align-items-center pb-3 mb-3" style="border-bottom: 1px solid var(--border-color);">
-                    <div class="d-flex justify-content-between align-items-center" style="flex: 1; max-width: 50%;">
-                        <strong style="font-size: 18px;">Bundle Discount</strong>
-                        <div class="toggle-switch active" style="transform: scale(0.6);"><div class="toggle-slider"></div></div>
-                    </div>
-                    <div class="d-flex gap-2">
-                        <button style="background: white; border: 1px solid #e3e3e3; border-radius: 12px; padding: 10px 16px; font-weight: 600; font-size: 13px;">Create Another Discount</button>
-                        <button class="create-btn" style="padding:10px 20px;">Create Bundle</button>
+            <!-- Page Structure Example -->
+            <h5 class="mt-4 mb-3">Complete Page Layout</h5>
+            <div style="background: var(--bg-light); padding: 20px; border-radius: 12px;">
+                <!-- Header (in parent component) -->
+                <div style="background: white; padding: 16px; border-radius: 8px; margin-bottom: 16px; border: 2px dashed #4CAF50;">
+                    <small style="color: #4CAF50; font-weight: 600;">← HEADER (in BundleForm.jsx / parent)</small>
+                    <div class="d-flex justify-content-between align-items-center mt-2">
+                        <div>
+                            <strong style="font-size: 20px;">Bundle Discount</strong>
+                            <p style="color: #616161; font-size: 14px; margin: 4px 0 0 0;">Get Noticed! Want to make sure your message...</p>
+                        </div>
+                        <div class="d-flex align-items-center gap-3">
+                            <button style="background: black; color: white; border: none; border-radius: 15px; padding: 15px 25px; font-weight: 500;">Create Another Discount</button>
+                            <div class="toggle-switch active" style="transform: scale(0.8);"><div class="toggle-slider"></div></div>
+                        </div>
                     </div>
                 </div>
-                <div class="app-tabs"><button class="app-tab active" style="padding:8px 16px;">Overview</button><button class="app-tab" style="padding:8px 16px;">Discounts</button></div>
+                
+                <!-- Body (DiscountList.jsx) -->
+                <div style="background: white; padding: 16px; border-radius: 8px; border: 2px dashed #2196F3;">
+                    <small style="color: #2196F3; font-weight: 600;">← BODY (DiscountList.jsx - tabs only, no header)</small>
+                    <div class="app-tabs mt-2" style="background: #F1F2F4; padding: 8px; border-radius: 15px;">
+                        <button class="app-tab active" style="padding:10px 20px;">Overview</button>
+                        <button class="app-tab" style="padding:10px 20px;">Discounts</button>
+                        <button class="app-tab" style="padding:10px 20px;">Settings</button>
+                        <button class="app-tab" style="padding:10px 20px;">Analytics</button>
+                    </div>
+                    <div style="margin-top: 16px; padding: 20px; background: #f8f9fa; border-radius: 8px; text-align: center; color: #666;">
+                        Tab content area...
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/web/frontend/apps/announcement-bar/AnnouncementBarForm.jsx
+++ b/web/frontend/apps/announcement-bar/AnnouncementBarForm.jsx
@@ -1,48 +1,49 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Container, Row, Col } from "react-bootstrap";
 import { ArrowLeft } from "lucide-react";
-// import DiscountModal from "../../pages/DiscountModal";
 import DiscountList from "./DiscountList";
 import Button from "../../components/Button";
-import DiscountModal from "../../components/Modals/GlobalDisountModal";
 import ToggleSwitch from "../../components/ToggelSwitch";
 
 export default function AnnouncementBarForm({ goBack, setActiveAction }) {
-  const [showDiscountModal, setShowDiscountModal] = useState(false);
   const [fromDiscountPage, setFromDiscountPage] = useState(false);
   const [resetDiscountList, setResetDiscountList] = useState(false);
-  const [refreshTrigger, setRefreshTrigger] = useState(1); // Add refresh trigger state
-  const [autoTriggerActions, setAutoTriggerActions] = useState(true); // Add this state
+  const [refreshTrigger, setRefreshTrigger] = useState(1);
+  const [autoTriggerActions, setAutoTriggerActions] = useState(true);
   const discountActionsRef = useRef();
-  // Add this useEffect to automatically trigger the flow
+  
   useEffect(() => {
     if (autoTriggerActions) {
-      // Automatically set fromDiscountPage to true and trigger the flow
       setFromDiscountPage(true);
-      setAutoTriggerActions(false); // Prevent infinite loop
+      setAutoTriggerActions(false);
     }
   }, [autoTriggerActions]);
+  
   const handleOpenDiscountModal = () => {
-    setAutoTriggerActions(true)
+    setAutoTriggerActions(true);
   };
+  
   const handleDiscard = () => {
     setFromDiscountPage(false);
-    setResetDiscountList((prev) => !prev); // Toggle to force re-render
+    setResetDiscountList((prev) => !prev);
   };
+  
   const handleBundleCreated = () => {
     setFromDiscountPage(false);
-    // Trigger refresh by incrementing the trigger value
     setRefreshTrigger((prev) => prev + 1);
   };
+  
   const handleSaveChanges = () => {
     if (discountActionsRef.current) {
       discountActionsRef.current.handleSaveChanges();
     }
   };
+  
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
-        <Row className="mb-4 align-items-start">
+        {/* Header Row: [Back] [Title ... Toggle] [Create Announcement Bar] */}
+        <Row className="mb-2 align-items-center">
           <Col xs="auto">
             {fromDiscountPage ? (
               <></>
@@ -63,9 +64,10 @@ export default function AnnouncementBarForm({ goBack, setActiveAction }) {
               </div>
             )}
           </Col>
-          <Col>
+          {/* Left Column: Title + Toggle */}
+          <Col className="d-flex align-items-center justify-content-between">
             <h5
-              className="mb-2"
+              className="mb-0"
               style={{
                 fontWeight: 600,
                 fontSize: "20px",
@@ -74,23 +76,11 @@ export default function AnnouncementBarForm({ goBack, setActiveAction }) {
             >
               Announcement Bar
             </h5>
-            <p
-              className="mb-0"
-              style={{
-                fontWeight: 500,
-                fontSize: "14px",
-                lineHeight: "1.3",
-                color: "#616161",
-              }}
-            >
-              Get Noticed! 🔔 Want to make sure your message doesn’t get missed? Announcement Bar lets you
-              display important alerts right at the top of your store. Whether it’s a sale, promotion, or
-              update, it’s impossible to ignore!
-            </p>
+            <ToggleSwitch appId="announcement_bar" />
           </Col>
-
+          {/* Right Column: Buttons */}
           {fromDiscountPage ? (
-            <Col xs="auto" className="d-flex align-items-center" style={{ maxWidth: "300px", width: "100%" }}>
+            <Col xs="auto" className="d-flex align-items-center gap-2">
               <Button
                 text="Discard"
                 onClick={handleDiscard}
@@ -100,9 +90,7 @@ export default function AnnouncementBarForm({ goBack, setActiveAction }) {
                   height: "45px",
                   fontWeight: 500,
                   fontSize: "15px",
-                  maxWidth: "95px",
                   borderRadius: "8px",
-                  marginRight: "10px",
                   padding: "10px 20px",
                 }}
               />
@@ -121,26 +109,40 @@ export default function AnnouncementBarForm({ goBack, setActiveAction }) {
               />
             </Col>
           ) : (
-            <Col xs="auto" className="d-flex align-items-center gap-2">
+            <Col xs="auto" className="d-flex align-items-center">
               <Button
                 text="Create Announcement Bar"
                 onClick={handleOpenDiscountModal}
                 style={{
                   borderRadius: "15px",
-
                   backgroundColor: "#000",
                   color: "#FFFFFF",
                   padding: "15px 25px",
-                  fontFamily: "Inter",
-                  fontStyle: "normal",
                   fontWeight: "500",
                   fontSize: "15px",
-                  lineHeight: "100%",
                 }}
               />
-              <ToggleSwitch appId="announcement_bar" />
             </Col>
           )}
+        </Row>
+
+        {/* Description Row */}
+        <Row className="mb-4">
+          <Col>
+            <p
+              className="mb-0"
+              style={{
+                fontWeight: 500,
+                fontSize: "14px",
+                lineHeight: "1.3",
+                color: "#616161",
+              }}
+            >
+              Get Noticed! 🔔 Want to make sure your message doesn't get missed? Announcement Bar lets you
+              display important alerts right at the top of your store. Whether it's a sale, promotion, or
+              update, it's impossible to ignore!
+            </p>
+          </Col>
         </Row>
       </Container>
       <DiscountList

--- a/web/frontend/apps/announcement-bar/AnnouncementBarForm.jsx
+++ b/web/frontend/apps/announcement-bar/AnnouncementBarForm.jsx
@@ -76,7 +76,7 @@ export default function AnnouncementBarForm({ goBack, setActiveAction }) {
             >
               Announcement Bar
             </h5>
-            <ToggleSwitch appId="announcement_bar" />
+            <ToggleSwitch size="small" appId="announcement_bar" />
           </Col>
           {/* Right Column: Buttons */}
           {fromDiscountPage ? (

--- a/web/frontend/apps/announcement-bar/AnnouncementBarForm.jsx
+++ b/web/frontend/apps/announcement-bar/AnnouncementBarForm.jsx
@@ -65,7 +65,7 @@ export default function AnnouncementBarForm({ goBack, setActiveAction }) {
             )}
           </Col>
           {/* Left Column: Title + Toggle */}
-          <Col className="d-flex align-items-center justify-content-between">
+          <Col className="d-flex align-items-center gap-3">
             <h5
               className="mb-0"
               style={{

--- a/web/frontend/apps/announcement-bar/DiscountList.jsx
+++ b/web/frontend/apps/announcement-bar/DiscountList.jsx
@@ -229,15 +229,17 @@ export default function DiscountList({
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Title with Toggle on left, Create Button on right */}
+      {/* App Header - Two columns: [Title + Toggle] | [Create Button] */}
       <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        {/* Left Column: Title (left) + Toggle (right) */}
+        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
           <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
             Announcement Bar
           </h2>
           <ToggleSwitch appId="announcement_bar" />
         </Col>
-        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+        {/* Right Column: Create Button */}
+        <Col xs={12} md={6} className="d-flex justify-content-end">
           <Button
             text="Create Announcement"
             onClick={() => {
@@ -251,7 +253,6 @@ export default function DiscountList({
               color: "white",
               fontWeight: 600,
               fontSize: "14px",
-              minWidth: "180px",
               height: "48px",
             }}
           />

--- a/web/frontend/apps/announcement-bar/DiscountList.jsx
+++ b/web/frontend/apps/announcement-bar/DiscountList.jsx
@@ -13,7 +13,6 @@ import dropdown from "../../assets/Vector.png";
 import { Spinner } from "@shopify/polaris";
 import Analytics from "../../components/Analytics/AnnouncementAnalytics";
 import VideoList from "../../components/VideoList";
-import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Announcement Bar specific videos
 const announcementBarVideos = [
@@ -229,36 +228,6 @@ export default function DiscountList({
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Two columns: [Title + Toggle] | [Create Button] */}
-      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        {/* Left Column: Title (left) + Toggle (right) */}
-        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
-          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
-            Announcement Bar
-          </h2>
-          <ToggleSwitch appId="announcement_bar" />
-        </Col>
-        {/* Right Column: Create Button */}
-        <Col xs={12} md={6} className="d-flex justify-content-end">
-          <Button
-            text="Create Announcement"
-            onClick={() => {
-              setShowBundleAction(true);
-              if (onMakeBundleClick) onMakeBundleClick();
-            }}
-            style={{
-              background: "black",
-              borderRadius: "12px",
-              padding: "12px 24px",
-              color: "white",
-              fontWeight: 600,
-              fontSize: "14px",
-              height: "48px",
-            }}
-          />
-        </Col>
-      </Row>
-
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">

--- a/web/frontend/apps/announcement-bar/DiscountList.jsx
+++ b/web/frontend/apps/announcement-bar/DiscountList.jsx
@@ -13,6 +13,7 @@ import dropdown from "../../assets/Vector.png";
 import { Spinner } from "@shopify/polaris";
 import Analytics from "../../components/Analytics/AnnouncementAnalytics";
 import VideoList from "../../components/VideoList";
+import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Announcement Bar specific videos
 const announcementBarVideos = [
@@ -228,6 +229,35 @@ export default function DiscountList({
         padding: "5px 15px",
       }}
     >
+      {/* App Header - Title with Toggle on left, Create Button on right */}
+      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
+        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
+            Announcement Bar
+          </h2>
+          <ToggleSwitch appId="announcement_bar" />
+        </Col>
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text="Create Announcement"
+            onClick={() => {
+              setShowBundleAction(true);
+              if (onMakeBundleClick) onMakeBundleClick();
+            }}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px",
+            }}
+          />
+        </Col>
+      </Row>
+
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">
@@ -236,7 +266,6 @@ export default function DiscountList({
             style={{
               marginLeft: "0",
               marginRight: "0",
-
               padding: "0px",
               boxShadow: "1px 1px 4px 0px #0000001A inset",
               backgroundColor: "#F1F2F4",
@@ -265,7 +294,6 @@ export default function DiscountList({
                           borderColor: "black",
                           borderRadius: "15px",
                           width: "180px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -278,7 +306,6 @@ export default function DiscountList({
                       : {
                           borderRadius: "15px",
                           width: "180px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -295,23 +322,7 @@ export default function DiscountList({
                 </ToggleButton>
               ))}
             </ButtonGroup>
-
-            {/* Right-aligned Create Discount Button */}
           </div>
-          {selectedTab === "Discounts" && (
-            <Button
-              text="Create Discount"
-              onClick={() => console.log("Create Discount")}
-              style={{
-                background: "black",
-                borderRadius: "12px",
-                padding: "15px 12px",
-                color: "white",
-                width: "200px",
-                height: "51px",
-              }}
-            />
-          )}
         </div>
       </Row>
       {selectedTab === "Discounts" && (

--- a/web/frontend/apps/announcement-bar/DiscountList.jsx
+++ b/web/frontend/apps/announcement-bar/DiscountList.jsx
@@ -12,6 +12,43 @@ import videoimg from "../../assets/videoimg.png";
 import dropdown from "../../assets/Vector.png";
 import { Spinner } from "@shopify/polaris";
 import Analytics from "../../components/Analytics/AnnouncementAnalytics";
+import VideoList from "../../components/VideoList";
+
+// Announcement Bar specific videos
+const announcementBarVideos = [
+  {
+    id: 1,
+    title: "Creating Your First Bar",
+    description: "Learn how to set up an announcement bar",
+    src: "/videos/announcement-getting-started.mp4",
+    poster: null,
+    duration: "2:15"
+  },
+  {
+    id: 2,
+    title: "Styling Options",
+    description: "Customize colors, fonts, and animations",
+    src: "/videos/announcement-styling.mp4",
+    poster: null,
+    duration: "3:30"
+  },
+  {
+    id: 3,
+    title: "Countdown Timers",
+    description: "Add urgency with countdown features",
+    src: "/videos/announcement-countdown.mp4",
+    poster: null,
+    duration: "2:45"
+  },
+  {
+    id: 4,
+    title: "Targeting & Scheduling",
+    description: "Show bars to the right audience",
+    src: "/videos/announcement-targeting.mp4",
+    poster: null,
+    duration: "3:00"
+  }
+];
 
 export default function DiscountList({
   onMakeBundleClick,
@@ -326,237 +363,7 @@ export default function DiscountList({
         }}
       >
         {selectedTab === "Overview" && (
-          <>
-            {/* Video Display */}
-            <Col
-              lg={6}
-              md={12}
-              style={{
-                padding: "50px",
-              }}
-            >
-              <Card className="border-0 h-100 " style={{ background: "transparent !important" }}>
-                <Card.Body className="p-0 " style={{ background: "transparent !important" }}>
-                  <div className="position-relative h-100">
-                    <video
-                      controls
-                      poster={videoimg}
-                      style={{
-                        width: "100%",
-                        height: "auto",
-                        borderRadius: "15px",
-                        padding: "4px",
-                      }}
-                    >
-                      <source src="/videos/marshall-promo.mp4" type="video/mp4" />
-                      Your browser does not support the video tag.
-                    </video>
-                    <div className="position-absolute top-50 start-50 translate-middle">
-                      <Button
-                        text={<Play size={24} />}
-                        onClick={() => console.log("Discard")}
-                        variant="light"
-                        className="rounded-circle p-3 opacity-75"
-                      />
-                    </div>
-                  </div>
-                </Card.Body>
-              </Card>
-            </Col>
-
-            {/* Side Features */}
-            <Col
-              lg={6}
-              md={12}
-              style={{
-                padding: "50px 0",
-              }}
-            >
-              <div
-                className="d-flex justify-content-between flex-column linrrowleft"
-                style={{ height: "100%" }}
-              >
-                <div>
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
-                        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Customizable
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Discount, Display style & Priority.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Responsive
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Looks great on any device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-5 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
-                        <path d="M13 2v7h7"></path>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Attention grabbing
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Keep your customers informed without disrupting their shopping.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="d-flex align-items-start flex-column">
-                  <Button
-                    variant="dark"
-                    className="mb-3 d-flex align-items-center justify-content-center"
-                    text=" Make your Announcement Bar!"
-                    style={{
-                      maxWidth: "400px",
-                      borderRadius: "40px",
-                      height: "45px",
-                      fontWeight: 500,
-                      fontSize: "15px",
-                      letterSpacing: "0",
-                      backgroundColor: "black",
-                      borderColor: "black",
-                      color: "white",
-                      padding: "15px 25px",
-                    }}
-                    onClick={() => {
-                      setShowBundleAction(true);
-                      onMakeBundleClick();
-                    }}
-                  />
-
-                  <div>
-                    <span
-                      className="text-secondary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                      }}
-                    >
-                      Learn More about{" "}
-                    </span>
-                    <a
-                      href="#"
-                      className="text-primary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                        color: "#5169DD",
-                      }}
-                    >
-                      How to create bundle?
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </Col>
-          </>
+          <VideoList videos={announcementBarVideos} appName="Announcement Bar" />
         )}
 
         {selectedTab === "Announcement Bars" && (

--- a/web/frontend/apps/bundle-discounts/BundleForm.jsx
+++ b/web/frontend/apps/bundle-discounts/BundleForm.jsx
@@ -46,7 +46,8 @@ export default function BundleForm({ goBack, setActiveAction }) {
   return (
     <div>
       <Container fluid style={{ margin: "0 auto" }}>
-        <Row className="mb-4 align-items-start">
+        {/* Header Row: [Back] [Title ... Toggle] [Create Another Discount] [Create Bundle] */}
+        <Row className="mb-2 align-items-center">
           <Col xs="auto">
             {fromDiscountPage ? (
               <></>
@@ -67,9 +68,10 @@ export default function BundleForm({ goBack, setActiveAction }) {
               </div>
             )}
           </Col>
-          <Col>
+          {/* Left Column: Title + Toggle */}
+          <Col className="d-flex align-items-center justify-content-between">
             <h5
-              className="mb-2"
+              className="mb-0"
               style={{
                 fontWeight: 600,
                 fontSize: "20px",
@@ -78,23 +80,11 @@ export default function BundleForm({ goBack, setActiveAction }) {
             >
               Bundle Discount
             </h5>
-            <p
-              className="mb-0"
-              style={{
-                fontWeight: 500,
-                fontSize: "14px",
-                lineHeight: "1.3",
-                color: "#616161",
-              }}
-            >
-              Get Noticed! Want to make sure your message doesn't get missed? Announcement Bar lets you
-              display important alerts right at the top of your store. Whether it's a sale, promotion, or
-              update, it's impossible to ignore!
-            </p>
+            <ToggleSwitch appId="bundle_discount" />
           </Col>
-
+          {/* Right Column: Buttons */}
           {fromDiscountPage ? (
-            <Col xs="auto" className="d-flex align-items-center" style={{ maxWidth: "300px", width: "100%" }}>
+            <Col xs="auto" className="d-flex align-items-center gap-2">
               <Button
                 text="Discard"
                 onClick={handleDiscard}
@@ -104,9 +94,7 @@ export default function BundleForm({ goBack, setActiveAction }) {
                   height: "45px",
                   fontWeight: 500,
                   fontSize: "15px",
-                  maxWidth: "95px",
                   borderRadius: "8px",
-                  marginRight: "10px",
                   padding: "10px 20px",
                 }}
               />
@@ -131,20 +119,47 @@ export default function BundleForm({ goBack, setActiveAction }) {
                 onClick={handleOpenDiscountModal}
                 style={{
                   borderRadius: "15px",
-
+                  backgroundColor: "#fff",
+                  color: "#000",
+                  border: "1px solid #dee2e6",
+                  padding: "15px 25px",
+                  fontWeight: "500",
+                  fontSize: "15px",
+                }}
+              />
+              <Button
+                text="Create Bundle"
+                onClick={() => setFromDiscountPage(true)}
+                style={{
+                  borderRadius: "15px",
                   backgroundColor: "#000",
                   color: "#FFFFFF",
                   padding: "15px 25px",
-                  fontFamily: "Inter",
-                  fontStyle: "normal",
                   fontWeight: "500",
                   fontSize: "15px",
-                  lineHeight: "100%",
                 }}
               />
-              <ToggleSwitch appId="bundle_discount" />
             </Col>
           )}
+        </Row>
+
+        {/* Description Row */}
+        <Row className="mb-4">
+          <Col>
+            <p
+              className="mb-0"
+              style={{
+                fontWeight: 500,
+                fontSize: "14px",
+                lineHeight: "1.3",
+                color: "#616161",
+              }}
+            >
+              Get Noticed! Want to make sure your message doesn't get missed? Announcement Bar lets you
+              display important alerts right at the top of your store. Whether it's a sale, promotion, or
+              update, it's impossible to ignore!
+            </p>
+          </Col>
         </Row>
 
         <DiscountModal show={showDiscountModal} onHide={handleCloseDiscountModal} setActiveAction={setActiveAction} />

--- a/web/frontend/apps/bundle-discounts/BundleForm.jsx
+++ b/web/frontend/apps/bundle-discounts/BundleForm.jsx
@@ -80,7 +80,7 @@ export default function BundleForm({ goBack, setActiveAction }) {
             >
               Bundle Discount
             </h5>
-            <ToggleSwitch appId="bundle_discount" />
+            <ToggleSwitch size="small" appId="bundle_discount" />
           </Col>
           {/* Right Column: Buttons */}
           {fromDiscountPage ? (

--- a/web/frontend/apps/bundle-discounts/BundleForm.jsx
+++ b/web/frontend/apps/bundle-discounts/BundleForm.jsx
@@ -69,7 +69,7 @@ export default function BundleForm({ goBack, setActiveAction }) {
             )}
           </Col>
           {/* Left Column: Title + Toggle */}
-          <Col className="d-flex align-items-center justify-content-between">
+          <Col className="d-flex align-items-center gap-3">
             <h5
               className="mb-0"
               style={{

--- a/web/frontend/apps/bundle-discounts/DiscountList.jsx
+++ b/web/frontend/apps/bundle-discounts/DiscountList.jsx
@@ -166,20 +166,36 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Title with Toggle on left, Create Button on right */}
+      {/* App Header - Two columns: [Title + Toggle] | [Create Another Discount + Create Bundle] */}
       <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        {/* Left Column: Title (left) + Toggle (right) */}
+        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
           <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
             Bundle Discount
           </h2>
           <ToggleSwitch appId="bundle_discount" />
         </Col>
-        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+        {/* Right Column: Create Another Discount + Create Bundle */}
+        <Col xs={12} md={6} className="d-flex justify-content-end gap-2">
+          <Button
+            text="Create Another Discount"
+            onClick={() => console.log("Create Another Discount")}
+            style={{
+              background: "white",
+              borderRadius: "12px",
+              padding: "12px 20px",
+              color: "#303030",
+              fontWeight: 600,
+              fontSize: "14px",
+              border: "1px solid #e3e3e3",
+              height: "48px",
+            }}
+          />
           <Button
             text="Create Bundle"
             onClick={() => {
               setShowBundleAction(true);
-              onMakeBundleClick();
+              if (onMakeBundleClick) onMakeBundleClick();
             }}
             style={{
               background: "black",
@@ -188,7 +204,6 @@ export default function DiscountList({ onMakeBundleClick }) {
               color: "white",
               fontWeight: 600,
               fontSize: "14px",
-              minWidth: "180px",
               height: "48px",
             }}
           />

--- a/web/frontend/apps/bundle-discounts/DiscountList.jsx
+++ b/web/frontend/apps/bundle-discounts/DiscountList.jsx
@@ -9,6 +9,43 @@ import Button from "../../components/Button";
 import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
+import VideoList from "../../components/VideoList";
+
+// Bundle Discount specific videos
+const bundleDiscountVideos = [
+  {
+    id: 1,
+    title: "Getting Started with Bundles",
+    description: "Learn how to create your first product bundle",
+    src: "/videos/bundle-getting-started.mp4",
+    poster: null,
+    duration: "2:30"
+  },
+  {
+    id: 2,
+    title: "Discount Strategies",
+    description: "Best practices for bundle discounting",
+    src: "/videos/bundle-discount-strategies.mp4",
+    poster: null,
+    duration: "3:45"
+  },
+  {
+    id: 3,
+    title: "Customizing Your Bundle",
+    description: "Style and design options for bundles",
+    src: "/videos/bundle-customization.mp4",
+    poster: null,
+    duration: "4:15"
+  },
+  {
+    id: 4,
+    title: "Analytics & Performance",
+    description: "Track your bundle performance metrics",
+    src: "/videos/bundle-analytics.mp4",
+    poster: null,
+    duration: "2:50"
+  }
+];
 
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Discounts", "Setting", "Analytics"];
@@ -311,237 +348,7 @@ export default function DiscountList({ onMakeBundleClick }) {
         }}
       >
         {selectedTab === "Overview" && (
-          <>
-            {/* Video Display */}
-            <Col
-              lg={6}
-              md={12}
-              style={{
-                padding: "50px",
-              }}
-            >
-              <Card className="border-0 h-100 " style={{ background: "transparent !important" }}>
-                <Card.Body className="p-0 " style={{ background: "transparent !important" }}>
-                  <div className="position-relative h-100">
-                    <video
-                      controls
-                      poster={videoimg}
-                      style={{
-                        width: "100%",
-                        height: "auto",
-                        borderRadius: "15px",
-                        padding: "4px",
-                      }}
-                    >
-                      <source src="/videos/marshall-promo.mp4" type="video/mp4" />
-                      Your browser does not support the video tag.
-                    </video>
-                    <div className="position-absolute top-50 start-50 translate-middle">
-                      <Button
-                        text={<Play size={24} />}
-                        onClick={() => console.log("Discard")}
-                        variant="light"
-                        className="rounded-circle p-3 opacity-75"
-                      />
-                    </div>
-                  </div>
-                </Card.Body>
-              </Card>
-            </Col>
-
-            {/* Side Features */}
-            <Col
-              lg={6}
-              md={12}
-              style={{
-                padding: "50px 0",
-              }}
-            >
-              <div
-                className="d-flex justify-content-between flex-column linrrowleft"
-                style={{ height: "100%" }}
-              >
-                <div>
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
-                        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Customizable
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Discount, Display style & Priority.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Responsive
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Looks great on any device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-5 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
-                        <path d="M13 2v7h7"></path>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Attention grabbing
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Keep your customers informed without disrupting their shopping.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="d-flex align-items-start flex-column">
-                  <Button
-                    variant="dark"
-                    className="mb-3 d-flex align-items-center justify-content-center"
-                    text=" Make your Bundle Now!"
-                    style={{
-                      maxWidth: "220px",
-                      borderRadius: "40px",
-                      height: "45px",
-                      fontWeight: 500,
-                      fontSize: "15px",
-                      letterSpacing: "0",
-                      backgroundColor: "black",
-                      borderColor: "black",
-                      color: "white",
-                      padding: "15px 25px",
-                    }}
-                    onClick={() => {
-                      setShowBundleAction(true);
-                      onMakeBundleClick();
-                    }}
-                  />
-
-                  <div>
-                    <span
-                      className="text-secondary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                      }}
-                    >
-                      Learn More about{" "}
-                    </span>
-                    <a
-                      href="#"
-                      className="text-primary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                        color: "#5169DD",
-                      }}
-                    >
-                      How to create bundle?
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </Col>
-          </>
+          <VideoList videos={bundleDiscountVideos} appName="Bundle Discount" />
         )}
         {selectedTab === "Discounts" && (
           <>

--- a/web/frontend/apps/bundle-discounts/DiscountList.jsx
+++ b/web/frontend/apps/bundle-discounts/DiscountList.jsx
@@ -10,7 +10,6 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
-import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Bundle Discount specific videos
 const bundleDiscountVideos = [
@@ -166,50 +165,6 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Two columns: [Title + Toggle] | [Create Another Discount + Create Bundle] */}
-      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        {/* Left Column: Title (left) + Toggle (right) */}
-        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
-          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
-            Bundle Discount
-          </h2>
-          <ToggleSwitch appId="bundle_discount" />
-        </Col>
-        {/* Right Column: Create Another Discount + Create Bundle */}
-        <Col xs={12} md={6} className="d-flex justify-content-end gap-2">
-          <Button
-            text="Create Another Discount"
-            onClick={() => console.log("Create Another Discount")}
-            style={{
-              background: "white",
-              borderRadius: "12px",
-              padding: "12px 20px",
-              color: "#303030",
-              fontWeight: 600,
-              fontSize: "14px",
-              border: "1px solid #e3e3e3",
-              height: "48px",
-            }}
-          />
-          <Button
-            text="Create Bundle"
-            onClick={() => {
-              setShowBundleAction(true);
-              if (onMakeBundleClick) onMakeBundleClick();
-            }}
-            style={{
-              background: "black",
-              borderRadius: "12px",
-              padding: "12px 24px",
-              color: "white",
-              fontWeight: 600,
-              fontSize: "14px",
-              height: "48px",
-            }}
-          />
-        </Col>
-      </Row>
-
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">

--- a/web/frontend/apps/bundle-discounts/DiscountList.jsx
+++ b/web/frontend/apps/bundle-discounts/DiscountList.jsx
@@ -10,6 +10,7 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
+import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Bundle Discount specific videos
 const bundleDiscountVideos = [
@@ -165,6 +166,35 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
+      {/* App Header - Title with Toggle on left, Create Button on right */}
+      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
+        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
+            Bundle Discount
+          </h2>
+          <ToggleSwitch appId="bundle_discount" />
+        </Col>
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text="Create Bundle"
+            onClick={() => {
+              setShowBundleAction(true);
+              onMakeBundleClick();
+            }}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px",
+            }}
+          />
+        </Col>
+      </Row>
+
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">
@@ -173,7 +203,6 @@ export default function DiscountList({ onMakeBundleClick }) {
             style={{
               marginLeft: "0",
               marginRight: "0",
-
               padding: "0px",
               boxShadow: "1px 1px 4px 0px #0000001A inset",
               backgroundColor: "#F1F2F4",
@@ -202,7 +231,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                           borderColor: "black",
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -215,7 +243,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                       : {
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -232,23 +259,7 @@ export default function DiscountList({ onMakeBundleClick }) {
                 </ToggleButton>
               ))}
             </ButtonGroup>
-
-            {/* Right-aligned Create Discount Button */}
           </div>
-          {selectedTab === "Discounts" && (
-            <Button
-              text="Create Discount"
-              onClick={() => console.log("Create Discount")}
-              style={{
-                background: "black",
-                borderRadius: "12px",
-                padding: "15px 12px",
-                color: "white",
-                width: "200px",
-                height: "51px",
-              }}
-            />
-          )}
         </div>
       </Row>
       {/* {selectedTab === "Discounts" && (

--- a/web/frontend/apps/buy-one-get-one/DiscountList.jsx
+++ b/web/frontend/apps/buy-one-get-one/DiscountList.jsx
@@ -98,15 +98,31 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Title with Toggle on left, Create Button on right */}
+      {/* App Header - Two columns: [Title + Toggle] | [Create Another Discount + Create BOGO] */}
       <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        {/* Left Column: Title (left) + Toggle (right) */}
+        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
           <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
             Buy One Get One
           </h2>
           <ToggleSwitch appId="bogo" />
         </Col>
-        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+        {/* Right Column: Create Another Discount + Create BOGO */}
+        <Col xs={12} md={6} className="d-flex justify-content-end gap-2">
+          <Button
+            text="Create Another Discount"
+            onClick={() => console.log("Create Another Discount")}
+            style={{
+              background: "white",
+              borderRadius: "12px",
+              padding: "12px 20px",
+              color: "#303030",
+              fontWeight: 600,
+              fontSize: "14px",
+              border: "1px solid #e3e3e3",
+              height: "48px",
+            }}
+          />
           <Button
             text="Create BOGO"
             onClick={() => {
@@ -120,7 +136,6 @@ export default function DiscountList({ onMakeBundleClick }) {
               color: "white",
               fontWeight: 600,
               fontSize: "14px",
-              minWidth: "180px",
               height: "48px",
             }}
           />

--- a/web/frontend/apps/buy-one-get-one/DiscountList.jsx
+++ b/web/frontend/apps/buy-one-get-one/DiscountList.jsx
@@ -16,6 +16,43 @@ import Button from "../../components/Button";
 import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
+import VideoList from "../../components/VideoList";
+
+// BOGO specific videos
+const bogoVideos = [
+  {
+    id: 1,
+    title: "BOGO Basics",
+    description: "Create your first Buy One Get One offer",
+    src: "/videos/bogo-getting-started.mp4",
+    poster: null,
+    duration: "2:20"
+  },
+  {
+    id: 2,
+    title: "Discount Configurations",
+    description: "Set up different BOGO discount types",
+    src: "/videos/bogo-discounts.mp4",
+    poster: null,
+    duration: "3:15"
+  },
+  {
+    id: 3,
+    title: "Product Selection",
+    description: "Choose which products to include",
+    src: "/videos/bogo-products.mp4",
+    poster: null,
+    duration: "2:40"
+  },
+  {
+    id: 4,
+    title: "BOGO Best Practices",
+    description: "Tips for maximizing BOGO sales",
+    src: "/videos/bogo-best-practices.mp4",
+    poster: null,
+    duration: "3:30"
+  }
+];
 
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Discounts", "Setting", "Analytics"];
@@ -203,252 +240,7 @@ export default function DiscountList({ onMakeBundleClick }) {
         }}
       >
         {selectedTab === "Overview" && (
-          <>
-           {/* Video Display */}
-           <Col
-              lg={6} md={12}
-              style={{
-                padding: "50px",
-              }}
-            >
-              <Card
-                className="border-0 h-100 "
-                style={{ background: "transparent !important" }}
-              >
-                <Card.Body
-                  className="p-0 "
-                  style={{ background: "transparent !important" }}
-                >
-                  <div className="position-relative h-100">
-                    <video
-                      controls
-                      poster={videoimg}
-                      style={{
-                        width: "100%",
-                        height: "auto",
-                        borderRadius: "15px",
-                        padding: "4px",
-                      }}
-                    >
-                      <source
-                        src="/videos/marshall-promo.mp4"
-                        type="video/mp4"
-                      />
-                      Your browser does not support the video tag.
-                    </video>
-                    <div className="position-absolute top-50 start-50 translate-middle">
-                      <Button
-                        text={<Play size={24} />}
-                        onClick={() => console.log("Discard")}
-                        variant="light"
-                        className="rounded-circle p-3 opacity-75"
-                      />
-                    </div>
-                  </div>
-                </Card.Body>
-              </Card>
-            </Col>
-
-            {/* Side Features */}
-            <Col
-              lg={6} md={12}
-              style={{
-                padding: "50px 0",
-              }}
-            >
-              <div
-                className="d-flex justify-content-between flex-column linrrowleft"
-                style={{ height: "100%" }}
-              >
-                <div>
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
-                        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Customizable
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Discount, Display style & Priority.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <rect
-                          x="2"
-                          y="3"
-                          width="20"
-                          height="14"
-                          rx="2"
-                          ry="2"
-                        ></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Responsive
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Looks great on any device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-5 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
-                        <path d="M13 2v7h7"></path>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Attention grabbing
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Keep your customers informed without disrupting their
-                        shopping.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="d-flex align-items-start flex-column">
-                  <Button
-                    variant="dark"
-                    className="mb-3 d-flex align-items-center justify-content-center"
-                    text=" Make your Bundle Now!"
-                    style={{
-                      maxWidth: "220px",
-                      borderRadius: "40px",
-                      height: "45px",
-                      fontWeight: 500,
-                      fontSize: "15px",
-                      letterSpacing: "0",
-                      backgroundColor: "black",
-                      borderColor: "black",
-                      color: "white",
-                      padding: "15px 25px",
-                    }}
-                    onClick={() => {
-                      setShowBundleAction(true);
-                      onMakeBundleClick();
-                    }}
-                  />
-
-                  <div>
-                    <span
-                      className="text-secondary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                      }}
-                    >
-                      Learn More about{" "}
-                    </span>
-                    <a
-                      href="#"
-                      className="text-primary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                        color: "#5169DD",
-                      }}
-                    >
-                      How to create bundle?
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </Col>
-          </>
+          <VideoList videos={bogoVideos} appName="Buy One Get One" />
         )}
 
         {selectedTab === "Discounts" && (

--- a/web/frontend/apps/buy-one-get-one/DiscountList.jsx
+++ b/web/frontend/apps/buy-one-get-one/DiscountList.jsx
@@ -17,7 +17,6 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
-import ToggleSwitch from "../../components/ToggelSwitch";
 
 // BOGO specific videos
 const bogoVideos = [
@@ -98,50 +97,6 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Two columns: [Title + Toggle] | [Create Another Discount + Create BOGO] */}
-      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        {/* Left Column: Title (left) + Toggle (right) */}
-        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
-          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
-            Buy One Get One
-          </h2>
-          <ToggleSwitch appId="bogo" />
-        </Col>
-        {/* Right Column: Create Another Discount + Create BOGO */}
-        <Col xs={12} md={6} className="d-flex justify-content-end gap-2">
-          <Button
-            text="Create Another Discount"
-            onClick={() => console.log("Create Another Discount")}
-            style={{
-              background: "white",
-              borderRadius: "12px",
-              padding: "12px 20px",
-              color: "#303030",
-              fontWeight: 600,
-              fontSize: "14px",
-              border: "1px solid #e3e3e3",
-              height: "48px",
-            }}
-          />
-          <Button
-            text="Create BOGO"
-            onClick={() => {
-              setShowBundleAction(true);
-              if (onMakeBundleClick) onMakeBundleClick();
-            }}
-            style={{
-              background: "black",
-              borderRadius: "12px",
-              padding: "12px 24px",
-              color: "white",
-              fontWeight: 600,
-              fontSize: "14px",
-              height: "48px",
-            }}
-          />
-        </Col>
-      </Row>
-
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">

--- a/web/frontend/apps/buy-one-get-one/DiscountList.jsx
+++ b/web/frontend/apps/buy-one-get-one/DiscountList.jsx
@@ -17,6 +17,7 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
+import ToggleSwitch from "../../components/ToggelSwitch";
 
 // BOGO specific videos
 const bogoVideos = [
@@ -97,6 +98,35 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
+      {/* App Header - Title with Toggle on left, Create Button on right */}
+      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
+        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
+            Buy One Get One
+          </h2>
+          <ToggleSwitch appId="bogo" />
+        </Col>
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text="Create BOGO"
+            onClick={() => {
+              setShowBundleAction(true);
+              if (onMakeBundleClick) onMakeBundleClick();
+            }}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px",
+            }}
+          />
+        </Col>
+      </Row>
+
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">
@@ -105,15 +135,13 @@ export default function DiscountList({ onMakeBundleClick }) {
             style={{
               marginLeft: "0",
               marginRight: "0",
-             
-                padding: "0px",
-                boxShadow: "1px 1px 4px 0px #0000001A inset",
-                backgroundColor: "#F1F2F4",
-                borderRadius: "15px",
-                marginBottom: "8px",
-                height: "51px",
-                width:"100%"
-              
+              padding: "0px",
+              boxShadow: "1px 1px 4px 0px #0000001A inset",
+              backgroundColor: "#F1F2F4",
+              borderRadius: "15px",
+              marginBottom: "8px",
+              height: "51px",
+              width: "100%",
             }}
           >
             {/* Left-aligned Toggle Buttons */}
@@ -138,7 +166,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                           borderColor: "black",
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -151,7 +178,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                       : {
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -168,23 +194,7 @@ export default function DiscountList({ onMakeBundleClick }) {
                 </ToggleButton>
               ))}
             </ButtonGroup>
-
-            {/* Right-aligned Create Discount Button */}
           </div>
-          {selectedTab === "Discounts" && (
-            <Button
-              text="Create Discount"
-              onClick={() => console.log("Create Discount")}
-              style={{
-                background: "black",
-                borderRadius: "12px",
-                padding: "15px 12px",
-                color: "white",
-                width: "200px",
-                height: "51px",
-              }}
-            />
-          )}
         </div>
       </Row>
       {selectedTab === "Discounts" && (

--- a/web/frontend/apps/buy-one-get-one/buyoneGetone.jsx
+++ b/web/frontend/apps/buy-one-get-one/buyoneGetone.jsx
@@ -45,7 +45,8 @@ export default function BuyonegetoneForm({ goBack, setActiveAction }) {
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
-        <Row className="mb-4 align-items-start">
+        {/* Header Row: [Back] [Title ... Toggle] [Create Another Discount] [Create BOGO] */}
+        <Row className="mb-2 align-items-center">
           <Col xs="auto">
             {fromDiscountPage ? (
               <></>
@@ -66,9 +67,10 @@ export default function BuyonegetoneForm({ goBack, setActiveAction }) {
               </div>
             )}
           </Col>
-          <Col>
+          {/* Left Column: Title + Toggle */}
+          <Col className="d-flex align-items-center justify-content-between">
             <h5
-              className="mb-2"
+              className="mb-0"
               style={{
                 fontWeight: 600,
                 fontSize: "20px",
@@ -77,23 +79,11 @@ export default function BuyonegetoneForm({ goBack, setActiveAction }) {
             >
               Buy One Get One
             </h5>
-            <p
-              className="mb-0"
-              style={{
-                fontWeight: 500,
-                fontSize: "14px",
-                lineHeight: "1.3",
-                color: "#616161",
-              }}
-            >
-              Get Noticed! Want to make sure your message doesn't get missed? Announcement Bar lets you
-              display important alerts right at the top of your store. Whether it's a sale, promotion, or
-              update, it's impossible to ignore!
-            </p>
+            <ToggleSwitch appId="buy_one_get_one" />
           </Col>
-
+          {/* Right Column: Buttons */}
           {fromDiscountPage ? (
-            <Col xs="auto" className="d-flex align-items-center" style={{ maxWidth: "300px", width: "100%" }}>
+            <Col xs="auto" className="d-flex align-items-center gap-2">
               <Button
                 text="Discard"
                 onClick={handleDiscard}
@@ -103,9 +93,7 @@ export default function BuyonegetoneForm({ goBack, setActiveAction }) {
                   height: "45px",
                   fontWeight: 500,
                   fontSize: "15px",
-                  maxWidth: "95px",
                   borderRadius: "8px",
-                  marginRight: "10px",
                   padding: "10px 20px",
                 }}
               />
@@ -130,20 +118,47 @@ export default function BuyonegetoneForm({ goBack, setActiveAction }) {
                 onClick={handleOpenDiscountModal}
                 style={{
                   borderRadius: "15px",
-
+                  backgroundColor: "#fff",
+                  color: "#000",
+                  border: "1px solid #dee2e6",
+                  padding: "15px 25px",
+                  fontWeight: "500",
+                  fontSize: "15px",
+                }}
+              />
+              <Button
+                text="Create BOGO"
+                onClick={() => setFromDiscountPage(true)}
+                style={{
+                  borderRadius: "15px",
                   backgroundColor: "#000",
                   color: "#FFFFFF",
                   padding: "15px 25px",
-                  fontFamily: "Inter",
-                  fontStyle: "normal",
                   fontWeight: "500",
                   fontSize: "15px",
-                  lineHeight: "100%",
                 }}
               />
-              <ToggleSwitch appId="buy_one_get_one" />
             </Col>
           )}
+        </Row>
+
+        {/* Description Row */}
+        <Row className="mb-4">
+          <Col>
+            <p
+              className="mb-0"
+              style={{
+                fontWeight: 500,
+                fontSize: "14px",
+                lineHeight: "1.3",
+                color: "#616161",
+              }}
+            >
+              Get Noticed! Want to make sure your message doesn't get missed? Announcement Bar lets you
+              display important alerts right at the top of your store. Whether it's a sale, promotion, or
+              update, it's impossible to ignore!
+            </p>
+          </Col>
         </Row>
 
         <DiscountModal show={showDiscountModal} onHide={handleCloseDiscountModal} setActiveAction={setActiveAction} />

--- a/web/frontend/apps/buy-one-get-one/buyoneGetone.jsx
+++ b/web/frontend/apps/buy-one-get-one/buyoneGetone.jsx
@@ -68,7 +68,7 @@ export default function BuyonegetoneForm({ goBack, setActiveAction }) {
             )}
           </Col>
           {/* Left Column: Title + Toggle */}
-          <Col className="d-flex align-items-center justify-content-between">
+          <Col className="d-flex align-items-center gap-3">
             <h5
               className="mb-0"
               style={{

--- a/web/frontend/apps/buy-one-get-one/buyoneGetone.jsx
+++ b/web/frontend/apps/buy-one-get-one/buyoneGetone.jsx
@@ -79,7 +79,7 @@ export default function BuyonegetoneForm({ goBack, setActiveAction }) {
             >
               Buy One Get One
             </h5>
-            <ToggleSwitch appId="buy_one_get_one" />
+            <ToggleSwitch size="small" appId="buy_one_get_one" />
           </Col>
           {/* Right Column: Buttons */}
           {fromDiscountPage ? (

--- a/web/frontend/apps/car-notice/CarNoticeForm.jsx
+++ b/web/frontend/apps/car-notice/CarNoticeForm.jsx
@@ -40,7 +40,7 @@ export default function CarNoticeForm({ goBack, setActiveAction }) {
             )}
           </Col>
           {/* Left Column: Title + Toggle */}
-          <Col className="d-flex align-items-center justify-content-between">
+          <Col className="d-flex align-items-center gap-3">
             <h5
               className="mb-0"
               style={{

--- a/web/frontend/apps/car-notice/CarNoticeForm.jsx
+++ b/web/frontend/apps/car-notice/CarNoticeForm.jsx
@@ -51,7 +51,7 @@ export default function CarNoticeForm({ goBack, setActiveAction }) {
             >
               Cart Notice
             </h5>
-            <ToggleSwitch appId="cart_notice" />
+            <ToggleSwitch size="small" appId="cart_notice" />
           </Col>
           {/* Right Column: Buttons */}
           {fromDiscountPage ? (

--- a/web/frontend/apps/car-notice/CarNoticeForm.jsx
+++ b/web/frontend/apps/car-notice/CarNoticeForm.jsx
@@ -1,30 +1,24 @@
 import React, { useState } from "react";
 import { Container, Row, Col } from "react-bootstrap";
 import { ArrowLeft } from "lucide-react";
-// import DiscountModal from "../../pages/DiscountModal";
-// import DiscountList from "./DiscountList";
+import DiscountList from "./DiscountList";
 import Button from "../../components/Button";
-import DiscountModal from "../../components/Modals/GlobalDisountModal";
 import ToggleSwitch from "../../components/ToggelSwitch";
-export default function CountdownTimerForm() {
-  const [showDiscountModal, setShowDiscountModal] = useState(false);
-  const [fromDiscountPage, setFromDiscountPage] = useState(false);
-  const [resetDiscountList, setResetDiscountList] = useState(false); 
-  const handleOpenDiscountModal = () => {
-    setShowDiscountModal(true);
-  };
 
-  const handleCloseDiscountModal = () => {
-    setShowDiscountModal(false);
-  };
+export default function CarNoticeForm({ goBack, setActiveAction }) {
+  const [fromDiscountPage, setFromDiscountPage] = useState(false);
+  const [resetDiscountList, setResetDiscountList] = useState(false);
+  
   const handleDiscard = () => {
     setFromDiscountPage(false);
-    setResetDiscountList(prev => !prev); // Toggle to force re-render
+    setResetDiscountList(prev => !prev);
   };
+  
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
-        <Row className="mb-4 align-items-start">
+        {/* Header Row: [Back] [Title ... Toggle] [Create Cart Notice] */}
+        <Row className="mb-2 align-items-center">
           <Col xs="auto">
             {fromDiscountPage ? (
               <></>
@@ -36,57 +30,42 @@ export default function CountdownTimerForm() {
                   border: "none",
                   cursor: "pointer",
                 }}
-                onClick={() => console.log("Go back")}
+                onClick={() => {
+                  goBack(true);
+                  setActiveAction(null);
+                }}
               >
                 <ArrowLeft size={24} />
               </div>
             )}
           </Col>
-          <Col>
+          {/* Left Column: Title + Toggle */}
+          <Col className="d-flex align-items-center justify-content-between">
             <h5
-              className="mb-2"
+              className="mb-0"
               style={{
                 fontWeight: 600,
                 fontSize: "20px",
                 lineHeight: "1",
               }}
             >
-              Bundle Discount
+              Cart Notice
             </h5>
-            <p
-              className="mb-0"
-              style={{
-                fontWeight: 500,
-                fontSize: "14px",
-                lineHeight: "1.3",
-                color: "#616161",
-              }}
-            >
-              Get Noticed! Want to make sure your message doesn't get missed?
-              Announcement Bar lets you display important alerts right at the
-              top of your store. Whether it's a sale, promotion, or update, it's
-              impossible to ignore!
-            </p>
+            <ToggleSwitch appId="cart_notice" />
           </Col>
-
+          {/* Right Column: Buttons */}
           {fromDiscountPage ? (
-            <Col
-              xs="auto"
-              className="d-flex align-items-center"
-              style={{ maxWidth: "300px", width: "100%" }}
-            >
+            <Col xs="auto" className="d-flex align-items-center gap-2">
               <Button
                 text="Discard"
-                onClick={handleDiscard} 
+                onClick={handleDiscard}
                 style={{
-                  background:"white",
+                  background: "white",
                   border: "1px solid #dee2e6",
                   height: "45px",
                   fontWeight: 500,
                   fontSize: "15px",
-                  maxWidth: "95px",
                   borderRadius: "8px",
-                  marginRight: "10px",
                   padding: "10px 20px",
                 }}
               />
@@ -105,37 +84,44 @@ export default function CountdownTimerForm() {
               />
             </Col>
           ) : (
-            <Col xs="auto" className="d-flex align-items-center gap-2">
+            <Col xs="auto" className="d-flex align-items-center">
               <Button
-                text="Create Another Discount"
-                onClick={handleOpenDiscountModal}
+                text="Create Cart Notice"
+                onClick={() => setFromDiscountPage(true)}
                 style={{
                   borderRadius: "15px",
-
                   backgroundColor: "#000",
                   color: "#FFFFFF",
                   padding: "15px 25px",
-                  fontFamily: "Inter",
-                  fontStyle: "normal",
                   fontWeight: "500",
                   fontSize: "15px",
-                  lineHeight: "100%",
                 }}
               />
-              <ToggleSwitch appId="buy_one_get_one" />
             </Col>
           )}
         </Row>
 
-        <DiscountModal
-          show={showDiscountModal}
-          onHide={handleCloseDiscountModal}
-          setActiveAction={()=>{}}
-        />
+        {/* Description Row */}
+        <Row className="mb-4">
+          <Col>
+            <p
+              className="mb-0"
+              style={{
+                fontWeight: 500,
+                fontSize: "14px",
+                lineHeight: "1.3",
+                color: "#616161",
+              }}
+            >
+              Display helpful notices in the shopping cart! Show shipping thresholds,
+              promotional messages, or important information to customers as they shop.
+            </p>
+          </Col>
+        </Row>
       </Container>
-      <DiscountList 
-        key={resetDiscountList ? 'reset' : 'normal'} 
-        onMakeBundleClick={() => setFromDiscountPage(true)} 
+      <DiscountList
+        key={resetDiscountList ? 'reset' : 'normal'}
+        onMakeBundleClick={() => setFromDiscountPage(true)}
       />
     </div>
   );

--- a/web/frontend/apps/car-notice/DiscountList.jsx
+++ b/web/frontend/apps/car-notice/DiscountList.jsx
@@ -16,6 +16,43 @@ import Button from "../../components/Button";
 import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
+import VideoList from "../../components/VideoList";
+
+// Cart Notice specific videos
+const cartNoticeVideos = [
+  {
+    id: 1,
+    title: "Cart Notice Basics",
+    description: "Create your first cart notification",
+    src: "/videos/cart-notice-getting-started.mp4",
+    poster: null,
+    duration: "2:25"
+  },
+  {
+    id: 2,
+    title: "Customization",
+    description: "Style your cart notices",
+    src: "/videos/cart-notice-styling.mp4",
+    poster: null,
+    duration: "3:10"
+  },
+  {
+    id: 3,
+    title: "Upsell Strategies",
+    description: "Increase cart value with notices",
+    src: "/videos/cart-notice-upsell.mp4",
+    poster: null,
+    duration: "3:35"
+  },
+  {
+    id: 4,
+    title: "Display Rules",
+    description: "Control when notices appear",
+    src: "/videos/cart-notice-rules.mp4",
+    poster: null,
+    duration: "2:50"
+  }
+];
 
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Discounts", "Setting", "Analytics"];
@@ -197,252 +234,7 @@ export default function DiscountList({ onMakeBundleClick }) {
         }}
       >
         {selectedTab === "Overview" && (
-          <>
-          {/* Video Display */}
-          <Col
-              lg={6} md={12}
-              style={{
-                padding: "50px",
-              }}
-            >
-              <Card
-                className="border-0 h-100 "
-                style={{ background: "transparent !important" }}
-              >
-                <Card.Body
-                  className="p-0 "
-                  style={{ background: "transparent !important" }}
-                >
-                  <div className="position-relative h-100">
-                    <video
-                      controls
-                      poster={videoimg}
-                      style={{
-                        width: "100%",
-                        height: "auto",
-                        borderRadius: "15px",
-                        padding: "4px",
-                      }}
-                    >
-                      <source
-                        src="/videos/marshall-promo.mp4"
-                        type="video/mp4"
-                      />
-                      Your browser does not support the video tag.
-                    </video>
-                    <div className="position-absolute top-50 start-50 translate-middle">
-                      <Button
-                        text={<Play size={24} />}
-                        onClick={() => console.log("Discard")}
-                        variant="light"
-                        className="rounded-circle p-3 opacity-75"
-                      />
-                    </div>
-                  </div>
-                </Card.Body>
-              </Card>
-            </Col>
-
-            {/* Side Features */}
-            <Col
-              lg={6} md={12}
-              style={{
-                padding: "50px 0",
-              }}
-            >
-              <div
-                className="d-flex justify-content-between flex-column linrrowleft"
-                style={{ height: "100%" }}
-              >
-                <div>
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
-                        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Customizable
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Discount, Display style & Priority.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <rect
-                          x="2"
-                          y="3"
-                          width="20"
-                          height="14"
-                          rx="2"
-                          ry="2"
-                        ></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Responsive
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Looks great on any device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-5 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
-                        <path d="M13 2v7h7"></path>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Attention grabbing
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Keep your customers informed without disrupting their
-                        shopping.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="d-flex align-items-start flex-column">
-                  <Button
-                    variant="dark"
-                    className="mb-3 d-flex align-items-center justify-content-center"
-                    text=" Make your Bundle Now!"
-                    style={{
-                      maxWidth: "220px",
-                      borderRadius: "40px",
-                      height: "45px",
-                      fontWeight: 500,
-                      fontSize: "15px",
-                      letterSpacing: "0",
-                      backgroundColor: "black",
-                      borderColor: "black",
-                      color: "white",
-                      padding: "15px 25px",
-                    }}
-                    onClick={() => {
-                      setShowBundleAction(true);
-                      onMakeBundleClick();
-                    }}
-                  />
-
-                  <div>
-                    <span
-                      className="text-secondary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                      }}
-                    >
-                      Learn More about{" "}
-                    </span>
-                    <a
-                      href="#"
-                      className="text-primary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                        color: "#5169DD",
-                      }}
-                    >
-                      How to create bundle?
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </Col>
-          </>
+          <VideoList videos={cartNoticeVideos} appName="Cart Notice" />
         )}
 
         {selectedTab === "Discounts" && (

--- a/web/frontend/apps/car-notice/DiscountList.jsx
+++ b/web/frontend/apps/car-notice/DiscountList.jsx
@@ -92,15 +92,17 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Title with Toggle on left, Create Button on right */}
+      {/* App Header - Two columns: [Title + Toggle] | [Create Button] */}
       <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        {/* Left Column: Title (left) + Toggle (right) */}
+        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
           <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
             Cart Notice
           </h2>
           <ToggleSwitch appId="cart_notice" />
         </Col>
-        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+        {/* Right Column: Create Button */}
+        <Col xs={12} md={6} className="d-flex justify-content-end">
           <Button
             text="Create Notice"
             onClick={() => {
@@ -114,7 +116,6 @@ export default function DiscountList({ onMakeBundleClick }) {
               color: "white",
               fontWeight: 600,
               fontSize: "14px",
-              minWidth: "180px",
               height: "48px",
             }}
           />

--- a/web/frontend/apps/car-notice/DiscountList.jsx
+++ b/web/frontend/apps/car-notice/DiscountList.jsx
@@ -17,6 +17,7 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
+import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Cart Notice specific videos
 const cartNoticeVideos = [
@@ -91,6 +92,35 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
+      {/* App Header - Title with Toggle on left, Create Button on right */}
+      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
+        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
+            Cart Notice
+          </h2>
+          <ToggleSwitch appId="cart_notice" />
+        </Col>
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text="Create Notice"
+            onClick={() => {
+              setShowBundleAction(true);
+              if (onMakeBundleClick) onMakeBundleClick();
+            }}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px",
+            }}
+          />
+        </Col>
+      </Row>
+
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">
@@ -99,15 +129,13 @@ export default function DiscountList({ onMakeBundleClick }) {
             style={{
               marginLeft: "0",
               marginRight: "0",
-             
-                padding: "0px",
-                boxShadow: "1px 1px 4px 0px #0000001A inset",
-                backgroundColor: "#F1F2F4",
-                borderRadius: "15px",
-                marginBottom: "8px",
-                height: "51px",
-                width:"100%"
-              
+              padding: "0px",
+              boxShadow: "1px 1px 4px 0px #0000001A inset",
+              backgroundColor: "#F1F2F4",
+              borderRadius: "15px",
+              marginBottom: "8px",
+              height: "51px",
+              width: "100%",
             }}
           >
             {/* Left-aligned Toggle Buttons */}
@@ -132,7 +160,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                           borderColor: "black",
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -145,7 +172,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                       : {
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -162,23 +188,7 @@ export default function DiscountList({ onMakeBundleClick }) {
                 </ToggleButton>
               ))}
             </ButtonGroup>
-
-            {/* Right-aligned Create Discount Button */}
           </div>
-          {selectedTab === "Discounts" && (
-            <Button
-              text="Create Discount"
-              onClick={() => console.log("Create Discount")}
-              style={{
-                background: "black",
-                borderRadius: "12px",
-                padding: "15px 12px",
-                color: "white",
-                width: "200px",
-                height: "51px",
-              }}
-            />
-          )}
         </div>
       </Row>
       {selectedTab === "Discounts" && (

--- a/web/frontend/apps/car-notice/DiscountList.jsx
+++ b/web/frontend/apps/car-notice/DiscountList.jsx
@@ -17,7 +17,6 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
-import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Cart Notice specific videos
 const cartNoticeVideos = [
@@ -92,36 +91,6 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Two columns: [Title + Toggle] | [Create Button] */}
-      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        {/* Left Column: Title (left) + Toggle (right) */}
-        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
-          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
-            Cart Notice
-          </h2>
-          <ToggleSwitch appId="cart_notice" />
-        </Col>
-        {/* Right Column: Create Button */}
-        <Col xs={12} md={6} className="d-flex justify-content-end">
-          <Button
-            text="Create Notice"
-            onClick={() => {
-              setShowBundleAction(true);
-              if (onMakeBundleClick) onMakeBundleClick();
-            }}
-            style={{
-              background: "black",
-              borderRadius: "12px",
-              padding: "12px 24px",
-              color: "white",
-              fontWeight: 600,
-              fontSize: "14px",
-              height: "48px",
-            }}
-          />
-        </Col>
-      </Row>
-
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">

--- a/web/frontend/apps/countdown-timer/CountdownTimerForm.jsx
+++ b/web/frontend/apps/countdown-timer/CountdownTimerForm.jsx
@@ -1,31 +1,24 @@
 import React, { useState } from "react";
 import { Container, Row, Col } from "react-bootstrap";
 import { ArrowLeft } from "lucide-react";
-// import DiscountModal from "../../pages/DiscountModal";
 import DiscountList from "./DiscountList";
 import Button from "../../components/Button";
-import DiscountModal from "../../components/Modals/GlobalDisountModal";
 import ToggleSwitch from "../../components/ToggelSwitch";
 
-export default function InactiveTabMessageForm() {
-  const [showDiscountModal, setShowDiscountModal] = useState(false);
+export default function CountdownTimerForm({ goBack, setActiveAction }) {
   const [fromDiscountPage, setFromDiscountPage] = useState(false);
-  const [resetDiscountList, setResetDiscountList] = useState(false); 
-  const handleOpenDiscountModal = () => {
-    setShowDiscountModal(true);
-  };
-
-  const handleCloseDiscountModal = () => {
-    setShowDiscountModal(false);
-  };
+  const [resetDiscountList, setResetDiscountList] = useState(false);
+  
   const handleDiscard = () => {
     setFromDiscountPage(false);
-    setResetDiscountList(prev => !prev); // Toggle to force re-render
+    setResetDiscountList(prev => !prev);
   };
+  
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
-        <Row className="mb-4 align-items-start">
+        {/* Header Row: [Back] [Title ... Toggle] [Create Countdown Timer] */}
+        <Row className="mb-2 align-items-center">
           <Col xs="auto">
             {fromDiscountPage ? (
               <></>
@@ -37,57 +30,42 @@ export default function InactiveTabMessageForm() {
                   border: "none",
                   cursor: "pointer",
                 }}
-                onClick={() => console.log("Go back")}
+                onClick={() => {
+                  goBack(true);
+                  setActiveAction(null);
+                }}
               >
                 <ArrowLeft size={24} />
               </div>
             )}
           </Col>
-          <Col>
+          {/* Left Column: Title + Toggle */}
+          <Col className="d-flex align-items-center justify-content-between">
             <h5
-              className="mb-2"
+              className="mb-0"
               style={{
                 fontWeight: 600,
                 fontSize: "20px",
                 lineHeight: "1",
               }}
             >
-              Bundle Discount
+              Countdown Timer
             </h5>
-            <p
-              className="mb-0"
-              style={{
-                fontWeight: 500,
-                fontSize: "14px",
-                lineHeight: "1.3",
-                color: "#616161",
-              }}
-            >
-              Get Noticed! Want to make sure your message doesn't get missed?
-              Announcement Bar lets you display important alerts right at the
-              top of your store. Whether it's a sale, promotion, or update, it's
-              impossible to ignore!
-            </p>
+            <ToggleSwitch appId="countdown_timer" />
           </Col>
-
+          {/* Right Column: Buttons */}
           {fromDiscountPage ? (
-            <Col
-              xs="auto"
-              className="d-flex align-items-center"
-              style={{ maxWidth: "300px", width: "100%" }}
-            >
+            <Col xs="auto" className="d-flex align-items-center gap-2">
               <Button
                 text="Discard"
-                onClick={handleDiscard} 
+                onClick={handleDiscard}
                 style={{
-                  background:"white",
+                  background: "white",
                   border: "1px solid #dee2e6",
                   height: "45px",
                   fontWeight: 500,
                   fontSize: "15px",
-                  maxWidth: "95px",
                   borderRadius: "8px",
-                  marginRight: "10px",
                   padding: "10px 20px",
                 }}
               />
@@ -106,37 +84,44 @@ export default function InactiveTabMessageForm() {
               />
             </Col>
           ) : (
-            <Col xs="auto" className="d-flex align-items-center gap-2">
+            <Col xs="auto" className="d-flex align-items-center">
               <Button
-                text="Create Another Discount"
-                onClick={handleOpenDiscountModal}
+                text="Create Countdown Timer"
+                onClick={() => setFromDiscountPage(true)}
                 style={{
                   borderRadius: "15px",
-
                   backgroundColor: "#000",
                   color: "#FFFFFF",
                   padding: "15px 25px",
-                  fontFamily: "Inter",
-                  fontStyle: "normal",
                   fontWeight: "500",
                   fontSize: "15px",
-                  lineHeight: "100%",
                 }}
               />
-              <ToggleSwitch appId="buy_one_get_one" />
             </Col>
           )}
         </Row>
 
-        <DiscountModal
-          show={showDiscountModal}
-          onHide={handleCloseDiscountModal}
-          setActiveAction={()=>{}}
-        />
+        {/* Description Row */}
+        <Row className="mb-4">
+          <Col>
+            <p
+              className="mb-0"
+              style={{
+                fontWeight: 500,
+                fontSize: "14px",
+                lineHeight: "1.3",
+                color: "#616161",
+              }}
+            >
+              Create urgency with countdown timers! Display time-limited offers and sales
+              countdowns to encourage customers to act fast before they miss out.
+            </p>
+          </Col>
+        </Row>
       </Container>
-      <DiscountList 
-        key={resetDiscountList ? 'reset' : 'normal'} 
-        onMakeBundleClick={() => setFromDiscountPage(true)} 
+      <DiscountList
+        key={resetDiscountList ? 'reset' : 'normal'}
+        onMakeBundleClick={() => setFromDiscountPage(true)}
       />
     </div>
   );

--- a/web/frontend/apps/countdown-timer/CountdownTimerForm.jsx
+++ b/web/frontend/apps/countdown-timer/CountdownTimerForm.jsx
@@ -51,7 +51,7 @@ export default function CountdownTimerForm({ goBack, setActiveAction }) {
             >
               Countdown Timer
             </h5>
-            <ToggleSwitch appId="countdown_timer" />
+            <ToggleSwitch size="small" appId="countdown_timer" />
           </Col>
           {/* Right Column: Buttons */}
           {fromDiscountPage ? (

--- a/web/frontend/apps/countdown-timer/CountdownTimerForm.jsx
+++ b/web/frontend/apps/countdown-timer/CountdownTimerForm.jsx
@@ -40,7 +40,7 @@ export default function CountdownTimerForm({ goBack, setActiveAction }) {
             )}
           </Col>
           {/* Left Column: Title + Toggle */}
-          <Col className="d-flex align-items-center justify-content-between">
+          <Col className="d-flex align-items-center gap-3">
             <h5
               className="mb-0"
               style={{

--- a/web/frontend/apps/countdown-timer/DiscountList.jsx
+++ b/web/frontend/apps/countdown-timer/DiscountList.jsx
@@ -16,6 +16,43 @@ import Button from "../../components/Button";
 import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
+import VideoList from "../../components/VideoList";
+
+// Countdown Timer specific videos
+const countdownTimerVideos = [
+  {
+    id: 1,
+    title: "Timer Setup",
+    description: "Create your first countdown timer",
+    src: "/videos/countdown-getting-started.mp4",
+    poster: null,
+    duration: "2:10"
+  },
+  {
+    id: 2,
+    title: "Timer Styles",
+    description: "Customize the look of your timer",
+    src: "/videos/countdown-styling.mp4",
+    poster: null,
+    duration: "2:45"
+  },
+  {
+    id: 3,
+    title: "Urgency Marketing",
+    description: "Use timers to boost conversions",
+    src: "/videos/countdown-urgency.mp4",
+    poster: null,
+    duration: "3:20"
+  },
+  {
+    id: 4,
+    title: "Scheduling",
+    description: "Schedule timers for promotions",
+    src: "/videos/countdown-scheduling.mp4",
+    poster: null,
+    duration: "2:55"
+  }
+];
 
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Discounts", "Setting", "Analytics"];
@@ -197,252 +234,7 @@ export default function DiscountList({ onMakeBundleClick }) {
         }}
       >
         {selectedTab === "Overview" && (
-          <>
-           {/* Video Display */}
-           <Col
-              lg={6} md={12}
-              style={{
-                padding: "50px",
-              }}
-            >
-              <Card
-                className="border-0 h-100 "
-                style={{ background: "transparent !important" }}
-              >
-                <Card.Body
-                  className="p-0 "
-                  style={{ background: "transparent !important" }}
-                >
-                  <div className="position-relative h-100">
-                    <video
-                      controls
-                      poster={videoimg}
-                      style={{
-                        width: "100%",
-                        height: "auto",
-                        borderRadius: "15px",
-                        padding: "4px",
-                      }}
-                    >
-                      <source
-                        src="/videos/marshall-promo.mp4"
-                        type="video/mp4"
-                      />
-                      Your browser does not support the video tag.
-                    </video>
-                    <div className="position-absolute top-50 start-50 translate-middle">
-                      <Button
-                        text={<Play size={24} />}
-                        onClick={() => console.log("Discard")}
-                        variant="light"
-                        className="rounded-circle p-3 opacity-75"
-                      />
-                    </div>
-                  </div>
-                </Card.Body>
-              </Card>
-            </Col>
-
-            {/* Side Features */}
-            <Col
-              lg={6} md={12}
-              style={{
-                padding: "50px 0",
-              }}
-            >
-              <div
-                className="d-flex justify-content-between flex-column linrrowleft"
-                style={{ height: "100%" }}
-              >
-                <div>
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
-                        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Customizable
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Discount, Display style & Priority.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <rect
-                          x="2"
-                          y="3"
-                          width="20"
-                          height="14"
-                          rx="2"
-                          ry="2"
-                        ></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Responsive
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Looks great on any device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-5 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
-                        <path d="M13 2v7h7"></path>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Attention grabbing
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Keep your customers informed without disrupting their
-                        shopping.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="d-flex align-items-start flex-column">
-                  <Button
-                    variant="dark"
-                    className="mb-3 d-flex align-items-center justify-content-center"
-                    text=" Make your Bundle Now!"
-                    style={{
-                      maxWidth: "220px",
-                      borderRadius: "40px",
-                      height: "45px",
-                      fontWeight: 500,
-                      fontSize: "15px",
-                      letterSpacing: "0",
-                      backgroundColor: "black",
-                      borderColor: "black",
-                      color: "white",
-                      padding: "15px 25px",
-                    }}
-                    onClick={() => {
-                      setShowBundleAction(true);
-                      onMakeBundleClick();
-                    }}
-                  />
-
-                  <div>
-                    <span
-                      className="text-secondary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                      }}
-                    >
-                      Learn More about{" "}
-                    </span>
-                    <a
-                      href="#"
-                      className="text-primary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                        color: "#5169DD",
-                      }}
-                    >
-                      How to create bundle?
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </Col>
-          </>
+          <VideoList videos={countdownTimerVideos} appName="Countdown Timer" />
         )}
 
         {selectedTab === "Discounts" && (

--- a/web/frontend/apps/countdown-timer/DiscountList.jsx
+++ b/web/frontend/apps/countdown-timer/DiscountList.jsx
@@ -17,6 +17,7 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
+import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Countdown Timer specific videos
 const countdownTimerVideos = [
@@ -91,6 +92,35 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
+      {/* App Header - Title with Toggle on left, Create Button on right */}
+      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
+        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
+            Countdown Timer
+          </h2>
+          <ToggleSwitch appId="countdown_timer" />
+        </Col>
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text="Create Timer"
+            onClick={() => {
+              setShowBundleAction(true);
+              if (onMakeBundleClick) onMakeBundleClick();
+            }}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px",
+            }}
+          />
+        </Col>
+      </Row>
+
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">
@@ -99,15 +129,13 @@ export default function DiscountList({ onMakeBundleClick }) {
             style={{
               marginLeft: "0",
               marginRight: "0",
-             
-                padding: "0px",
-                boxShadow: "1px 1px 4px 0px #0000001A inset",
-                backgroundColor: "#F1F2F4",
-                borderRadius: "15px",
-                marginBottom: "8px",
-                height: "51px",
-                width:"100%"
-              
+              padding: "0px",
+              boxShadow: "1px 1px 4px 0px #0000001A inset",
+              backgroundColor: "#F1F2F4",
+              borderRadius: "15px",
+              marginBottom: "8px",
+              height: "51px",
+              width: "100%",
             }}
           >
             {/* Left-aligned Toggle Buttons */}
@@ -132,7 +160,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                           borderColor: "black",
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -145,7 +172,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                       : {
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -162,23 +188,7 @@ export default function DiscountList({ onMakeBundleClick }) {
                 </ToggleButton>
               ))}
             </ButtonGroup>
-
-            {/* Right-aligned Create Discount Button */}
           </div>
-          {selectedTab === "Discounts" && (
-            <Button
-              text="Create Discount"
-              onClick={() => console.log("Create Discount")}
-              style={{
-                background: "black",
-                borderRadius: "12px",
-                padding: "15px 12px",
-                color: "white",
-                width: "200px",
-                height: "51px",
-              }}
-            />
-          )}
         </div>
       </Row>
       {selectedTab === "Discounts" && (

--- a/web/frontend/apps/countdown-timer/DiscountList.jsx
+++ b/web/frontend/apps/countdown-timer/DiscountList.jsx
@@ -17,7 +17,6 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
-import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Countdown Timer specific videos
 const countdownTimerVideos = [
@@ -92,36 +91,6 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Two columns: [Title + Toggle] | [Create Button] */}
-      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        {/* Left Column: Title (left) + Toggle (right) */}
-        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
-          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
-            Countdown Timer
-          </h2>
-          <ToggleSwitch appId="countdown_timer" />
-        </Col>
-        {/* Right Column: Create Button */}
-        <Col xs={12} md={6} className="d-flex justify-content-end">
-          <Button
-            text="Create Timer"
-            onClick={() => {
-              setShowBundleAction(true);
-              if (onMakeBundleClick) onMakeBundleClick();
-            }}
-            style={{
-              background: "black",
-              borderRadius: "12px",
-              padding: "12px 24px",
-              color: "white",
-              fontWeight: 600,
-              fontSize: "14px",
-              height: "48px",
-            }}
-          />
-        </Col>
-      </Row>
-
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">

--- a/web/frontend/apps/countdown-timer/DiscountList.jsx
+++ b/web/frontend/apps/countdown-timer/DiscountList.jsx
@@ -92,15 +92,17 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Title with Toggle on left, Create Button on right */}
+      {/* App Header - Two columns: [Title + Toggle] | [Create Button] */}
       <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        {/* Left Column: Title (left) + Toggle (right) */}
+        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
           <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
             Countdown Timer
           </h2>
           <ToggleSwitch appId="countdown_timer" />
         </Col>
-        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+        {/* Right Column: Create Button */}
+        <Col xs={12} md={6} className="d-flex justify-content-end">
           <Button
             text="Create Timer"
             onClick={() => {
@@ -114,7 +116,6 @@ export default function DiscountList({ onMakeBundleClick }) {
               color: "white",
               fontWeight: 600,
               fontSize: "14px",
-              minWidth: "180px",
               height: "48px",
             }}
           />

--- a/web/frontend/apps/inactive-tab-message/DiscountList.jsx
+++ b/web/frontend/apps/inactive-tab-message/DiscountList.jsx
@@ -20,7 +20,6 @@ import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import EmojiPicker from "emoji-picker-react";
 import VideoList from "../../components/VideoList";
-import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Inactive Tab Message specific videos
 const inactiveTabVideos = [
@@ -267,36 +266,6 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Two columns: [Title + Toggle] | [Create Button] */}
-      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        {/* Left Column: Title (left) + Toggle (right) */}
-        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
-          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
-            Inactive Tab Message
-          </h2>
-          <ToggleSwitch appId="inactive_tab_message" />
-        </Col>
-        {/* Right Column: Create Button */}
-        <Col xs={12} md={6} className="d-flex justify-content-end">
-          <Button
-            text="Create Message"
-            onClick={() => {
-              setShowBundleAction(true);
-              if (onMakeBundleClick) onMakeBundleClick();
-            }}
-            style={{
-              background: "black",
-              borderRadius: "12px",
-              padding: "12px 24px",
-              color: "white",
-              fontWeight: 600,
-              fontSize: "14px",
-              height: "48px",
-            }}
-          />
-        </Col>
-      </Row>
-
       {/* Alert Notification */}
       {alert.show && (
         <Alert variant={alert.type} className="mt-3">

--- a/web/frontend/apps/inactive-tab-message/DiscountList.jsx
+++ b/web/frontend/apps/inactive-tab-message/DiscountList.jsx
@@ -267,15 +267,17 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Title with Toggle on left, Create Button on right */}
+      {/* App Header - Two columns: [Title + Toggle] | [Create Button] */}
       <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        {/* Left Column: Title (left) + Toggle (right) */}
+        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
           <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
             Inactive Tab Message
           </h2>
           <ToggleSwitch appId="inactive_tab_message" />
         </Col>
-        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+        {/* Right Column: Create Button */}
+        <Col xs={12} md={6} className="d-flex justify-content-end">
           <Button
             text="Create Message"
             onClick={() => {
@@ -289,7 +291,6 @@ export default function DiscountList({ onMakeBundleClick }) {
               color: "white",
               fontWeight: 600,
               fontSize: "14px",
-              minWidth: "180px",
               height: "48px",
             }}
           />

--- a/web/frontend/apps/inactive-tab-message/DiscountList.jsx
+++ b/web/frontend/apps/inactive-tab-message/DiscountList.jsx
@@ -20,6 +20,7 @@ import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import EmojiPicker from "emoji-picker-react";
 import VideoList from "../../components/VideoList";
+import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Inactive Tab Message specific videos
 const inactiveTabVideos = [
@@ -266,6 +267,35 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
+      {/* App Header - Title with Toggle on left, Create Button on right */}
+      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
+        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
+            Inactive Tab Message
+          </h2>
+          <ToggleSwitch appId="inactive_tab_message" />
+        </Col>
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text="Create Message"
+            onClick={() => {
+              setShowBundleAction(true);
+              if (onMakeBundleClick) onMakeBundleClick();
+            }}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px",
+            }}
+          />
+        </Col>
+      </Row>
+
       {/* Alert Notification */}
       {alert.show && (
         <Alert variant={alert.type} className="mt-3">

--- a/web/frontend/apps/inactive-tab-message/DiscountList.jsx
+++ b/web/frontend/apps/inactive-tab-message/DiscountList.jsx
@@ -19,6 +19,43 @@ import { X, Trash, Upload } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import EmojiPicker from "emoji-picker-react";
+import VideoList from "../../components/VideoList";
+
+// Inactive Tab Message specific videos
+const inactiveTabVideos = [
+  {
+    id: 1,
+    title: "Tab Message Setup",
+    description: "Configure your browser tab messages",
+    src: "/videos/inactive-tab-getting-started.mp4",
+    poster: null,
+    duration: "2:00"
+  },
+  {
+    id: 2,
+    title: "Message Customization",
+    description: "Create engaging tab messages",
+    src: "/videos/inactive-tab-messages.mp4",
+    poster: null,
+    duration: "2:30"
+  },
+  {
+    id: 3,
+    title: "Favicon Animation",
+    description: "Use animated favicons for attention",
+    src: "/videos/inactive-tab-favicon.mp4",
+    poster: null,
+    duration: "2:15"
+  },
+  {
+    id: 4,
+    title: "Best Practices",
+    description: "Tips for effective tab messaging",
+    src: "/videos/inactive-tab-best-practices.mp4",
+    poster: null,
+    duration: "2:45"
+  }
+];
 
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Setting"];
@@ -317,232 +354,7 @@ export default function DiscountList({ onMakeBundleClick }) {
         }}
       >
         {selectedTab === "Overview" && (
-          <>
-            {/* Video Display */}
-            <Col
-              lg={6}
-              md={12}
-              style={{
-                padding: "50px",
-              }}
-            >
-              <Card
-                className="border-0 h-100 "
-                style={{ background: "transparent !important" }}
-              >
-                <Card.Body
-                  className="p-0 "
-                  style={{ background: "transparent !important" }}
-                >
-                  <div className="position-relative h-100">
-                    <video
-                      controls
-                      poster={videoimg}
-                      style={{
-                        width: "100%",
-                        height: "auto",
-                        borderRadius: "15px",
-                        padding: "4px",
-                      }}
-                    >
-                      <source
-                        src="/videos/marshall-promo.mp4"
-                        type="video/mp4"
-                      />
-                      Your browser does not support the video tag.
-                    </video>
-                    <div className="position-absolute top-50 start-50 translate-middle">
-                      <Button
-                        text={<Play size={24} />}
-                        onClick={() => console.log("Discard")}
-                        variant="light"
-                        className="rounded-circle p-3 opacity-75"
-                      />
-                    </div>
-                  </div>
-                </Card.Body>
-              </Card>
-            </Col>
-
-            {/* Side Features */}
-            <Col
-              lg={6}
-              md={12}
-              style={{
-                padding: "50px 0",
-              }}
-            >
-              <div
-                className="d-flex justify-content-between flex-column linrrowleft"
-                style={{ height: "100%" }}
-              >
-                <div>
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
-                        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Customizable
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Message, Display timing & Images.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <rect
-                          x="2"
-                          y="3"
-                          width="20"
-                          height="14"
-                          rx="2"
-                          ry="2"
-                        ></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Responsive
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Looks great on any device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-5 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
-                        <path d="M13 2v7h7"></path>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Attention grabbing
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Keep your customers informed without disrupting their
-                        shopping.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="d-flex align-items-start flex-column">
-                  <div>
-                    <span
-                      className="text-secondary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                      }}
-                    >
-                      Learn More about{" "}
-                    </span>
-                    <a
-                      href="#"
-                      className="text-primary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                        color: "#5169DD",
-                      }}
-                    >
-                      How to create inactive tab messages?
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </Col>
-          </>
+          <VideoList videos={inactiveTabVideos} appName="Inactive Tab Message" />
         )}
 
         {selectedTab === "Setting" && (

--- a/web/frontend/apps/inactive-tab-message/InactiveTabMessageForm.jsx
+++ b/web/frontend/apps/inactive-tab-message/InactiveTabMessageForm.jsx
@@ -40,7 +40,7 @@ export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
             )}
           </Col>
           {/* Left Column: Title + Toggle */}
-          <Col className="d-flex align-items-center justify-content-between">
+          <Col className="d-flex align-items-center gap-3">
             <h5
               className="mb-0"
               style={{
@@ -53,52 +53,7 @@ export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
             </h5>
             <ToggleSwitch appId="inactive_tab" />
           </Col>
-          {/* Right Column: Buttons */}
-          {fromDiscountPage ? (
-            <Col xs="auto" className="d-flex align-items-center gap-2">
-              <Button
-                text="Discard"
-                onClick={handleDiscard}
-                style={{
-                  background: "white",
-                  border: "1px solid #dee2e6",
-                  height: "45px",
-                  fontWeight: 500,
-                  fontSize: "15px",
-                  borderRadius: "8px",
-                  padding: "10px 20px",
-                }}
-              />
-              <Button
-                text="Save Changes"
-                onClick={() => console.log("Save")}
-                style={{
-                  height: "45px",
-                  fontWeight: 500,
-                  fontSize: "15px",
-                  borderRadius: "8px",
-                  backgroundColor: "#000",
-                  color: "#fff",
-                  padding: "10px 20px",
-                }}
-              />
-            </Col>
-          ) : (
-            <Col xs="auto" className="d-flex align-items-center">
-              <Button
-                text="Create Inactive Tab Message"
-                onClick={() => setFromDiscountPage(true)}
-                style={{
-                  borderRadius: "15px",
-                  backgroundColor: "#000",
-                  color: "#FFFFFF",
-                  padding: "15px 25px",
-                  fontWeight: "500",
-                  fontSize: "15px",
-                }}
-              />
-            </Col>
-          )}
+          {/* No create button for Inactive Tab Message */}
         </Row>
 
         {/* Description Row */}

--- a/web/frontend/apps/inactive-tab-message/InactiveTabMessageForm.jsx
+++ b/web/frontend/apps/inactive-tab-message/InactiveTabMessageForm.jsx
@@ -1,32 +1,24 @@
 import React, { useState } from "react";
 import { Container, Row, Col } from "react-bootstrap";
 import { ArrowLeft } from "lucide-react";
-// import DiscountModal from "../../pages/DiscountModal";
 import DiscountList from "./DiscountList";
 import Button from "../../components/Button";
-import DiscountModal from "../../components/Modals/GlobalDisountModal";
 import ToggleSwitch from "../../components/ToggelSwitch";
 
 export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
-  const [showDiscountModal, setShowDiscountModal] = useState(false);
   const [fromDiscountPage, setFromDiscountPage] = useState(false);
   const [resetDiscountList, setResetDiscountList] = useState(false);
-  const handleOpenDiscountModal = () => {
-    setShowDiscountModal(true);
-  };
-
-  const handleCloseDiscountModal = () => {
-    setShowDiscountModal(false);
-  };
+  
   const handleDiscard = () => {
     setFromDiscountPage(false);
-    setResetDiscountList((prev) => !prev); // Toggle to force re-render
+    setResetDiscountList((prev) => !prev);
   };
 
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
-        <Row className="mb-4 align-items-start">
+        {/* Header Row: [Back] [Title ... Toggle] [Create Inactive Tab Message] */}
+        <Row className="mb-2 align-items-center">
           <Col xs="auto">
             {fromDiscountPage ? (
               <></>
@@ -47,9 +39,10 @@ export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
               </div>
             )}
           </Col>
-          <Col>
+          {/* Left Column: Title + Toggle */}
+          <Col className="d-flex align-items-center justify-content-between">
             <h5
-              className="mb-2"
+              className="mb-0"
               style={{
                 fontWeight: 600,
                 fontSize: "20px",
@@ -58,28 +51,11 @@ export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
             >
               Inactive Tab Message
             </h5>
-            <p
-              className="mb-0"
-              style={{
-                fontWeight: 500,
-                fontSize: "14px",
-                lineHeight: "1.3",
-                color: "#616161",
-              }}
-            >
-              Don’t Let Them Forget! 🔖 Keep your store top-of-mind – even when
-              customers switch tabs! Inactive Tab Message displays a custom
-              alert in the title of their browser tab, so they’ll remember their
-              cart, discounts, or promotions!
-            </p>
+            <ToggleSwitch appId="inactive_tab" />
           </Col>
-
+          {/* Right Column: Buttons */}
           {fromDiscountPage ? (
-            <Col
-              xs="auto"
-              className="d-flex align-items-center"
-              style={{ maxWidth: "300px", width: "100%" }}
-            >
+            <Col xs="auto" className="d-flex align-items-center gap-2">
               <Button
                 text="Discard"
                 onClick={handleDiscard}
@@ -89,9 +65,7 @@ export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
                   height: "45px",
                   fontWeight: 500,
                   fontSize: "15px",
-                  maxWidth: "95px",
                   borderRadius: "8px",
-                  marginRight: "10px",
                   padding: "10px 20px",
                 }}
               />
@@ -110,33 +84,42 @@ export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
               />
             </Col>
           ) : (
-            <Col xs="auto" className="d-flex align-items-center gap-2">
+            <Col xs="auto" className="d-flex align-items-center">
               <Button
-                text="Create Another Discount"
-                onClick={handleOpenDiscountModal}
+                text="Create Inactive Tab Message"
+                onClick={() => setFromDiscountPage(true)}
                 style={{
                   borderRadius: "15px",
-
                   backgroundColor: "#000",
                   color: "#FFFFFF",
                   padding: "15px 25px",
-                  fontFamily: "Inter",
-                  fontStyle: "normal",
                   fontWeight: "500",
                   fontSize: "15px",
-                  lineHeight: "100%",
                 }}
               />
-              <ToggleSwitch appId="inactive_tab" />
             </Col>
           )}
         </Row>
 
-        <DiscountModal
-          show={showDiscountModal}
-          onHide={handleCloseDiscountModal}
-          setActiveAction={setActiveAction}
-        />
+        {/* Description Row */}
+        <Row className="mb-4">
+          <Col>
+            <p
+              className="mb-0"
+              style={{
+                fontWeight: 500,
+                fontSize: "14px",
+                lineHeight: "1.3",
+                color: "#616161",
+              }}
+            >
+              Don't Let Them Forget! 🔖 Keep your store top-of-mind – even when
+              customers switch tabs! Inactive Tab Message displays a custom
+              alert in the title of their browser tab, so they'll remember their
+              cart, discounts, or promotions!
+            </p>
+          </Col>
+        </Row>
       </Container>
       <DiscountList
         key={resetDiscountList ? "reset" : "normal"}
@@ -145,5 +128,3 @@ export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
     </div>
   );
 }
-
-

--- a/web/frontend/apps/inactive-tab-message/InactiveTabMessageForm.jsx
+++ b/web/frontend/apps/inactive-tab-message/InactiveTabMessageForm.jsx
@@ -51,7 +51,7 @@ export default function InactiveTabMessageForm({ goBack, setActiveAction }) {
             >
               Inactive Tab Message
             </h5>
-            <ToggleSwitch appId="inactive_tab" />
+            <ToggleSwitch size="small" appId="inactive_tab" />
           </Col>
           {/* No create button for Inactive Tab Message */}
         </Row>

--- a/web/frontend/apps/mix-and-match-discounts/DiscountList.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/DiscountList.jsx
@@ -17,7 +17,6 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
-import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Mix & Match specific videos
 const mixMatchVideos = [
@@ -98,50 +97,6 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Two columns: [Title + Toggle] | [Create Another Discount + Create Mix & Match] */}
-      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        {/* Left Column: Title (left) + Toggle (right) */}
-        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
-          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
-            Mix & Match
-          </h2>
-          <ToggleSwitch appId="mix_match" />
-        </Col>
-        {/* Right Column: Create Another Discount + Create Mix & Match */}
-        <Col xs={12} md={6} className="d-flex justify-content-end gap-2">
-          <Button
-            text="Create Another Discount"
-            onClick={() => console.log("Create Another Discount")}
-            style={{
-              background: "white",
-              borderRadius: "12px",
-              padding: "12px 20px",
-              color: "#303030",
-              fontWeight: 600,
-              fontSize: "14px",
-              border: "1px solid #e3e3e3",
-              height: "48px",
-            }}
-          />
-          <Button
-            text="Create Mix & Match"
-            onClick={() => {
-              setShowBundleAction(true);
-              if (onMakeBundleClick) onMakeBundleClick();
-            }}
-            style={{
-              background: "black",
-              borderRadius: "12px",
-              padding: "12px 24px",
-              color: "white",
-              fontWeight: 600,
-              fontSize: "14px",
-              height: "48px",
-            }}
-          />
-        </Col>
-      </Row>
-
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">

--- a/web/frontend/apps/mix-and-match-discounts/DiscountList.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/DiscountList.jsx
@@ -17,6 +17,7 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
+import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Mix & Match specific videos
 const mixMatchVideos = [
@@ -97,6 +98,35 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
+      {/* App Header - Title with Toggle on left, Create Button on right */}
+      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
+        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
+            Mix & Match
+          </h2>
+          <ToggleSwitch appId="mix_match" />
+        </Col>
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text="Create Mix & Match"
+            onClick={() => {
+              setShowBundleAction(true);
+              if (onMakeBundleClick) onMakeBundleClick();
+            }}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px",
+            }}
+          />
+        </Col>
+      </Row>
+
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">
@@ -105,15 +135,13 @@ export default function DiscountList({ onMakeBundleClick }) {
             style={{
               marginLeft: "0",
               marginRight: "0",
-             
-                padding: "0px",
-                boxShadow: "1px 1px 4px 0px #0000001A inset",
-                backgroundColor: "#F1F2F4",
-                borderRadius: "15px",
-                marginBottom: "8px",
-                height: "51px",
-                width:"100%"
-              
+              padding: "0px",
+              boxShadow: "1px 1px 4px 0px #0000001A inset",
+              backgroundColor: "#F1F2F4",
+              borderRadius: "15px",
+              marginBottom: "8px",
+              height: "51px",
+              width: "100%",
             }}
           >
             {/* Left-aligned Toggle Buttons */}
@@ -138,7 +166,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                           borderColor: "black",
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -151,7 +178,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                       : {
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -168,23 +194,7 @@ export default function DiscountList({ onMakeBundleClick }) {
                 </ToggleButton>
               ))}
             </ButtonGroup>
-
-            {/* Right-aligned Create Discount Button */}
           </div>
-          {selectedTab === "Discounts" && (
-            <Button
-              text="Create Discount"
-              onClick={() => console.log("Create Discount")}
-              style={{
-                background: "black",
-                borderRadius: "12px",
-                padding: "15px 12px",
-                color: "white",
-                width: "200px",
-                height: "51px",
-              }}
-            />
-          )}
         </div>
       </Row>
       {selectedTab === "Discounts" && (

--- a/web/frontend/apps/mix-and-match-discounts/DiscountList.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/DiscountList.jsx
@@ -98,15 +98,31 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Title with Toggle on left, Create Button on right */}
+      {/* App Header - Two columns: [Title + Toggle] | [Create Another Discount + Create Mix & Match] */}
       <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        {/* Left Column: Title (left) + Toggle (right) */}
+        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
           <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
             Mix & Match
           </h2>
           <ToggleSwitch appId="mix_match" />
         </Col>
-        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+        {/* Right Column: Create Another Discount + Create Mix & Match */}
+        <Col xs={12} md={6} className="d-flex justify-content-end gap-2">
+          <Button
+            text="Create Another Discount"
+            onClick={() => console.log("Create Another Discount")}
+            style={{
+              background: "white",
+              borderRadius: "12px",
+              padding: "12px 20px",
+              color: "#303030",
+              fontWeight: 600,
+              fontSize: "14px",
+              border: "1px solid #e3e3e3",
+              height: "48px",
+            }}
+          />
           <Button
             text="Create Mix & Match"
             onClick={() => {
@@ -120,7 +136,6 @@ export default function DiscountList({ onMakeBundleClick }) {
               color: "white",
               fontWeight: 600,
               fontSize: "14px",
-              minWidth: "180px",
               height: "48px",
             }}
           />

--- a/web/frontend/apps/mix-and-match-discounts/DiscountList.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/DiscountList.jsx
@@ -16,6 +16,43 @@ import Button from "../../components/Button";
 import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
+import VideoList from "../../components/VideoList";
+
+// Mix & Match specific videos
+const mixMatchVideos = [
+  {
+    id: 1,
+    title: "Mix & Match Basics",
+    description: "Create flexible bundle combinations",
+    src: "/videos/mixmatch-getting-started.mp4",
+    poster: null,
+    duration: "2:50"
+  },
+  {
+    id: 2,
+    title: "Product Groups",
+    description: "Set up product groups for mixing",
+    src: "/videos/mixmatch-groups.mp4",
+    poster: null,
+    duration: "3:15"
+  },
+  {
+    id: 3,
+    title: "Pricing Rules",
+    description: "Configure mix & match pricing",
+    src: "/videos/mixmatch-pricing.mp4",
+    poster: null,
+    duration: "2:40"
+  },
+  {
+    id: 4,
+    title: "Customer Experience",
+    description: "Optimize the shopping experience",
+    src: "/videos/mixmatch-experience.mp4",
+    poster: null,
+    duration: "3:00"
+  }
+];
 
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Discounts", "Setting", "Analytics"];
@@ -203,252 +240,7 @@ export default function DiscountList({ onMakeBundleClick }) {
         }}
       >
         {selectedTab === "Overview" && (
-          <>
-         {/* Video Display */}
-         <Col
-              lg={6} md={12}
-              style={{
-                padding: "50px",
-              }}
-            >
-              <Card
-                className="border-0 h-100 "
-                style={{ background: "transparent !important" }}
-              >
-                <Card.Body
-                  className="p-0 "
-                  style={{ background: "transparent !important" }}
-                >
-                  <div className="position-relative h-100">
-                    <video
-                      controls
-                      poster={videoimg}
-                      style={{
-                        width: "100%",
-                        height: "auto",
-                        borderRadius: "15px",
-                        padding: "4px",
-                      }}
-                    >
-                      <source
-                        src="/videos/marshall-promo.mp4"
-                        type="video/mp4"
-                      />
-                      Your browser does not support the video tag.
-                    </video>
-                    <div className="position-absolute top-50 start-50 translate-middle">
-                      <Button
-                        text={<Play size={24} />}
-                        onClick={() => console.log("Discard")}
-                        variant="light"
-                        className="rounded-circle p-3 opacity-75"
-                      />
-                    </div>
-                  </div>
-                </Card.Body>
-              </Card>
-            </Col>
-
-            {/* Side Features */}
-            <Col
-              lg={6} md={12}
-              style={{
-                padding: "50px 0",
-              }}
-            >
-              <div
-                className="d-flex justify-content-between flex-column linrrowleft"
-                style={{ height: "100%" }}
-              >
-                <div>
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
-                        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Customizable
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Discount, Display style & Priority.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <rect
-                          x="2"
-                          y="3"
-                          width="20"
-                          height="14"
-                          rx="2"
-                          ry="2"
-                        ></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Responsive
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Looks great on any device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-5 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
-                        <path d="M13 2v7h7"></path>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Attention grabbing
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Keep your customers informed without disrupting their
-                        shopping.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="d-flex align-items-start flex-column">
-                  <Button
-                    variant="dark"
-                    className="mb-3 d-flex align-items-center justify-content-center"
-                    text=" Make your Bundle Now!"
-                    style={{
-                      maxWidth: "220px",
-                      borderRadius: "40px",
-                      height: "45px",
-                      fontWeight: 500,
-                      fontSize: "15px",
-                      letterSpacing: "0",
-                      backgroundColor: "black",
-                      borderColor: "black",
-                      color: "white",
-                      padding: "15px 25px",
-                    }}
-                    onClick={() => {
-                      setShowBundleAction(true);
-                      onMakeBundleClick();
-                    }}
-                  />
-
-                  <div>
-                    <span
-                      className="text-secondary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                      }}
-                    >
-                      Learn More about{" "}
-                    </span>
-                    <a
-                      href="#"
-                      className="text-primary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                        color: "#5169DD",
-                      }}
-                    >
-                      How to create bundle?
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </Col>
-          </>
+          <VideoList videos={mixMatchVideos} appName="Mix & Match" />
         )}
 
         {selectedTab === "Discounts" && (

--- a/web/frontend/apps/mix-and-match-discounts/MixMatchForm.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixMatchForm.jsx
@@ -65,7 +65,7 @@ export default function MixMatchForm({goBack, setActiveAction}) {
             )}
           </Col>
           {/* Left Column: Title + Toggle */}
-          <Col className="d-flex align-items-center justify-content-between">
+          <Col className="d-flex align-items-center gap-3">
             <h5
               className="mb-0"
               style={{

--- a/web/frontend/apps/mix-and-match-discounts/MixMatchForm.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixMatchForm.jsx
@@ -76,7 +76,7 @@ export default function MixMatchForm({goBack, setActiveAction}) {
             >
               Mix & Match
             </h5>
-            <ToggleSwitch appId="mix_match" />
+            <ToggleSwitch size="small" appId="mix_match" />
           </Col>
           {/* Right Column: Buttons */}
           {fromDiscountPage ? (

--- a/web/frontend/apps/mix-and-match-discounts/MixMatchForm.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixMatchForm.jsx
@@ -45,7 +45,8 @@ export default function MixMatchForm({goBack, setActiveAction}) {
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
-        <Row className="mb-4 align-items-start">
+        {/* Header Row: [Back] [Title ... Toggle] [Create Another Discount] [Create Mix & Match] */}
+        <Row className="mb-2 align-items-center">
           <Col xs="auto">
             {fromDiscountPage ? (
               <></>
@@ -63,51 +64,33 @@ export default function MixMatchForm({goBack, setActiveAction}) {
               </div>
             )}
           </Col>
-          <Col>
+          {/* Left Column: Title + Toggle */}
+          <Col className="d-flex align-items-center justify-content-between">
             <h5
-              className="mb-2"
+              className="mb-0"
               style={{
                 fontWeight: 600,
                 fontSize: "20px",
                 lineHeight: "1",
               }}
             >
-              Mix and Match Form
+              Mix & Match
             </h5>
-            <p
-              className="mb-0"
-              style={{
-                fontWeight: 500,
-                fontSize: "14px",
-                lineHeight: "1.3",
-                color: "#616161",
-              }}
-            >
-              Get Noticed! Want to make sure your message doesn't get missed?
-              Announcement Bar lets you display important alerts right at the
-              top of your store. Whether it's a sale, promotion, or update, it's
-              impossible to ignore!
-            </p>
+            <ToggleSwitch appId="mix_match" />
           </Col>
-
+          {/* Right Column: Buttons */}
           {fromDiscountPage ? (
-            <Col
-              xs="auto"
-              className="d-flex align-items-center"
-              style={{ maxWidth: "300px", width: "100%" }}
-            >
-             <Button
+            <Col xs="auto" className="d-flex align-items-center gap-2">
+              <Button
                 text="Discard"
                 onClick={handleDiscard} 
                 style={{
-                  background:"white",
+                  background: "white",
                   border: "1px solid #dee2e6",
                   height: "45px",
                   fontWeight: 500,
                   fontSize: "15px",
-                  maxWidth: "95px",
                   borderRadius: "8px",
-                  marginRight: "10px",
                   padding: "10px 20px",
                 }}
               />
@@ -132,20 +115,48 @@ export default function MixMatchForm({goBack, setActiveAction}) {
                 onClick={handleOpenDiscountModal}
                 style={{
                   borderRadius: "15px",
-
+                  backgroundColor: "#fff",
+                  color: "#000",
+                  border: "1px solid #dee2e6",
+                  padding: "15px 25px",
+                  fontWeight: "500",
+                  fontSize: "15px",
+                }}
+              />
+              <Button
+                text="Create Mix & Match"
+                onClick={() => setFromDiscountPage(true)}
+                style={{
+                  borderRadius: "15px",
                   backgroundColor: "#000",
                   color: "#FFFFFF",
                   padding: "15px 25px",
-                  fontFamily: "Inter",
-                  fontStyle: "normal",
                   fontWeight: "500",
                   fontSize: "15px",
-                  lineHeight: "100%",
                 }}
               />
-              <ToggleSwitch appId="mix_match" />
             </Col>
           )}
+        </Row>
+
+        {/* Description Row */}
+        <Row className="mb-4">
+          <Col>
+            <p
+              className="mb-0"
+              style={{
+                fontWeight: 500,
+                fontSize: "14px",
+                lineHeight: "1.3",
+                color: "#616161",
+              }}
+            >
+              Get Noticed! Want to make sure your message doesn't get missed?
+              Announcement Bar lets you display important alerts right at the
+              top of your store. Whether it's a sale, promotion, or update, it's
+              impossible to ignore!
+            </p>
+          </Col>
         </Row>
 
         <DiscountModal

--- a/web/frontend/apps/volume-discounts/DiscountList.jsx
+++ b/web/frontend/apps/volume-discounts/DiscountList.jsx
@@ -10,6 +10,7 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
+import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Volume Discounts specific videos
 const volumeDiscountVideos = [
@@ -170,6 +171,35 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
+      {/* App Header - Title with Toggle on left, Create Button on right */}
+      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
+        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
+            Volume Discount
+          </h2>
+          <ToggleSwitch appId="volume_discount" />
+        </Col>
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text="Create Discount"
+            onClick={() => {
+              setShowBundleAction(true);
+              if (onMakeBundleClick) onMakeBundleClick();
+            }}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px",
+            }}
+          />
+        </Col>
+      </Row>
+
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">
@@ -178,7 +208,6 @@ export default function DiscountList({ onMakeBundleClick }) {
             style={{
               marginLeft: "0",
               marginRight: "0",
-
               padding: "0px",
               boxShadow: "1px 1px 4px 0px #0000001A inset",
               backgroundColor: "#F1F2F4",
@@ -207,7 +236,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                           borderColor: "black",
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -220,7 +248,6 @@ export default function DiscountList({ onMakeBundleClick }) {
                       : {
                           borderRadius: "15px",
                           width: "130px",
-                          // height: "43px",
                           padding: "15px 12px",
                           fontFamily: "Inter",
                           fontStyle: "normal",
@@ -237,23 +264,7 @@ export default function DiscountList({ onMakeBundleClick }) {
                 </ToggleButton>
               ))}
             </ButtonGroup>
-
-            {/* Right-aligned Create Discount Button */}
           </div>
-          {selectedTab === "Discounts" && (
-            <Button
-              text="Create Discount"
-              onClick={() => console.log("Create Discount")}
-              style={{
-                background: "black",
-                borderRadius: "12px",
-                padding: "15px 12px",
-                color: "white",
-                width: "200px",
-                height: "51px",
-              }}
-            />
-          )}
         </div>
       </Row>
       {selectedTab === "Discounts" && (

--- a/web/frontend/apps/volume-discounts/DiscountList.jsx
+++ b/web/frontend/apps/volume-discounts/DiscountList.jsx
@@ -10,7 +10,6 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 import VideoList from "../../components/VideoList";
-import ToggleSwitch from "../../components/ToggelSwitch";
 
 // Volume Discounts specific videos
 const volumeDiscountVideos = [
@@ -171,50 +170,6 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Two columns: [Title + Toggle] | [Create Another Discount + Create Volume Discount] */}
-      <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        {/* Left Column: Title (left) + Toggle (right) */}
-        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
-          <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
-            Volume Discount
-          </h2>
-          <ToggleSwitch appId="volume_discount" />
-        </Col>
-        {/* Right Column: Create Another Discount + Create Volume Discount */}
-        <Col xs={12} md={6} className="d-flex justify-content-end gap-2">
-          <Button
-            text="Create Another Discount"
-            onClick={() => console.log("Create Another Discount")}
-            style={{
-              background: "white",
-              borderRadius: "12px",
-              padding: "12px 20px",
-              color: "#303030",
-              fontWeight: 600,
-              fontSize: "14px",
-              border: "1px solid #e3e3e3",
-              height: "48px",
-            }}
-          />
-          <Button
-            text="Create Volume Discount"
-            onClick={() => {
-              setShowBundleAction(true);
-              if (onMakeBundleClick) onMakeBundleClick();
-            }}
-            style={{
-              background: "black",
-              borderRadius: "12px",
-              padding: "12px 24px",
-              color: "white",
-              fontWeight: 600,
-              fontSize: "14px",
-              height: "48px",
-            }}
-          />
-        </Col>
-      </Row>
-
       {/* Navigation Tabs */}
       <Row>
         <div className="d-flex gap-1">

--- a/web/frontend/apps/volume-discounts/DiscountList.jsx
+++ b/web/frontend/apps/volume-discounts/DiscountList.jsx
@@ -171,17 +171,33 @@ export default function DiscountList({ onMakeBundleClick }) {
         padding: "5px 15px",
       }}
     >
-      {/* App Header - Title with Toggle on left, Create Button on right */}
+      {/* App Header - Two columns: [Title + Toggle] | [Create Another Discount + Create Volume Discount] */}
       <Row className="align-items-center mb-3" style={{ padding: "20px 0", borderBottom: "1px solid #e3e3e3" }}>
-        <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        {/* Left Column: Title (left) + Toggle (right) */}
+        <Col xs={12} md={6} className="d-flex align-items-center justify-content-between mb-3 mb-md-0">
           <h2 style={{ fontWeight: 600, fontSize: "24px", margin: 0, color: "#303030" }}>
             Volume Discount
           </h2>
           <ToggleSwitch appId="volume_discount" />
         </Col>
-        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+        {/* Right Column: Create Another Discount + Create Volume Discount */}
+        <Col xs={12} md={6} className="d-flex justify-content-end gap-2">
           <Button
-            text="Create Discount"
+            text="Create Another Discount"
+            onClick={() => console.log("Create Another Discount")}
+            style={{
+              background: "white",
+              borderRadius: "12px",
+              padding: "12px 20px",
+              color: "#303030",
+              fontWeight: 600,
+              fontSize: "14px",
+              border: "1px solid #e3e3e3",
+              height: "48px",
+            }}
+          />
+          <Button
+            text="Create Volume Discount"
             onClick={() => {
               setShowBundleAction(true);
               if (onMakeBundleClick) onMakeBundleClick();
@@ -193,7 +209,6 @@ export default function DiscountList({ onMakeBundleClick }) {
               color: "white",
               fontWeight: 600,
               fontSize: "14px",
-              minWidth: "180px",
               height: "48px",
             }}
           />

--- a/web/frontend/apps/volume-discounts/DiscountList.jsx
+++ b/web/frontend/apps/volume-discounts/DiscountList.jsx
@@ -9,6 +9,43 @@ import Button from "../../components/Button";
 import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
+import VideoList from "../../components/VideoList";
+
+// Volume Discounts specific videos
+const volumeDiscountVideos = [
+  {
+    id: 1,
+    title: "Volume Discount Setup",
+    description: "Create tiered pricing for bulk purchases",
+    src: "/videos/volume-getting-started.mp4",
+    poster: null,
+    duration: "2:45"
+  },
+  {
+    id: 2,
+    title: "Tier Configuration",
+    description: "Set up multiple discount tiers",
+    src: "/videos/volume-tiers.mp4",
+    poster: null,
+    duration: "3:20"
+  },
+  {
+    id: 3,
+    title: "Display Customization",
+    description: "Customize how volume pricing is displayed",
+    src: "/videos/volume-display.mp4",
+    poster: null,
+    duration: "2:30"
+  },
+  {
+    id: 4,
+    title: "Volume Strategy Tips",
+    description: "Maximize sales with volume pricing",
+    src: "/videos/volume-strategy.mp4",
+    poster: null,
+    duration: "3:45"
+  }
+];
 
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Discounts", "Setting", "Analytics"];
@@ -268,237 +305,7 @@ export default function DiscountList({ onMakeBundleClick }) {
         }}
       >
         {selectedTab === "Overview" && (
-          <>
-            {/* Video Display */}
-            <Col
-              lg={6}
-              md={12}
-              style={{
-                padding: "50px",
-              }}
-            >
-              <Card className="border-0 h-100 " style={{ background: "transparent !important" }}>
-                <Card.Body className="p-0 " style={{ background: "transparent !important" }}>
-                  <div className="position-relative h-100">
-                    <video
-                      controls
-                      poster={videoimg}
-                      style={{
-                        width: "100%",
-                        height: "auto",
-                        borderRadius: "15px",
-                        padding: "4px",
-                      }}
-                    >
-                      <source src="/videos/marshall-promo.mp4" type="video/mp4" />
-                      Your browser does not support the video tag.
-                    </video>
-                    <div className="position-absolute top-50 start-50 translate-middle">
-                      <Button
-                        text={<Play size={24} />}
-                        onClick={() => console.log("Discard")}
-                        variant="light"
-                        className="rounded-circle p-3 opacity-75"
-                      />
-                    </div>
-                  </div>
-                </Card.Body>
-              </Card>
-            </Col>
-
-            {/* Side Features */}
-            <Col
-              lg={6}
-              md={12}
-              style={{
-                padding: "50px 0",
-              }}
-            >
-              <div
-                className="d-flex justify-content-between flex-column linrrowleft"
-                style={{ height: "100%" }}
-              >
-                <div>
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M20 14.66V20a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5.34"></path>
-                        <polygon points="18 2 22 6 12 16 8 16 8 12 18 2"></polygon>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Customizable
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Discount, Display style & Priority.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-3 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
-                        <line x1="8" y1="21" x2="16" y2="21"></line>
-                        <line x1="12" y1="17" x2="12" y2="21"></line>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Responsive
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Looks great on any device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="d-flex mb-5 gap-2 flex-column">
-                    <div
-                      className="bg-dark rounded-circle d-flex align-items-center justify-content-center"
-                      style={{ height: "50px", width: "50px" }}
-                    >
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="white"
-                        strokeWidth="2"
-                      >
-                        <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"></path>
-                        <path d="M13 2v7h7"></path>
-                      </svg>
-                    </div>
-                    <div>
-                      <h5
-                        className="mb-1"
-                        style={{
-                          fontWeight: 600,
-                          fontSize: "16px",
-                          letterSpacing: "0",
-                        }}
-                      >
-                        Attention grabbing
-                      </h5>
-                      <p
-                        className="text-secondary mb-0"
-                        style={{
-                          fontWeight: 500,
-                          fontSize: "14px",
-                          letterSpacing: "0",
-                          color: "#616161",
-                        }}
-                      >
-                        Keep your customers informed without disrupting their shopping.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="d-flex align-items-start flex-column">
-                  <Button
-                    variant="dark"
-                    className="mb-3 d-flex align-items-center justify-content-center"
-                    text=" Make your Bundle Now!"
-                    style={{
-                      maxWidth: "220px",
-                      borderRadius: "40px",
-                      height: "45px",
-                      fontWeight: 500,
-                      fontSize: "15px",
-                      letterSpacing: "0",
-                      backgroundColor: "black",
-                      borderColor: "black",
-                      color: "white",
-                      padding: "15px 25px",
-                    }}
-                    onClick={() => {
-                      setShowBundleAction(true);
-                      onMakeBundleClick();
-                    }}
-                  />
-
-                  <div>
-                    <span
-                      className="text-secondary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                      }}
-                    >
-                      Learn More about{" "}
-                    </span>
-                    <a
-                      href="#"
-                      className="text-primary"
-                      style={{
-                        fontWeight: 600,
-                        fontSize: "14px",
-                        letterSpacing: "0",
-                        textAlign: "center",
-                        color: "#5169DD",
-                      }}
-                    >
-                      How to create bundle?
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </Col>
-          </>
+          <VideoList videos={volumeDiscountVideos} appName="Volume Discounts" />
         )}
         {selectedTab === "Discounts" && (
           <>

--- a/web/frontend/apps/volume-discounts/VolumeForm.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeForm.jsx
@@ -80,7 +80,7 @@ export default function VolumeForm({ goBack, setActiveAction }) {
             >
               Volume Discount
             </h5>
-            <ToggleSwitch appId="volume_discounts" />
+            <ToggleSwitch size="small" appId="volume_discounts" />
           </Col>
           {/* Right Column: Buttons */}
           {fromDiscountPage ? (

--- a/web/frontend/apps/volume-discounts/VolumeForm.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeForm.jsx
@@ -69,7 +69,7 @@ export default function VolumeForm({ goBack, setActiveAction }) {
             )}
           </Col>
           {/* Left Column: Title + Toggle */}
-          <Col className="d-flex align-items-center justify-content-between">
+          <Col className="d-flex align-items-center gap-3">
             <h5
               className="mb-0"
               style={{

--- a/web/frontend/apps/volume-discounts/VolumeForm.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeForm.jsx
@@ -46,7 +46,8 @@ export default function VolumeForm({ goBack, setActiveAction }) {
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
-        <Row className="mb-4 align-items-start">
+        {/* Header Row: [Back] [Title ... Toggle] [Create Another Discount] [Create Volume Discount] */}
+        <Row className="mb-2 align-items-center">
           <Col xs="auto">
             {fromDiscountPage ? (
               <></>
@@ -67,9 +68,10 @@ export default function VolumeForm({ goBack, setActiveAction }) {
               </div>
             )}
           </Col>
-          <Col>
+          {/* Left Column: Title + Toggle */}
+          <Col className="d-flex align-items-center justify-content-between">
             <h5
-              className="mb-2"
+              className="mb-0"
               style={{
                 fontWeight: 600,
                 fontSize: "20px",
@@ -78,23 +80,11 @@ export default function VolumeForm({ goBack, setActiveAction }) {
             >
               Volume Discount
             </h5>
-            <p
-              className="mb-0"
-              style={{
-                fontWeight: 500,
-                fontSize: "14px",
-                lineHeight: "1.3",
-                color: "#616161",
-              }}
-            >
-              Get Noticed! Want to make sure your message doesn't get missed? Announcement Bar lets you
-              display important alerts right at the top of your store. Whether it's a sale, promotion, or
-              update, it's impossible to ignore!
-            </p>
+            <ToggleSwitch appId="volume_discounts" />
           </Col>
-
+          {/* Right Column: Buttons */}
           {fromDiscountPage ? (
-            <Col xs="auto" className="d-flex align-items-center" style={{ maxWidth: "300px", width: "100%" }}>
+            <Col xs="auto" className="d-flex align-items-center gap-2">
               <Button
                 text="Discard"
                 onClick={handleDiscard}
@@ -104,9 +94,7 @@ export default function VolumeForm({ goBack, setActiveAction }) {
                   height: "45px",
                   fontWeight: 500,
                   fontSize: "15px",
-                  maxWidth: "95px",
                   borderRadius: "8px",
-                  marginRight: "10px",
                   padding: "10px 20px",
                 }}
               />
@@ -131,20 +119,47 @@ export default function VolumeForm({ goBack, setActiveAction }) {
                 onClick={handleOpenDiscountModal}
                 style={{
                   borderRadius: "15px",
-
+                  backgroundColor: "#fff",
+                  color: "#000",
+                  border: "1px solid #dee2e6",
+                  padding: "15px 25px",
+                  fontWeight: "500",
+                  fontSize: "15px",
+                }}
+              />
+              <Button
+                text="Create Volume Discount"
+                onClick={() => setFromDiscountPage(true)}
+                style={{
+                  borderRadius: "15px",
                   backgroundColor: "#000",
                   color: "#FFFFFF",
                   padding: "15px 25px",
-                  fontFamily: "Inter",
-                  fontStyle: "normal",
                   fontWeight: "500",
                   fontSize: "15px",
-                  lineHeight: "100%",
                 }}
               />
-              <ToggleSwitch appId="volume_discounts" />
             </Col>
           )}
+        </Row>
+
+        {/* Description Row */}
+        <Row className="mb-4">
+          <Col>
+            <p
+              className="mb-0"
+              style={{
+                fontWeight: 500,
+                fontSize: "14px",
+                lineHeight: "1.3",
+                color: "#616161",
+              }}
+            >
+              Get Noticed! Want to make sure your message doesn't get missed? Announcement Bar lets you
+              display important alerts right at the top of your store. Whether it's a sale, promotion, or
+              update, it's impossible to ignore!
+            </p>
+          </Col>
         </Row>
 
         <DiscountModal show={showDiscountModal} onHide={handleCloseDiscountModal} setActiveAction={setActiveAction} />

--- a/web/frontend/components/AppHeader.jsx
+++ b/web/frontend/components/AppHeader.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Row, Col } from "react-bootstrap";
+import Button from "./Button";
+import ToggleSwitch from "./ToggelSwitch";
+
+/**
+ * AppHeader Component - Header for app detail pages
+ * Shows app title with toggle inline, and create button in top right
+ * 
+ * @param {string} appTitle - The title of the app
+ * @param {string} appId - The app identifier for toggle switch
+ * @param {string} createButtonText - Text for the create button
+ * @param {function} onCreateClick - Click handler for create button
+ * @param {boolean} showCreateButton - Whether to show the create button (default: true)
+ */
+const AppHeader = ({ 
+  appTitle, 
+  appId, 
+  createButtonText = "Create", 
+  onCreateClick,
+  showCreateButton = true 
+}) => {
+  return (
+    <Row 
+      className="align-items-center mb-4" 
+      style={{ 
+        padding: "20px 0",
+        borderBottom: "1px solid #e3e3e3"
+      }}
+    >
+      {/* Left side - App Title and Toggle */}
+      <Col xs={12} md={8} className="d-flex align-items-center gap-3">
+        <h2 style={{ 
+          fontWeight: 600, 
+          fontSize: "24px", 
+          margin: 0,
+          color: "#303030"
+        }}>
+          {appTitle}
+        </h2>
+        <ToggleSwitch appId={appId} />
+      </Col>
+      
+      {/* Right side - Create Button */}
+      {showCreateButton && (
+        <Col xs={12} md={4} className="d-flex justify-content-end mt-3 mt-md-0">
+          <Button
+            text={createButtonText}
+            onClick={onCreateClick}
+            style={{
+              background: "black",
+              borderRadius: "12px",
+              padding: "12px 24px",
+              color: "white",
+              fontWeight: 600,
+              fontSize: "14px",
+              minWidth: "180px",
+              height: "48px"
+            }}
+          />
+        </Col>
+      )}
+    </Row>
+  );
+};
+
+export default AppHeader;

--- a/web/frontend/components/BundelDiscountList.jsx
+++ b/web/frontend/components/BundelDiscountList.jsx
@@ -314,24 +314,7 @@ export default function DiscountList({
               ))}
             </ButtonGroup>
           </div>
-          {selectedTab === "Discounts" && (
-            <Button
-              text="Create Discount"
-              onClick={() => {
-                setEditingDiscount(null); // Ensure we're creating new, not editing
-                setShowAction(true);
-                onMakeBundleClick();
-              }}
-              style={{
-                background: "black",
-                borderRadius: "12px",
-                padding: "15px 12px",
-                color: "white",
-                width: "200px",
-                height: "51px",
-              }}
-            />
-          )}
+
         </div>
       </Row>
 

--- a/web/frontend/components/ToggelSwitch.jsx
+++ b/web/frontend/components/ToggelSwitch.jsx
@@ -1,33 +1,43 @@
 import { useState, useEffect } from "react";
 
 const ToggleSwitch = ({ appId }) => {
-  const [active, setActive] = useState(false);
-  const [loading, setLoading] = useState(false);
+  // Start with null to indicate "loading" state - prevents flash
+  const [active, setActive] = useState(null);
+  const [loading, setLoading] = useState(true); // Start loading as true
   const [error, setError] = useState(null);
   const [hasAppAccess, setHasAppAccess] = useState(true);
   const [subscriptionInfo, setSubscriptionInfo] = useState(null);
   const [isDisabledButton, setIsDisabledButton] = useState(false);
+  const [initialLoadComplete, setInitialLoadComplete] = useState(false);
 
   useEffect(() => {
     fetchInitialStatus();
     fetchSubscriptionInfo();
-    isDisabled();
   }, [appId]);
 
   useEffect(() => {
-    isDisabled();
-  }, [subscriptionInfo, active, loading, hasAppAccess]);
+    if (initialLoadComplete) {
+      isDisabled();
+    }
+  }, [subscriptionInfo, active, loading, hasAppAccess, initialLoadComplete]);
 
   const fetchInitialStatus = async () => {
+    setLoading(true);
     try {
       const response = await fetch(`/api/subscription/app-status?appId=${appId}`);
       const data = await response.json();
 
       if (data.status === "SUCCESS") {
         setActive(data.data.isEnabled || false);
+      } else {
+        setActive(false);
       }
     } catch (error) {
       console.error("Error fetching app status:", error);
+      setActive(false);
+    } finally {
+      setLoading(false);
+      setInitialLoadComplete(true);
     }
   };
 
@@ -184,12 +194,15 @@ const ToggleSwitch = ({ appId }) => {
     return "Click to enable";
   };
 
+  // Show neutral loading state during initial load to prevent flash
+  const isInitialLoading = active === null || !initialLoadComplete;
+  
   return (
     <div
       className="d-flex align-items-center"
-      style={{ cursor: isDisabledButton ? "not-allowed" : "pointer" }}
-      onClick={isDisabledButton && !active ? undefined : toggleSwitch}
-      title={isDisabledButton && !active ? "Upgrade your plan to enable more apps" : getToggleTitle()}
+      style={{ cursor: isInitialLoading || isDisabledButton ? "not-allowed" : "pointer" }}
+      onClick={isInitialLoading || (isDisabledButton && !active) ? undefined : toggleSwitch}
+      title={isInitialLoading ? "Loading..." : (isDisabledButton && !active ? "Upgrade your plan to enable more apps" : getToggleTitle())}
     >
       {error && (
         <div
@@ -211,7 +224,7 @@ const ToggleSwitch = ({ appId }) => {
       )}
 
       <div
-        className={`position-relative ${active ? "bg-success" : "bg-danger"} ${
+        className={`position-relative ${isInitialLoading ? "bg-secondary" : (active ? "bg-success" : "bg-danger")} ${
           isDisabledButton ? "opacity-50" : ""
         }`}
         style={{
@@ -220,10 +233,10 @@ const ToggleSwitch = ({ appId }) => {
           padding: "4px",
           borderRadius: "15px",
         }}
-        onClick={isDisabledButton ? undefined : toggleSwitch}
+        onClick={isInitialLoading || isDisabledButton ? undefined : toggleSwitch}
       >
-        {/* loading overlay */}
-        {loading && (
+        {/* loading overlay - shows during initial load and toggle operations */}
+        {(loading || isInitialLoading) && (
           <div
             className="position-absolute w-100 h-100 d-flex align-items-center justify-content-center"
             style={{
@@ -258,14 +271,14 @@ const ToggleSwitch = ({ appId }) => {
           </div>
         )}
 
-        {/* switch slider */}
+        {/* switch slider - centered during loading, positioned based on state after */}
         <div
           className="bg-white position-absolute"
           style={{
             width: "50px",
             height: "40px",
             transition: "all 0.3s ease",
-            left: active ? "78px" : "5px",
+            left: isInitialLoading ? "41px" : (active ? "78px" : "5px"),
             top: "4px",
             borderRadius: "11px",
             zIndex: 1,
@@ -276,13 +289,13 @@ const ToggleSwitch = ({ appId }) => {
         <div className="d-flex align-items-center justify-content-between h-100 px-3">
           <span
             className="text-white fw-medium"
-            style={{ visibility: active ? "visible" : "hidden", zIndex: 1 }}
+            style={{ visibility: isInitialLoading ? "hidden" : (active ? "visible" : "hidden"), zIndex: 1 }}
           >
             Active
           </span>
           <span
             className="text-white fw-medium ms-auto"
-            style={{ visibility: active ? "hidden" : "visible", zIndex: 1 }}
+            style={{ visibility: isInitialLoading ? "hidden" : (active ? "hidden" : "visible"), zIndex: 1 }}
           >
             Inactive
           </span>

--- a/web/frontend/components/ToggelSwitch.jsx
+++ b/web/frontend/components/ToggelSwitch.jsx
@@ -1,6 +1,13 @@
 import { useState, useEffect } from "react";
 
-const ToggleSwitch = ({ appId }) => {
+const ToggleSwitch = ({ appId, size = "large" }) => {
+  // Size configurations
+  const sizes = {
+    small: { width: "70px", height: "28px", sliderWidth: "24px", sliderHeight: "20px", fontSize: "10px", padding: "4px", borderRadius: "10px" },
+    medium: { width: "90px", height: "34px", sliderWidth: "32px", sliderHeight: "26px", fontSize: "11px", padding: "4px", borderRadius: "12px" },
+    large: { width: "132px", height: "48px", sliderWidth: "50px", sliderHeight: "40px", fontSize: "13px", padding: "4px", borderRadius: "15px" }
+  };
+  const sizeConfig = sizes[size] || sizes.large;
   // Start with null to indicate "loading" state - prevents flash
   const [active, setActive] = useState(null);
   const [loading, setLoading] = useState(true); // Start loading as true
@@ -228,10 +235,10 @@ const ToggleSwitch = ({ appId }) => {
           isDisabledButton ? "opacity-50" : ""
         }`}
         style={{
-          width: "132px",
-          height: "48px",
-          padding: "4px",
-          borderRadius: "15px",
+          width: sizeConfig.width,
+          height: sizeConfig.height,
+          padding: sizeConfig.padding,
+          borderRadius: sizeConfig.borderRadius,
         }}
         onClick={isInitialLoading || isDisabledButton ? undefined : toggleSwitch}
       >
@@ -275,27 +282,37 @@ const ToggleSwitch = ({ appId }) => {
         <div
           className="bg-white position-absolute"
           style={{
-            width: "50px",
-            height: "40px",
+            width: sizeConfig.sliderWidth,
+            height: sizeConfig.sliderHeight,
             transition: "all 0.3s ease",
-            left: isInitialLoading ? "41px" : (active ? "78px" : "5px"),
+            left: isInitialLoading 
+              ? `calc(50% - ${parseInt(sizeConfig.sliderWidth) / 2}px)` 
+              : (active ? `calc(100% - ${parseInt(sizeConfig.sliderWidth) + 4}px)` : "4px"),
             top: "4px",
-            borderRadius: "11px",
+            borderRadius: size === "small" ? "6px" : (size === "medium" ? "8px" : "11px"),
             zIndex: 1,
           }}
         />
 
         {/* labels */}
-        <div className="d-flex align-items-center justify-content-between h-100 px-3">
+        <div className="d-flex align-items-center justify-content-between h-100 px-2">
           <span
             className="text-white fw-medium"
-            style={{ visibility: isInitialLoading ? "hidden" : (active ? "visible" : "hidden"), zIndex: 1 }}
+            style={{ 
+              visibility: isInitialLoading ? "hidden" : (active ? "visible" : "hidden"), 
+              zIndex: 1,
+              fontSize: sizeConfig.fontSize
+            }}
           >
             Active
           </span>
           <span
             className="text-white fw-medium ms-auto"
-            style={{ visibility: isInitialLoading ? "hidden" : (active ? "hidden" : "visible"), zIndex: 1 }}
+            style={{ 
+              visibility: isInitialLoading ? "hidden" : (active ? "hidden" : "visible"), 
+              zIndex: 1,
+              fontSize: sizeConfig.fontSize
+            }}
           >
             Inactive
           </span>

--- a/web/frontend/components/ToggelSwitch.jsx
+++ b/web/frontend/components/ToggelSwitch.jsx
@@ -1,14 +1,6 @@
 import { useState, useEffect } from "react";
 
-const ToggleSwitch = ({ appId, size = "large", showLabels = true }) => {
-  // Size configurations
-  const sizes = {
-    small: { width: "44px", height: "24px", sliderWidth: "18px", sliderHeight: "18px", padding: "3px", borderRadius: "12px" },
-    medium: { width: "52px", height: "28px", sliderWidth: "22px", sliderHeight: "22px", padding: "3px", borderRadius: "14px" },
-    large: { width: "132px", height: "48px", sliderWidth: "50px", sliderHeight: "40px", fontSize: "13px", padding: "4px", borderRadius: "15px" }
-  };
-  const sizeConfig = sizes[size] || sizes.large;
-  
+const ToggleSwitch = ({ appId, size = "large" }) => {
   // App name mapping for tooltip
   const appNames = {
     bundle_discount: "Bundle Discount",
@@ -248,10 +240,9 @@ const ToggleSwitch = ({ appId, size = "large", showLabels = true }) => {
           isDisabledButton ? "opacity-50" : ""
         }`}
         style={{
-          width: sizeConfig.width,
-          height: sizeConfig.height,
-          padding: sizeConfig.padding,
-          borderRadius: sizeConfig.borderRadius,
+          width: size === "small" ? "40px" : "132px",
+          height: size === "small" ? "22px" : "48px",
+          borderRadius: size === "small" ? "11px" : "15px",
           cursor: isInitialLoading || isDisabledButton ? "not-allowed" : "pointer",
         }}
         onClick={isInitialLoading || isDisabledButton ? undefined : toggleSwitch}
@@ -293,18 +284,18 @@ const ToggleSwitch = ({ appId, size = "large", showLabels = true }) => {
           </div>
         )}
 
-        {/* switch slider - centered during loading, positioned based on state after */}
+        {/* switch slider */}
         <div
           className="bg-white position-absolute"
           style={{
-            width: sizeConfig.sliderWidth,
-            height: sizeConfig.sliderHeight,
+            width: size === "small" ? "16px" : "50px",
+            height: size === "small" ? "16px" : "40px",
             transition: "all 0.3s ease",
-            left: isInitialLoading 
-              ? `calc(50% - ${parseInt(sizeConfig.sliderWidth) / 2}px)` 
-              : (active ? `calc(100% - ${parseInt(sizeConfig.sliderWidth) + 4}px)` : "4px"),
-            top: "4px",
-            borderRadius: size === "small" ? "6px" : (size === "medium" ? "8px" : "11px"),
+            left: size === "small" 
+              ? (isInitialLoading ? "12px" : (active ? "21px" : "3px"))
+              : (isInitialLoading ? "41px" : (active ? "78px" : "4px")),
+            top: size === "small" ? "3px" : "4px",
+            borderRadius: size === "small" ? "50%" : "11px",
             zIndex: 1,
           }}
         />

--- a/web/frontend/components/ToggelSwitch.jsx
+++ b/web/frontend/components/ToggelSwitch.jsx
@@ -1,13 +1,26 @@
 import { useState, useEffect } from "react";
 
-const ToggleSwitch = ({ appId, size = "large" }) => {
+const ToggleSwitch = ({ appId, size = "large", showLabels = true }) => {
   // Size configurations
   const sizes = {
-    small: { width: "70px", height: "28px", sliderWidth: "24px", sliderHeight: "20px", fontSize: "10px", padding: "4px", borderRadius: "10px" },
-    medium: { width: "90px", height: "34px", sliderWidth: "32px", sliderHeight: "26px", fontSize: "11px", padding: "4px", borderRadius: "12px" },
+    small: { width: "44px", height: "24px", sliderWidth: "18px", sliderHeight: "18px", padding: "3px", borderRadius: "12px" },
+    medium: { width: "52px", height: "28px", sliderWidth: "22px", sliderHeight: "22px", padding: "3px", borderRadius: "14px" },
     large: { width: "132px", height: "48px", sliderWidth: "50px", sliderHeight: "40px", fontSize: "13px", padding: "4px", borderRadius: "15px" }
   };
   const sizeConfig = sizes[size] || sizes.large;
+  
+  // App name mapping for tooltip
+  const appNames = {
+    bundle_discount: "Bundle Discount",
+    volume_discounts: "Volume Discount",
+    buy_one_get_one: "Buy One Get One",
+    mix_match: "Mix & Match",
+    announcement_bar: "Announcement Bar",
+    countdown_timer: "Countdown Timer",
+    cart_notice: "Cart Notice",
+    inactive_tab: "Inactive Tab Message"
+  };
+  const appName = appNames[appId] || "This app";
   // Start with null to indicate "loading" state - prevents flash
   const [active, setActive] = useState(null);
   const [loading, setLoading] = useState(true); // Start loading as true
@@ -239,8 +252,10 @@ const ToggleSwitch = ({ appId, size = "large" }) => {
           height: sizeConfig.height,
           padding: sizeConfig.padding,
           borderRadius: sizeConfig.borderRadius,
+          cursor: isInitialLoading || isDisabledButton ? "not-allowed" : "pointer",
         }}
         onClick={isInitialLoading || isDisabledButton ? undefined : toggleSwitch}
+        title={`If inactive, ${appName} widgets will not appear on your storefront.`}
       >
         {/* loading overlay - shows during initial load and toggle operations */}
         {(loading || isInitialLoading) && (
@@ -294,29 +309,31 @@ const ToggleSwitch = ({ appId, size = "large" }) => {
           }}
         />
 
-        {/* labels */}
-        <div className="d-flex align-items-center justify-content-between h-100 px-2">
-          <span
-            className="text-white fw-medium"
-            style={{ 
-              visibility: isInitialLoading ? "hidden" : (active ? "visible" : "hidden"), 
-              zIndex: 1,
-              fontSize: sizeConfig.fontSize
-            }}
-          >
-            Active
-          </span>
-          <span
-            className="text-white fw-medium ms-auto"
-            style={{ 
-              visibility: isInitialLoading ? "hidden" : (active ? "hidden" : "visible"), 
-              zIndex: 1,
-              fontSize: sizeConfig.fontSize
-            }}
-          >
-            Inactive
-          </span>
-        </div>
+        {/* labels - only show for large size */}
+        {size === "large" && (
+          <div className="d-flex align-items-center justify-content-between h-100 px-2">
+            <span
+              className="text-white fw-medium"
+              style={{ 
+                visibility: isInitialLoading ? "hidden" : (active ? "visible" : "hidden"), 
+                zIndex: 1,
+                fontSize: sizeConfig.fontSize
+              }}
+            >
+              Active
+            </span>
+            <span
+              className="text-white fw-medium ms-auto"
+              style={{ 
+                visibility: isInitialLoading ? "hidden" : (active ? "hidden" : "visible"), 
+                zIndex: 1,
+                fontSize: sizeConfig.fontSize
+              }}
+            >
+              Inactive
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/web/frontend/components/VideoList.jsx
+++ b/web/frontend/components/VideoList.jsx
@@ -1,0 +1,195 @@
+import React, { useState } from "react";
+import { Row, Col, Card, ListGroup } from "react-bootstrap";
+import { Play, PlayCircle, CheckCircle } from "react-bootstrap-icons";
+import Button from "./Button";
+
+/**
+ * VideoList Component - Displays a list of videos with a video player
+ * The video player is on the left, list of video options on the right
+ * Clicking a list item changes the video being displayed
+ * 
+ * @param {Array} videos - Array of video objects with id, title, description, src, poster
+ * @param {string} appName - The name of the app (for display purposes)
+ */
+const VideoList = ({ videos = [], appName = "App" }) => {
+  const [selectedVideoIndex, setSelectedVideoIndex] = useState(0);
+  
+  // Default videos if none provided
+  const defaultVideos = [
+    {
+      id: 1,
+      title: "Getting Started",
+      description: "Learn how to set up your first widget",
+      src: "/videos/getting-started.mp4",
+      poster: null,
+      duration: "2:30"
+    },
+    {
+      id: 2,
+      title: "Customization Options",
+      description: "Explore all the styling options available",
+      src: "/videos/customization.mp4",
+      poster: null,
+      duration: "3:45"
+    },
+    {
+      id: 3,
+      title: "Advanced Features",
+      description: "Discover advanced features and tips",
+      src: "/videos/advanced.mp4",
+      poster: null,
+      duration: "4:15"
+    },
+    {
+      id: 4,
+      title: "Best Practices",
+      description: "Tips for maximizing conversions",
+      src: "/videos/best-practices.mp4",
+      poster: null,
+      duration: "2:50"
+    }
+  ];
+
+  const videoList = videos.length > 0 ? videos : defaultVideos;
+  const selectedVideo = videoList[selectedVideoIndex];
+
+  return (
+    <Row className="g-0" style={{ minHeight: "400px" }}>
+      {/* Video Player - Left Side */}
+      <Col lg={7} md={12} style={{ padding: "30px" }}>
+        <Card className="border-0 h-100" style={{ background: "transparent" }}>
+          <Card.Body className="p-0" style={{ background: "transparent" }}>
+            <div className="position-relative h-100">
+              <video
+                key={selectedVideo.id}
+                controls
+                poster={selectedVideo.poster}
+                style={{
+                  width: "100%",
+                  height: "auto",
+                  maxHeight: "350px",
+                  borderRadius: "15px",
+                  background: "#1a1a1a",
+                  objectFit: "cover"
+                }}
+              >
+                <source src={selectedVideo.src} type="video/mp4" />
+                Your browser does not support the video tag.
+              </video>
+              {/* Video title overlay */}
+              <div 
+                style={{
+                  position: "absolute",
+                  bottom: "20px",
+                  left: "20px",
+                  background: "rgba(0,0,0,0.7)",
+                  padding: "8px 16px",
+                  borderRadius: "8px"
+                }}
+              >
+                <span style={{ color: "white", fontWeight: 500 }}>
+                  {selectedVideo.title}
+                </span>
+              </div>
+            </div>
+          </Card.Body>
+        </Card>
+      </Col>
+
+      {/* Video List - Right Side */}
+      <Col lg={5} md={12} style={{ padding: "30px 30px 30px 0" }}>
+        <div style={{ height: "100%" }}>
+          <h6 style={{ 
+            fontWeight: 600, 
+            fontSize: "14px", 
+            color: "#303030",
+            marginBottom: "16px",
+            textTransform: "uppercase",
+            letterSpacing: "0.5px"
+          }}>
+            {appName} Video Tutorials
+          </h6>
+          
+          <ListGroup variant="flush" style={{ gap: "8px" }}>
+            {videoList.map((video, index) => (
+              <ListGroup.Item
+                key={video.id}
+                action
+                active={selectedVideoIndex === index}
+                onClick={() => setSelectedVideoIndex(index)}
+                style={{
+                  cursor: "pointer",
+                  borderRadius: "12px",
+                  border: selectedVideoIndex === index 
+                    ? "2px solid #303030" 
+                    : "1px solid #e3e3e3",
+                  padding: "16px",
+                  marginBottom: "8px",
+                  background: selectedVideoIndex === index ? "#f8f9fa" : "white",
+                  transition: "all 0.2s ease"
+                }}
+                className="video-list-item"
+              >
+                <div className="d-flex align-items-center gap-3">
+                  {/* Play Icon */}
+                  <div 
+                    style={{
+                      width: "40px",
+                      height: "40px",
+                      borderRadius: "50%",
+                      background: selectedVideoIndex === index ? "#303030" : "#f1f2f4",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      flexShrink: 0
+                    }}
+                  >
+                    {selectedVideoIndex === index ? (
+                      <PlayCircle size={20} color="white" />
+                    ) : (
+                      <Play size={16} color="#616161" />
+                    )}
+                  </div>
+                  
+                  {/* Video Info */}
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <h6 style={{ 
+                      margin: 0, 
+                      fontWeight: 600, 
+                      fontSize: "14px",
+                      color: selectedVideoIndex === index ? "#303030" : "#4A4A4A"
+                    }}>
+                      {video.title}
+                    </h6>
+                    <p style={{ 
+                      margin: "4px 0 0 0", 
+                      fontSize: "12px", 
+                      color: "#616161",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis"
+                    }}>
+                      {video.description}
+                    </p>
+                  </div>
+
+                  {/* Duration */}
+                  <span style={{
+                    fontSize: "12px",
+                    color: "#616161",
+                    fontWeight: 500,
+                    flexShrink: 0
+                  }}>
+                    {video.duration}
+                  </span>
+                </div>
+              </ListGroup.Item>
+            ))}
+          </ListGroup>
+        </div>
+      </Col>
+    </Row>
+  );
+};
+
+export default VideoList;

--- a/web/frontend/pages/index.jsx
+++ b/web/frontend/pages/index.jsx
@@ -265,24 +265,24 @@ export default function HomePage() {
                 </Banner>
               </div>
             )}
-            {/* Current Plan Banner */}
-            <div style={{ marginTop: "20px", marginBottom: "20px" }}>
-              <Banner
-                title={`Current Plan: ${currentPlan}`}
-                status="info"
-                action={{
-                  content: "View Plans",
-                  onAction: handleBannerAction,
-                }}
-              >
-                {currentPlan === "Free" &&
-                  "Upgrade to access more features and increase your app limits."}
-                {currentPlan === "Starter" &&
-                  "You have access to essential features. Upgrade to Advanced for full capabilities."}
-                {currentPlan === "Advanced" &&
-                  "You have full access to all features. Thank you for being a valued customer!"}
-              </Banner>
-            </div>
+            {/* Current Plan Banner - Hidden when user is on Advanced (highest) plan */}
+            {currentPlan !== "Advanced" && (
+              <div style={{ marginTop: "20px", marginBottom: "20px" }}>
+                <Banner
+                  title={`Current Plan: ${currentPlan}`}
+                  status="info"
+                  action={{
+                    content: "View Plans",
+                    onAction: handleBannerAction,
+                  }}
+                >
+                  {currentPlan === "Free" &&
+                    "Upgrade to access more features and increase your app limits."}
+                  {currentPlan === "Starter" &&
+                    "You have access to essential features. Upgrade to Advanced for full capabilities."}
+                </Banner>
+              </div>
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
## 📌 Description
Implements all frontend refinements for the BusyBuddy homepage and App homepages as specified in Issue #28.

## ✅ Acceptance Criteria Addressed

- [x] **Subtask #37:** Hide Plan Banner When User Is On the Highest Plan
  - Banner is now hidden when `currentPlan === "Advanced"`
  - Renders for Free and Starter plans

- [x] **Subtask #38:** App Overview Tabs Render A List Of Videos
  - Created reusable `VideoList` component
  - Updated all 8 app DiscountList.jsx files with VideoList
  - Each app has unique video content configured

- [x] **Subtask #39:** Re-Order App Header Buttons
  - Created `AppHeader` component with title + toggle inline on left
  - "Create" button positioned in top right corner

- [x] **Subtask #40:** Fix Active/Inactive Toggle Flash On Load
  - Toggle now starts with `null` (loading) state instead of `false` (inactive)
  - Shows neutral gray background during initial load
  - Slider centered during loading state
  - Prevents red "Inactive" flash on page load

## 📁 Files Changed

| File | Changes |
|------|---------|
| `web/frontend/pages/index.jsx` | Added conditional rendering to hide plan banner for Advanced plan |
| `web/frontend/components/VideoList.jsx` | **NEW** - Reusable video list component with player and clickable list |
| `web/frontend/components/AppHeader.jsx` | **NEW** - Header component with title, toggle, and create button |
| `web/frontend/components/ToggelSwitch.jsx` | Fixed flash issue by starting with neutral loading state |
| `web/frontend/apps/announcement-bar/DiscountList.jsx` | Replaced Overview section with VideoList |
| `web/frontend/apps/bundle-discounts/DiscountList.jsx` | Replaced Overview section with VideoList |
| `web/frontend/apps/buy-one-get-one/DiscountList.jsx` | Replaced Overview section with VideoList |
| `web/frontend/apps/volume-discounts/DiscountList.jsx` | Replaced Overview section with VideoList |
| `web/frontend/apps/mix-and-match-discounts/DiscountList.jsx` | Replaced Overview section with VideoList |
| `web/frontend/apps/countdown-timer/DiscountList.jsx` | Replaced Overview section with VideoList |
| `web/frontend/apps/car-notice/DiscountList.jsx` | Replaced Overview section with VideoList |
| `web/frontend/apps/inactive-tab-message/DiscountList.jsx` | Replaced Overview section with VideoList |
| `demo/issue-28-demo.html` | Demo page showcasing all changes |

## 📸 Demo
A demo HTML page is included at `demo/issue-28-demo.html` showcasing:
- Acceptance criteria checklist
- Before/After comparisons for each subtask
- Interactive toggle demonstrations
- Files changed summary

## 🔗 Related Issue
Closes #28
Closes #37
Closes #38
Closes #39
Closes #40