### PR TITLE
Fix product images not rendering in preview components

### DIFF
--- a/web/frontend/apps/bundle-discounts/DiscountList.jsx
+++ b/web/frontend/apps/bundle-discounts/DiscountList.jsx
@@ -10,6 +10,25 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirt;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Discounts", "Settings", "Analytics"];
   const [selectedTab, setSelectedTab] = useState(tabs[0]);
@@ -579,7 +598,7 @@ export default function DiscountList({ onMakeBundleClick }) {
                               />
 
                               <img
-                                src={bundle.products[0]?.media || tshirt}
+                                src={getProductImageUrl(bundle.products[0])}
                                 alt={bundle.products[0]?.title || "Bundle Product"}
                                 width={80}
                                 height={80}

--- a/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
+++ b/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
@@ -97,6 +97,25 @@ const TABS = [
   { id: 'schedule', label: 'Schedule' },
 ];
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirt;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 const DISCOUNT_TYPE_OPTIONS = [
   { value: '', label: 'Select Discount Type' },
   { value: 'Percentage', label: 'Percentage' },
@@ -579,7 +598,7 @@ export const StandardBundleEditor = () => {
                         border: '1px solid rgba(255,255,255,0.1)'
                       }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                          <img src={product.media || tshirt} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
+                          <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
                           <div>
                             <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                             <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -627,7 +646,7 @@ export const StandardBundleEditor = () => {
                         border: '1px solid rgba(81, 105, 221, 0.3)'
                       }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                          <img src={product.media || tshirt} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
+                          <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
                           <div>
                             <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                             <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -1189,7 +1208,7 @@ export const StandardBundleEditor = () => {
                   border: `1px solid ${colorSettings.borderColor}`,
                 }}>
                   <img
-                    src={product.media || tshirt}
+                    src={getProductImageUrl(product)}
                     alt={product.title}
                     style={{ width: '50px', height: '50px', borderRadius: '8px', objectFit: 'cover' }}
                   />

--- a/web/frontend/apps/bundle-discounts/bundleDiscountActions.jsx
+++ b/web/frontend/apps/bundle-discounts/bundleDiscountActions.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState, forwardRef, useImperativeHandle } from "react";
 import { Container, Row, Col, ButtonGroup, ToggleButton, Card, CardBody, Form } from "react-bootstrap";
-import { X, Trash } from "react-bootstrap-icons";
+import { X, Trash, Copy, CaretDownFill } from "react-bootstrap-icons";
 import tshirt from "./tshirt.png";
+import tshirtp from "../../assets/tshirt.png";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import Button from "../../components/Button";
@@ -9,12 +10,29 @@ import verticalicon from "../../assets/vertical-drag-&-drop.png";
 import dropdown from "../../assets/Vector.png";
 import edit from "../../assets/elements.png";
 import customize from "../../assets/customize.png";
-import { Copy, CaretDownFill } from "react-bootstrap-icons";
-import tshirtp from "../../assets/tshirt.png";
 import learnmore from "../../assets/help-square.png";
 import Products from "./products";
 import { useAppBridge } from "@shopify/app-bridge-react";
 import DatePicker from "../../components/DatePicker";
+
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirtp;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
 
 const BundleDiscountActions = React.forwardRef(({ onSuccess, editData }, ref) => {
   const shopify = useAppBridge();
@@ -812,7 +830,7 @@ const BundleDiscountActions = React.forwardRef(({ onSuccess, editData }, ref) =>
                             <div className="d-flex align-items-center">
                               <img src={verticalicon} alt="T-Shirt" width={20} height={20} className="me-2" />
                               <img
-                                src={product.media}
+                                src={getProductImageUrl(product)}
                                 alt="T-Shirt"
                                 width={60}
                                 height={60}
@@ -2010,7 +2028,7 @@ const BundleDiscountActions = React.forwardRef(({ onSuccess, editData }, ref) =>
                               <div className="d-flex flex-column">
                                 <div className="d-flex align-items-center">
                                   <img
-                                    src={product.media || tshirtp}
+                                    src={getProductImageUrl(product)}
                                     alt={product.title}
                                     width={100}
                                     height={100}

--- a/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
+++ b/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
@@ -19,6 +19,25 @@ import {
 import { useEditorNavigation } from '../../hooks';
 import tshirt from "./tshirt.png";
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirt;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 // Buy X Get Y specific settings configuration
 const BXGY_SETTINGS = {
   bundle: [
@@ -560,7 +579,7 @@ export const BuyXGetYEditor = () => {
                       display: 'flex', alignItems: 'center', padding: '8px', marginBottom: '8px',
                       background: '#f5f5f5', borderRadius: '8px', gap: '10px'
                     }}>
-                      <img src={product.media || tshirt} alt={product.title} style={{ width: 40, height: 40, borderRadius: '6px', objectFit: 'cover' }} />
+                      <img src={getProductImageUrl(product)} alt={product.title} style={{ width: 40, height: 40, borderRadius: '6px', objectFit: 'cover' }} />
                       <span style={{ flex: 1, fontSize: '13px', fontWeight: 500 }}>{product.title}</span>
                       <button onClick={() => removeProductFromX(product.productId || product.id)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#999', fontSize: '18px' }}>×</button>
                     </div>
@@ -580,7 +599,7 @@ export const BuyXGetYEditor = () => {
                       display: 'flex', alignItems: 'center', padding: '10px', marginBottom: '8px',
                       background: '#fff', borderRadius: '8px', border: '1px solid #e0e0e0', cursor: 'pointer', gap: '10px'
                     }}>
-                      <img src={product.media || tshirt} alt={product.title} style={{ width: 50, height: 50, borderRadius: '8px', objectFit: 'cover' }} />
+                      <img src={getProductImageUrl(product)} alt={product.title} style={{ width: 50, height: 50, borderRadius: '8px', objectFit: 'cover' }} />
                       <div style={{ flex: 1 }}>
                         <div style={{ fontWeight: 500, fontSize: '13px' }}>{product.title}</div>
                         <div style={{ color: '#666', fontSize: '12px' }}>${product.price}</div>
@@ -620,7 +639,7 @@ export const BuyXGetYEditor = () => {
                       display: 'flex', alignItems: 'center', padding: '8px', marginBottom: '8px',
                       background: '#E8F5E9', borderRadius: '8px', gap: '10px'
                     }}>
-                      <img src={product.media || tshirt} alt={product.title} style={{ width: 40, height: 40, borderRadius: '6px', objectFit: 'cover' }} />
+                      <img src={getProductImageUrl(product)} alt={product.title} style={{ width: 40, height: 40, borderRadius: '6px', objectFit: 'cover' }} />
                       <span style={{ flex: 1, fontSize: '13px', fontWeight: 500 }}>{product.title}</span>
                       <button onClick={() => removeProductFromY(product.productId || product.id)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#999', fontSize: '18px' }}>×</button>
                     </div>
@@ -640,7 +659,7 @@ export const BuyXGetYEditor = () => {
                       display: 'flex', alignItems: 'center', padding: '10px', marginBottom: '8px',
                       background: '#fff', borderRadius: '8px', border: '1px solid #e0e0e0', cursor: 'pointer', gap: '10px'
                     }}>
-                      <img src={product.media || tshirt} alt={product.title} style={{ width: 50, height: 50, borderRadius: '8px', objectFit: 'cover' }} />
+                      <img src={getProductImageUrl(product)} alt={product.title} style={{ width: 50, height: 50, borderRadius: '8px', objectFit: 'cover' }} />
                       <div style={{ flex: 1 }}>
                         <div style={{ fontWeight: 500, fontSize: '13px' }}>{product.title}</div>
                         <div style={{ color: '#666', fontSize: '12px' }}>${product.price}</div>
@@ -1044,7 +1063,7 @@ export const BuyXGetYEditor = () => {
               }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
                   <img
-                    src={product.media || tshirt}
+                    src={getProductImageUrl(product)}
                     alt={product.title}
                     style={{ width: 70, height: 70, borderRadius: '8px', objectFit: 'cover' }}
                   />
@@ -1123,7 +1142,7 @@ export const BuyXGetYEditor = () => {
                     }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
                         <img
-                          src={product.media || tshirt}
+                          src={getProductImageUrl(product)}
                           alt={product.title}
                           style={{ width: 70, height: 70, borderRadius: '8px', objectFit: 'cover' }}
                         />

--- a/web/frontend/apps/buy-one-get-one/buyoneGetoneActions.jsx
+++ b/web/frontend/apps/buy-one-get-one/buyoneGetoneActions.jsx
@@ -16,6 +16,25 @@ import Products from "./products";
 import { useAppBridge } from "@shopify/app-bridge-react";
 import DatePicker from "../../components/DatePicker";
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirtp;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 const BuyoneGetoneActions = React.forwardRef(({ onSuccess, editData }, ref) => {
   const shopify = useAppBridge();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -843,7 +862,7 @@ const BuyoneGetoneActions = React.forwardRef(({ onSuccess, editData }, ref) => {
                           >
                             <div className="d-flex align-items-center">
                               <img
-                                src={product.media || tshirtp}
+                                src={getProductImageUrl(product)}
                                 alt={product.title}
                                 width={80}
                                 height={80}
@@ -947,7 +966,7 @@ const BuyoneGetoneActions = React.forwardRef(({ onSuccess, editData }, ref) => {
                           >
                             <div className="d-flex align-items-center">
                               <img
-                                src={product.media || tshirtp}
+                                src={getProductImageUrl(product)}
                                 alt={product.title}
                                 width={80}
                                 height={80}
@@ -2054,7 +2073,7 @@ const BuyoneGetoneActions = React.forwardRef(({ onSuccess, editData }, ref) => {
                                 <div className="d-flex flex-column">
                                   <div className="d-flex align-items-center">
                                     <img
-                                      src={product.media || tshirtp}
+                                      src={getProductImageUrl(product)}
                                       alt={product.title}
                                       width={100}
                                       height={100}
@@ -2284,7 +2303,7 @@ const BuyoneGetoneActions = React.forwardRef(({ onSuccess, editData }, ref) => {
                                     <div className="d-flex flex-column">
                                       <div className="d-flex align-items-center">
                                         <img
-                                          src={product.media || tshirtp}
+                                          src={getProductImageUrl(product)}
                                           alt={product.title}
                                           width={100}
                                           height={100}

--- a/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
@@ -18,6 +18,25 @@ import {
 import { useEditorNavigation } from '../../hooks';
 import tshirt from "./tshirt.png";
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirt;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 // Mix and Match settings configuration
 const MIXMATCH_SETTINGS = {
   bundle: [
@@ -512,7 +531,7 @@ export const MixAndMatchEditor = () => {
                     availableProducts.slice(0, 10).map(product => (
                       <div key={product.id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(255,255,255,0.05)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(255,255,255,0.1)' }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                          <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
+                          <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
                           <div>
                             <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                             <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -540,7 +559,7 @@ export const MixAndMatchEditor = () => {
                   selectedProducts.map(product => (
                     <div key={product.productId} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(81, 105, 221, 0.1)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(81, 105, 221, 0.3)' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
+                        <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
                         <div>
                           <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                           <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -904,7 +923,7 @@ export const MixAndMatchEditor = () => {
               >
                 <div style={{ display: 'flex', alignItems: 'center' }}>
                   <img
-                    src={product.media || tshirt}
+                    src={getProductImageUrl(product)}
                     alt={product.title}
                     style={{
                       width: '80px',

--- a/web/frontend/apps/mix-and-match-discounts/mixMatchActions.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/mixMatchActions.jsx
@@ -15,6 +15,26 @@ import learnmore from "../../assets/help-square.png";
 import { useAppBridge } from "@shopify/app-bridge-react";
 import Products from "./products";
 import DatePicker from "../../components/DatePicker";
+
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirtp;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 const MixMatchActions = React.forwardRef(({ onSuccess, editData }, ref) => {
   const shopify = useAppBridge();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -811,7 +831,7 @@ const MixMatchActions = React.forwardRef(({ onSuccess, editData }, ref) => {
                             <div className="d-flex align-items-center">
                               <img src={verticalicon} alt="T-Shirt" width={20} height={20} className="me-2" />
                               <img
-                                src={product.media}
+                                src={getProductImageUrl(product)}
                                 alt="T-Shirt"
                                 width={60}
                                 height={60}
@@ -2170,7 +2190,7 @@ const MixMatchActions = React.forwardRef(({ onSuccess, editData }, ref) => {
                               <div className="d-flex flex-column">
                                 <div className="d-flex align-items-center">
                                   <img
-                                    src={product.media || tshirtp}
+                                    src={getProductImageUrl(product)}
                                     alt={product.title}
                                     width={100}
                                     height={100}

--- a/web/frontend/apps/volume-discounts/DiscountList.jsx
+++ b/web/frontend/apps/volume-discounts/DiscountList.jsx
@@ -10,6 +10,25 @@ import { X, Trash } from "react-bootstrap-icons";
 import view from "../../assets/view.png";
 import videoimg from "../../assets/videoimg.png";
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirt;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 export default function DiscountList({ onMakeBundleClick }) {
   const tabs = ["Overview", "Discounts", "Settings", "Analytics"];
   const [selectedTab, setSelectedTab] = useState(tabs[0]);
@@ -536,7 +555,7 @@ export default function DiscountList({ onMakeBundleClick }) {
                               />
 
                               <img
-                                src={bundle.products[0]?.media || tshirt}
+                                src={getProductImageUrl(bundle.products[0])}
                                 alt={bundle.products[0]?.title || "Bundle Product"}
                                 width={80}
                                 height={80}

--- a/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
@@ -18,6 +18,25 @@ import {
 import { useEditorNavigation } from '../../hooks';
 import tshirt from "./tshirt.png";
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirt;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 // Volume Discount settings configuration
 const VOLUME_SETTINGS = {
   bundle: [
@@ -546,7 +565,7 @@ export const VolumeDiscountEditor = () => {
                         onMouseOver={(e) => e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.1)'}
                         onMouseOut={(e) => e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.05)'}
                       >
-                        <img src={product.media || tshirt} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', marginRight: '10px', objectFit: 'cover' }} />
+                        <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', marginRight: '10px', objectFit: 'cover' }} />
                         <div style={{ flex: 1 }}>
                           <p style={{ fontSize: '13px', fontWeight: 500, margin: 0, color: 'rgba(255,255,255,0.9)' }}>{product.title}</p>
                           <p style={{ fontSize: '12px', color: 'rgba(255,255,255,0.6)', margin: 0 }}>${product.price}</p>
@@ -579,7 +598,7 @@ export const VolumeDiscountEditor = () => {
                       display: 'flex', alignItems: 'center', padding: '10px', backgroundColor: 'rgba(255,255,255,0.05)',
                       borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(255,255,255,0.1)',
                     }}>
-                      <img src={product.media || tshirt} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', marginRight: '10px', objectFit: 'cover' }} />
+                      <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', marginRight: '10px', objectFit: 'cover' }} />
                       <div style={{ flex: 1 }}>
                         <p style={{ fontSize: '13px', fontWeight: 500, margin: 0, color: 'rgba(255,255,255,0.9)' }}>{product.title}</p>
                         <p style={{ fontSize: '12px', color: 'rgba(255,255,255,0.6)', margin: 0 }}>${product.price}</p>
@@ -947,7 +966,7 @@ export const VolumeDiscountEditor = () => {
             }}>
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 <img
-                  src={selectedProducts[0]?.media || tshirt}
+                  src={getProductImageUrl(selectedProducts[0])}
                   alt={selectedProducts[0]?.title}
                   style={{
                     width: '80px',

--- a/web/frontend/apps/volume-discounts/volumeDiscountActions.jsx
+++ b/web/frontend/apps/volume-discounts/volumeDiscountActions.jsx
@@ -17,6 +17,25 @@ import { useAppBridge } from "@shopify/app-bridge-react";
 import { Navigation } from "@shopify/polaris";
 import DatePicker from "../../components/DatePicker";
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = tshirtp;
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 const volumeDiscountActions = React.forwardRef(({ onSuccess, editData }, ref) => {
   const shopify = useAppBridge();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -745,7 +764,7 @@ const volumeDiscountActions = React.forwardRef(({ onSuccess, editData }, ref) =>
                             <div className="d-flex align-items-center">
                               <img src={verticalicon} alt="T-Shirt" width={20} height={20} className="me-2" />
                               <img
-                                src={product.media}
+                                src={getProductImageUrl(product)}
                                 alt="T-Shirt"
                                 width={60}
                                 height={60}
@@ -2087,7 +2106,7 @@ const volumeDiscountActions = React.forwardRef(({ onSuccess, editData }, ref) =>
                               <div className="d-flex flex-column">
                                 <div className="d-flex align-items-center">
                                   <img
-                                    src={product.media || tshirtp}
+                                    src={getProductImageUrl(product)}
                                     alt={product.title}
                                     width={100}
                                     height={100}

--- a/web/frontend/bxgy-preview.jsx
+++ b/web/frontend/bxgy-preview.jsx
@@ -20,6 +20,25 @@ import {
 // Mock product image
 const tshirt = 'https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-product-1_large.png';
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = 'https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-product-1_large.png';
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 // Buy X Get Y settings configuration - same structure as BUNDLE_SETTINGS in preview.jsx
 const BXGY_SETTINGS = {
   bundle: [
@@ -252,7 +271,7 @@ const BuyXGetYEditorPreview = () => {
                     availableProducts.map(product => (
                       <div key={product.id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(255,255,255,0.05)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(255,255,255,0.1)' }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                          <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
+                          <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
                           <div>
                             <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                             <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -282,7 +301,7 @@ const BuyXGetYEditorPreview = () => {
                   selectedXProducts.map(product => (
                     <div key={product.productId} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(81, 105, 221, 0.1)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(81, 105, 221, 0.3)' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
+                        <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
                         <div>
                           <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                           <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -325,7 +344,7 @@ const BuyXGetYEditorPreview = () => {
                     availableProducts.map(product => (
                       <div key={product.id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(255,255,255,0.05)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(255,255,255,0.1)' }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                          <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
+                          <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
                           <div>
                             <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                             <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -355,7 +374,7 @@ const BuyXGetYEditorPreview = () => {
                   selectedYProducts.map(product => (
                     <div key={product.productId} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(76, 175, 80, 0.1)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(76, 175, 80, 0.3)' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
+                        <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
                         <div>
                           <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                           <div style={{ color: '#4CAF50', fontSize: '11px' }}>${calculateDiscountedPrice(product.price)} <span style={{ textDecoration: 'line-through', color: 'rgba(255,255,255,0.4)' }}>${product.price}</span></div>
@@ -576,7 +595,7 @@ const BuyXGetYEditorPreview = () => {
         {selectedXProducts.map((product) => (
           <div key={product.productId} style={{ padding: '12px', borderRadius: `${Math.max(0, cornerRadius - 5)}px`, marginBottom: '12px', backgroundColor: colorSettings.primaryBackgroundColor, border: `1px solid ${colorSettings.borderColor}` }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-              <img src={product.media} alt={product.title} style={{ width: 60, height: 60, borderRadius: '8px', objectFit: 'cover' }} />
+              <img src={getProductImageUrl(product)} alt={product.title} style={{ width: 60, height: 60, borderRadius: '8px', objectFit: 'cover' }} />
               <div>
                 <p style={{ fontWeight: 600, fontSize: '14px', marginBottom: '4px', color: colorSettings.primaryTextColor }}>{product.title}</p>
                 <p style={{ fontWeight: 600, fontSize: '14px', margin: 0, color: colorSettings.primaryTextColor }}>${product.price}</p>
@@ -593,7 +612,7 @@ const BuyXGetYEditorPreview = () => {
             {selectedYProducts.map((product) => (
               <div key={product.productId} style={{ padding: '12px', borderRadius: `${Math.max(0, cornerRadius - 5)}px`, marginTop: '5px', backgroundColor: 'rgba(255,255,255,0.9)' }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-                  <img src={product.media} alt={product.title} style={{ width: 60, height: 60, borderRadius: '8px', objectFit: 'cover' }} />
+                  <img src={getProductImageUrl(product)} alt={product.title} style={{ width: 60, height: 60, borderRadius: '8px', objectFit: 'cover' }} />
                   <div>
                     <p style={{ fontWeight: 600, fontSize: '14px', marginBottom: '4px', color: colorSettings.primaryTextColor }}>{product.title}</p>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>

--- a/web/frontend/mixmatch-preview.jsx
+++ b/web/frontend/mixmatch-preview.jsx
@@ -20,6 +20,25 @@ import {
 // Mock product image
 const tshirt = 'https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-product-1_large.png';
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = 'https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-product-1_large.png';
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 // Mix and Match settings configuration
 const MIXMATCH_SETTINGS = {
   bundle: [
@@ -296,7 +315,7 @@ const MixMatchEditorPreview = () => {
                   {availableProducts.map(product => (
                     <div key={product.id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(255,255,255,0.05)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(255,255,255,0.1)' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
+                        <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
                         <div>
                           <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                           <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -323,7 +342,7 @@ const MixMatchEditorPreview = () => {
                   selectedProducts.map(product => (
                     <div key={product.productId} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(81, 105, 221, 0.1)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(81, 105, 221, 0.3)' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
+                        <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
                         <div>
                           <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                           <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -706,7 +725,7 @@ const MixMatchEditorPreview = () => {
                   
                   <div style={{ display: 'flex', alignItems: 'center', paddingRight: '40px' }}>
                     <img 
-                      src={product.media || tshirt} 
+                      src={getProductImageUrl(product)} 
                       alt={product.title} 
                       style={{ 
                         width: '80px', 

--- a/web/frontend/preview.jsx
+++ b/web/frontend/preview.jsx
@@ -19,6 +19,25 @@ import {
   EditorRightContent
 } from './components/Editor';
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = 'https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-product-1_large.png?v=1530129292';
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 // Bundle settings configuration (same as StandardBundleEditor)
 const BUNDLE_SETTINGS = {
   bundle: [
@@ -277,7 +296,7 @@ const BundleEditorPreview = () => {
                         border: '1px solid rgba(255,255,255,0.1)'
                       }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                          <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
+                          <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
                           <div>
                             <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                             <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -325,7 +344,7 @@ const BundleEditorPreview = () => {
                         border: '1px solid rgba(81, 105, 221, 0.3)'
                       }}>
                         <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                          <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
+                          <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px' }} />
                           <div>
                             <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                             <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -630,7 +649,7 @@ const BundleEditorPreview = () => {
             background: colorSettings.secondaryBackgroundColor, borderRadius: '12px',
             border: `1px solid ${colorSettings.borderColor}`, marginBottom: '8px'
           }}>
-            <img src={product.media} alt={product.title} style={{ width: '50px', height: '50px', borderRadius: '8px' }} />
+            <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '50px', height: '50px', borderRadius: '8px' }} />
             <div style={{ flex: 1 }}>
               <div style={{ color: colorSettings.primaryTextColor, fontSize: '13px', fontWeight: '500' }}>{product.title}</div>
               <div style={{ color: colorSettings.secondaryTextColor, fontSize: '12px' }}>${product.price}</div>

--- a/web/frontend/volumediscount-preview.jsx
+++ b/web/frontend/volumediscount-preview.jsx
@@ -20,6 +20,25 @@ import {
 // Mock product image
 const tshirt = 'https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-product-1_large.png';
 
+// Default placeholder image for products without images
+const DEFAULT_PRODUCT_IMAGE = 'https://cdn.shopify.com/s/files/1/0533/2089/files/placeholder-images-product-1_large.png';
+
+/**
+ * Get product image URL from various possible sources
+ * Shopify API returns product.featuredMedia.image.url
+ * Fallback to product.media for backward compatibility
+ * @param {Object} product - Product object
+ * @returns {string} - Image URL
+ */
+const getProductImageUrl = (product) => {
+  if (!product) return DEFAULT_PRODUCT_IMAGE;
+  // Shopify API returns featuredMedia.image.url
+  if (product.featuredMedia?.image?.url) return product.featuredMedia.image.url;
+  // Fallback to media property for backward compatibility
+  if (product.media) return product.media;
+  return DEFAULT_PRODUCT_IMAGE;
+};
+
 // Volume Discount settings configuration
 const VOLUME_SETTINGS = {
   bundle: [
@@ -245,7 +264,7 @@ const VolumeDiscountEditorPreview = () => {
                   {MOCK_PRODUCTS.filter(p => p.title.toLowerCase().includes(productSearchQuery.toLowerCase())).map(product => (
                     <div key={product.id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(255,255,255,0.05)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(255,255,255,0.1)' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
+                        <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
                         <div>
                           <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                           <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -272,7 +291,7 @@ const VolumeDiscountEditorPreview = () => {
                   selectedProducts.map(product => (
                     <div key={product.productId} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px', background: 'rgba(81, 105, 221, 0.1)', borderRadius: '8px', marginBottom: '8px', border: '1px solid rgba(81, 105, 221, 0.3)' }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                        <img src={product.media} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
+                        <img src={getProductImageUrl(product)} alt={product.title} style={{ width: '40px', height: '40px', borderRadius: '6px', objectFit: 'cover' }} />
                         <div>
                           <div style={{ color: 'rgba(255,255,255,0.9)', fontSize: '13px' }}>{product.title}</div>
                           <div style={{ color: 'rgba(255,255,255,0.5)', fontSize: '11px' }}>${product.price}</div>
@@ -522,7 +541,7 @@ const VolumeDiscountEditorPreview = () => {
             {/* Product Display */}
             <div style={{ padding: '15px', backgroundColor: colorSettings.primaryBackgroundColor, borderRadius: `${Math.max(0, cornerRadius - 5)}px`, border: `1px solid ${colorSettings.borderColor}`, marginBottom: '15px' }}>
               <div style={{ display: 'flex', alignItems: 'center' }}>
-                <img src={selectedProducts[0]?.media || tshirt} alt={selectedProducts[0]?.title} style={{ width: '80px', height: '80px', borderRadius: '10px', marginRight: '15px', objectFit: 'cover', border: `1px solid ${colorSettings.borderColor}` }} />
+                <img src={getProductImageUrl(selectedProducts[0])} alt={selectedProducts[0]?.title} style={{ width: '80px', height: '80px', borderRadius: '10px', marginRight: '15px', objectFit: 'cover', border: `1px solid ${colorSettings.borderColor}` }} />
                 <div style={{ flex: 1 }}>
                   <p style={{ fontWeight: 600, fontSize: '14px', marginBottom: '5px', color: colorSettings.primaryTextColor }}>{selectedProducts[0]?.title}</p>
                   <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>


### PR DESCRIPTION
## Summary

Fixed the issue where product images were not rendering in preview components due to Shopify API returning product data in a different format.

### Root Cause
The Shopify API now returns product images via `featuredMedia.image.url` instead of `media`. The previous code only checked `product.media`, causing images to not display.

### Solution
Added a `getProductImageUrl()` utility function with a fallback chain:
1. `product.featuredMedia.image.url` - Shopify API format
2. `product.media` - Backward compatibility
3. Default placeholder image (tshirt.png)

### Files Changed
- **apps/bundle-discounts/**: DiscountList.jsx, StandardBundleEditor.jsx, bundleDiscountActions.jsx
- **apps/buy-one-get-one/**: BuyXGetYEditor.jsx, buyoneGetoneActions.jsx
- **apps/mix-and-match-discounts/**: MixAndMatchEditor.jsx, mixMatchActions.jsx
- **apps/volume-discounts/**: DiscountList.jsx, VolumeDiscountEditor.jsx, volumeDiscountActions.jsx
- **Root preview files**: preview.jsx, bxgy-preview.jsx, mixmatch-preview.jsx, volumediscount-preview.jsx

### Testing
- All product.media references updated to use getProductImageUrl(product)
- Backward compatibility maintained with fallback to product.media
- Default placeholder image shown when no image is available