### PR TITLE
Remove skill_folder from dev-pipeline.yml caller inputs

### DIFF
--- a/.github/workflows/dev-pipeline.yml
+++ b/.github/workflows/dev-pipeline.yml
@@ -20,7 +20,6 @@ jobs:
       test_command: "npm test -- --coverage"
       coverage_type: cobertura
       desired_coverage: 85
-      skill_folder: skills/app-1
       reviewer: heyitschloe
       action: >-
         ${{


### PR DESCRIPTION
## Summary
- `agent-ops`'s `dev-pipeline-reusable.yml` now resolves skills by tag-matching against `project_language`/repo instead of a single `skill_folder` path, and no longer declares that input.
- Passing an input a reusable workflow doesn't declare is a hard validation error in GitHub Actions (not a silent no-op), so the next `plan`/`implement` trigger on this repo would fail immediately at workflow-validation time without this fix.
- Removes the now-unsupported `skill_folder: skills/app-1` line from `.github/workflows/dev-pipeline.yml`'s `with:` block. Nothing else changes — labels (`approach-ready`/`approved`), the explicit `secrets:` mapping, and the `permissions:` block are all untouched.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger a `plan`/`implement` run on a test issue to confirm the caller workflow still validates and dispatches correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_014Vk3pkWLURRKcD4xHRqE5n)_