### PR TITLE
Fix dev-pipeline.yml: grant id-token: write for OIDC

### DIFF
--- a/.github/workflows/dev-pipeline.yml
+++ b/.github/workflows/dev-pipeline.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   dispatch:
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
     uses: HeyItsChloe/agent-ops/.github/workflows/dev-pipeline-reusable.yml@main
     with:
       project_language: typescript


### PR DESCRIPTION
## Problem

The step 5 test checkpoint got past the GitHub App token step (fixed in #151) but then failed inside `anthropics/claude-code-action@v1`:

```
Failed to get OIDC token: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

GitHub's reusable-workflow permission model requires a permission to be granted by **both** the caller and the reusable workflow for it to take effect. The `HeyItsChloe/agent-ops` side has already added `id-token: write` to the `plan`/`implement` jobs in `dev-pipeline-reusable.yml`, but our caller side never granted it either.

## Solution

Add a `permissions:` block to the `dispatch` job in `dev-pipeline.yml` with `id-token: write`, plus `contents: read` and `packages: read` to preserve the default `GITHUB_TOKEN` scope that was implicitly in effect before (declaring `permissions:` at all replaces the implicit defaults rather than adding to them).

## Test Plan

- [x] N/A — CI/automation config only, no application code changed
- [ ] After merge: re-run the step 5 checkpoint (label issue #149 `approach-ready`, confirm the `plan` job succeeds end-to-end and creates real sub-issues; re-trigger to confirm no duplicates)


---
_Generated by [Claude Code](https://claude.ai/code/session_014Vk3pkWLURRKcD4xHRqE5n)_