### PR TITLE
fix: use HTTP status code for trigger success detection

### DIFF
--- a/.github/workflows/openhands-automation.yml
+++ b/.github/workflows/openhands-automation.yml
@@ -82,15 +82,15 @@ jobs:
               },
               "selected_repository": "${{ github.repository }}"
             }
-          responseHandle: 'body'
         continue-on-error: true
 
       - name: Check trigger result
         id: check_result
         run: |
-          response=${{ steps.trigger.outputs.response }}
-          echo "Response: $response"
-          if echo "$response" | grep -q '"id"'; then
+          status="${{ steps.trigger.outputs.status }}"
+          echo "HTTP Status: $status"
+          # Check if status starts with 2 (success)
+          if [[ "$status" == 2* ]]; then
             echo "trigger_success=true" >> $GITHUB_OUTPUT
           else
             echo "trigger_success=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes the OpenHands automation trigger workflow by using HTTP status code for success detection instead of response body parsing.

**Problem**: Previous approach used response body parsing with `responseHandle: body` to check for `id` field, but this was not working correctly.

**Solution**: Uses the `status` output from http-request-action directly and checks if status starts with `2` for HTTP success.