### PR TITLE
DEBUG: Add logging to MixMatchForm and BundelDiscountList to trace na…

### DIFF
--- a/web/frontend/components/BundelDiscountList.jsx
+++ b/web/frontend/components/BundelDiscountList.jsx
@@ -108,7 +108,13 @@ export default function DiscountList({
     }, 10000);
     
     try {
-      const response = await fetch("/api/bundles", {
+      // Include shop param for proper session authentication
+      const params = new URLSearchParams(location.search);
+      const shop = params.get("shop");
+      const apiUrl = shop ? `/api/bundles?shop=${shop}` : "/api/bundles";
+      console.log("[DEBUG fetchDiscounts] URL:", apiUrl);
+      
+      const response = await fetch(apiUrl, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",

--- a/web/frontend/pages/DashboardHome.jsx
+++ b/web/frontend/pages/DashboardHome.jsx
@@ -189,7 +189,15 @@ export default function DashboardHome() {
     }, 5000);
     
     try {
-      const response = await fetch("/api/subscription/getUserSubscription", {
+      // Include shop param for proper session authentication
+      const params = new URLSearchParams(location.search);
+      const shop = params.get("shop");
+      const apiUrl = shop 
+        ? `/api/subscription/getUserSubscription?shop=${shop}`
+        : "/api/subscription/getUserSubscription";
+      console.log("[DEBUG fetchUserSubscription] URL:", apiUrl);
+      
+      const response = await fetch(apiUrl, {
         signal: controller.signal
       });
       clearTimeout(timeoutId);


### PR DESCRIPTION
Root cause: API calls without shop param use validateAuthenticatedSession() which hangs in embedded Shopify context. Adding shop param uses offline session lookup which works correctly.

- fetchUserSubscription: Add shop param from location.search
- fetchDiscounts: Add shop param from location.search