### PR TITLE
Fix dev-pipeline.yml: explicit secrets instead of inherit

### DIFF
--- a/.github/workflows/dev-pipeline.yml
+++ b/.github/workflows/dev-pipeline.yml
@@ -26,4 +26,8 @@ jobs:
           (contains(github.event.comment.body, '@dev-agent implement') && 'implement') ||
           github.event.client_payload.action
         }}
-    secrets: inherit
+    secrets:
+      LITELLM_PROXY_URL: ${{ secrets.LITELLM_PROXY_URL }}
+      LITELLM_VIRTUAL_KEY: ${{ secrets.LITELLM_VIRTUAL_KEY }}
+      GH_APP_ID: ${{ secrets.GH_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

The step 5 test checkpoint for the new `dev-pipeline.yml` (from #150) failed immediately with:

```
Secret LITELLM_PROXY_URL is required, but not provided while calling.
Secret LITELLM_VIRTUAL_KEY is required, but not provided while calling.
Secret GH_APP_ID is required, but not provided while calling.
Secret GH_APP_PRIVATE_KEY is required, but not provided while calling.
```

...despite all 4 secrets existing on `11thandOrange/BusyBuddy_v2`. `secrets: inherit` only auto-forwards secrets when the reusable workflow lives in the same organization/enterprise as the caller. `HeyItsChloe/agent-ops` is a different account than `11thandOrange`, so `inherit` silently passed nothing across that boundary.

## Solution

Replace `secrets: inherit` with explicit `NAME: ${{ secrets.NAME }}` mappings for all 4 secrets — this form isn't subject to the org-boundary restriction.

## Test Plan

- [x] N/A — CI/automation config only, no application code changed
- [ ] After merge: re-run the step 5 checkpoint (label a test issue `approach-ready`, confirm the `plan` job succeeds and creates real sub-issues; re-trigger to confirm no duplicates)


---
_Generated by [Claude Code](https://claude.ai/code/session_014Vk3pkWLURRKcD4xHRqE5n)_