### PR TITLE
Add repo-local skills: cart-transformer + backend/frontend conventions

### DIFF
--- a/skills/backend-frontend-conventions.md
+++ b/skills/backend-frontend-conventions.md
@@ -1,0 +1,146 @@
+# BusyBuddy_v2 Backend/Frontend Conventions
+
+Stack-specific implementation conventions for `web/backend` (Express +
+Mongoose) and `web/frontend` (React + Polaris). This is repo-local, not a
+shared skill, because it's specific to this stack — Node/Express/Mongoose/
+React/Polaris — not something every future project on this pipeline shares.
+
+## Problem
+
+The routing/controller/model split and the React/Redux/Polaris conventions
+here aren't self-evident from any single file — they're a pattern repeated
+across ~15 features. Getting the shop-scoping convention wrong (see below) is
+the easiest way to write a feature that leaks data across merchants.
+
+## Backend: Route → Controller → Model
+
+```
+web/backend/
+├── routes/<feature>/index.js       # Express router — thin, no logic
+├── controller/<feature>/index.js    # req/res handlers, Shopify GraphQL calls
+├── models/<feature>.model.js        # Mongoose schema
+└── services/                        # Shared logic (e.g. activityLogService, mutations.js)
+```
+
+**Route** (`routes/<feature>/index.js`):
+```javascript
+import express from "express";
+const router = express.Router();
+import { createItem, getItems, updateItem, deleteItem } from "../../controller/<feature>/index.js";
+
+router.post("/", createItem);
+router.get("/", getItems);
+router.put("/:id", updateItem);
+router.delete("/:id", deleteItem);
+
+export default router;
+```
+Register in `web/backend/routes/index.js`:
+```javascript
+import featureRoutes from "./<feature>/index.js";
+router.use("/<feature>", featureRoutes);
+```
+
+**Controller**: async handlers, `try/catch` returning 500 on error. Shop
+context comes from `res.locals.shopify.session` (confirmed used in 9+
+controllers — `frontStore`, `googleAnalytics`, `inactivetab`, `products`,
+`subscription`, `analytics`, `announcementBars`, `bundles`,
+`emailProvider`), typically `res.locals.shopify.session.shop`. For Shopify
+Admin GraphQL calls from a controller:
+```javascript
+const { admin } = await shopify.authenticate.admin(req, res);
+const response = await admin.graphql(`mutation { ... }`);
+const data = await response.json();
+```
+
+**Model / shop-scoping — two real patterns coexist, not one uniform field.**
+Don't assume every model scopes to a shop the same way; check similar
+existing models before adding a new one:
+- Some models reference the Shop doc by ObjectId, e.g. `bundle.model.js`:
+  `shopId: { type: Schema.Types.ObjectId, required: true }`
+- Others store the shop domain directly, e.g. `inactiveTab.model.js`:
+  `myshopify_domain: { type: String, required: true, unique: true }`
+
+Pick whichever pattern the feature's sibling models already use rather than
+introducing a third convention.
+
+## Frontend: Pages → App Modules → Components
+
+```
+web/frontend/
+├── pages/<feature>.jsx          # React Router page
+├── apps/<feature>/              # Form/Actions/Reducers per feature
+├── components/                  # Shared UI (Analytics, Settings, Modals)
+├── features/                    # Redux Toolkit slices (shared global state)
+└── hooks/
+```
+
+**Page pattern**:
+```jsx
+import { Page, Layout, Card } from "@shopify/polaris";
+import FeatureForm from "../apps/<feature>/FeatureForm";
+
+export default function FeaturePage() {
+  return (
+    <Page title="Feature Name">
+      <Layout>
+        <Layout.Section>
+          <Card><FeatureForm /></Card>
+        </Layout.Section>
+      </Layout>
+    </Page>
+  );
+}
+```
+
+**API calls** — always relative paths (Vite proxies `/api/*` to the backend):
+```javascript
+const response = await fetch("/api/<feature>/", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(payload),
+});
+```
+
+**State**: `useState`/`useEffect` for local component state, `@reduxjs/toolkit`
+slices under `web/frontend/features/` for shared global state, `react-query`
+for server state/caching.
+
+## Code Rules (verified against actual code, not just asserted)
+
+- `async/await` throughout — no `.then()` chains.
+- Every controller `async` handler wraps in `try/catch` returning 500.
+- Polaris (`@shopify/polaris`) components only for admin UI — no raw HTML
+  tables/buttons.
+- ES modules only (`import`/`export`) — no `require()`.
+- No hardcoded shop URLs, API endpoints, or credentials — `process.env.*`.
+
+## Running Tests
+
+```bash
+cd web && npm test                 # vitest run --config backend/vitest.config.js
+cd web/frontend && npm test         # vitest run (vite-based config)
+cd web && npm run test:coverage
+cd web/frontend && npm run coverage
+```
+
+Backend tests run with `environment: 'node'` — no DOM APIs. Frontend tests
+run with `environment: 'jsdom'`.
+
+### Frontend test setup (`web/frontend/tests/setup.js`) already mocks:
+- `window.fetch`, `window.open`, `window.location` (`?shop=test-shop.myshopify.com`)
+- `react-router-dom`'s `useNavigate`/`useLocation`/`useParams`
+- `@shopify/app-bridge-react` (`useAppBridge`, `Provider`)
+- `@shopify/polaris`'s `AppProvider` (passes children through)
+
+Don't re-mock these per-test — they're global. Mock model methods
+(`vi.mock('../../models/<feature>.model.js', ...)`) for backend controller
+tests instead of hitting real MongoDB.
+
+## Never Do
+
+- Use `require()` — ES modules only.
+- Block the event loop with synchronous I/O.
+- Commit `node_modules/`, `.env`, or any secret.
+- Assume a single shop-scoping field name across models — check the
+  feature's existing sibling models first (see above).

--- a/skills/shopify-cart-transformer.md
+++ b/skills/shopify-cart-transformer.md
@@ -1,0 +1,159 @@
+# BusyBuddy_v2 Cart Transformer Extension
+
+Domain knowledge for `extensions/cart-transformer` — the Shopify Function that
+implements bundle-discount pricing at checkout. This is narrow, easy-to-get-wrong
+detail specific to this extension; general JS/repo conventions live in the
+shared project-conventions skill, not here.
+
+## Problem
+
+Unlike the theme extension (storefront UI), this is a server-side Shopify
+Function: it has no UI, can't be manually clicked through, and its correctness
+depends entirely on matching an exact GraphQL input schema and metafield/attribute
+naming that isn't discoverable by reading `run.js` in isolation.
+
+## Where It Lives
+
+```
+extensions/cart-transformer/
+├── src/
+│   ├── index.js       # barrel: `export * from './run'`
+│   ├── run.js          # the actual function logic (exported as `run`)
+│   ├── run.graphql      # input query — defines exactly what cart data the function receives
+│   └── run.test.js      # Vitest tests
+├── schema.graphql        # full Shopify Function API schema (generated/reference, don't hand-edit)
+├── shopify.extension.toml # target, entrypoint, build config
+└── package.json
+```
+
+`shopify.extension.toml` wires it together:
+- `target = "purchase.cart-transform.run"` — this runs during checkout cart transform
+- `input_query = "src/run.graphql"` — the query below
+- `export = "run"` — must match the named export in `run.js`
+
+## The Input Schema (the part that's easy to get wrong)
+
+`run.graphql` currently requests:
+- `presentmentCurrencyRate` (top-level)
+- Per cart line:
+  - `bundleVariantIds`: a **cart-line attribute**, not a metafield — key
+    `_bundle_product_variant_ids` (leading underscore is part of the real key)
+  - On the line's `ProductVariant` → `product`, three **metafields** under
+    namespace `"busy-buddy"`:
+    - `bundle_discount_type` → aliased `bundledDiscountType`
+    - `bundle_discount_value` → aliased `bundledDiscountValue`
+    - `bundle_discount_products` → aliased `bundledProducts`
+
+If you need more cart data, add it to `run.graphql` — the function only sees
+what's explicitly queried. Getting the attribute-vs-metafield distinction or
+the `busy-buddy` namespace wrong is the most common way to silently get `null`
+values back with no error.
+
+## What `run()` Actually Does
+
+For each cart line, `optionallyBuildExpandOperation`:
+1. Only acts on `ProductVariant` lines that have a `bundleVariantIds` attribute value.
+2. Parses `bundledProducts` (format: comma-separated `variantId:price` pairs) into
+   `{ id, price }` objects, applying the discount:
+   - `bundleDiscountType === "percentage"` → `price -= price * (discountAmount / 100)`
+   - `bundleDiscountType === "fixed"` → `price -= discountAmount / bundleProductsLength`
+     (the fixed discount is split evenly across the bundle's product count)
+   - `discountAmount` itself is read from `bundleDiscounts[bundleProductsLength - 2]`
+     — i.e. the discount tiers array is indexed by bundle size, not a flat value.
+3. Filters `bundleVariantIds` down to only the IDs that also appear in `bundledProducts`.
+4. Throws `"Invalid bundle composition"` if the filtered result is empty but
+   `bundleProducts` was non-empty — this is a real thrown error, not a caught/logged
+   one, so a malformed metafield value will fail the whole checkout transform for
+   that line, not just skip it.
+5. Returns one `{ expand: { cartLineId, expandedCartItems } }` operation per
+   qualifying line, or `{ operations: [] }` if nothing qualifies.
+
+Each `expandedCartItems` entry sets `price.adjustment.fixedPricePerUnit` — this
+function always emits a fixed per-unit price, never a percentage-off operation,
+even when the underlying discount type is `"percentage"` (the percentage math
+happens before emission, producing a final fixed price).
+
+## Constraints (Shopify Function requirements, not just style)
+
+- Must be **pure and synchronous** — no `async`, no network calls, no side
+  effects. Shopify Functions compile to WASM and run in a sandboxed runtime
+  with strict execution limits; this isn't a lint preference.
+- Keep logic fast — this runs on every checkout, so added complexity here is
+  latency on the checkout critical path for every customer.
+- All input data must come through `run.graphql` — you cannot reach out for
+  more data mid-function.
+
+## Running Tests
+
+```bash
+cd extensions/cart-transformer
+npm test          # vitest run
+npm run test:watch
+```
+
+Current coverage (`run.test.js`) is thin — only the empty-cart case is tested.
+If you touch `run.js`, add cases for: a qualifying bundle line (percentage
+discount), a qualifying bundle line (fixed discount), a non-bundle line, and
+the invalid-bundle-composition throw path — none of those are currently covered.
+
+## Regenerating Types
+
+```bash
+npm run typegen    # shopify app function typegen — regenerates generated/api.ts from schema.graphql
+```
+
+Run this after changing `run.graphql` so the `FunctionRunResult`/input types
+referenced in JSDoc stay accurate.
+
+## Never Do
+
+- Add `async`/await, `fetch`, or any I/O inside `run()` or the functions it calls.
+- Hand-edit `schema.graphql` — it's the Shopify Function API schema, not
+  project-specific config.
+- Assume `bundleVariantIds` is a metafield — it's a cart-line **attribute**
+  (`attribute(key: "_bundle_product_variant_ids")`), a different GraphQL shape
+  than the `metafield(namespace:, key:)` calls used for the other three fields.
+- Change the `busy-buddy` metafield namespace without confirming the merchant
+  Admin UI / metafield definitions that populate it are updated in lockstep —
+  this function only reads what's already set there.
+
+---
+
+# BusyBuddy_v2 Theme Extension (bogo-shopify-app)
+
+Shorter reference for the storefront-facing half of `extensions/` — Liquid
+blocks + vanilla JS assets rendered in the Shopify theme editor.
+
+## Structure
+
+```
+extensions/bogo-shopify-app/
+├── blocks/        # Liquid blocks — placed by merchants in the theme editor
+├── assets/        # Vanilla JS + CSS loaded by blocks on storefront pages
+├── snippets/       # Reusable Liquid partials
+├── locales/
+└── shopify.extension.toml   # type = "theme"
+```
+
+## Block Conventions
+
+- `{% schema %}` block's `"target"` must be `"section"` for it to appear in
+  the theme editor.
+- Settings defined in `{% schema %}` become `block.settings.<id>` in Liquid —
+  pass them to JS via `data-*` attributes on the `<script>` tag, never hardcode
+  values in the JS file itself.
+- Script tags load `defer` — never block storefront page rendering.
+
+## Asset (JS) Conventions
+
+- Plain vanilla JS, loaded as **classic scripts** — no `import`/`export`
+  syntax; these are not bundled or transpiled.
+- Always guard on element existence first: `if (!el) return;` before doing
+  anything, since the block may not be present on every page.
+- Read configuration from `dataset.*` (set via the block's `data-*` attributes),
+  not from hardcoded constants.
+
+## Never Do
+
+- Use ES module syntax in `assets/*.js` — it will fail silently as a classic script.
+- Touch `web/` from here — that's the main app's domain, not this extension's.


### PR DESCRIPTION
## Summary
- agent-ops's dev pipeline now reads any `*.md` under this repo's own `skills/` directory automatically, no registration needed — separate from the shared `project-conventions` skill that lives centrally in agent-ops.
- Adds `skills/shopify-cart-transformer.md`, salvaging the durable domain knowledge from the retired `shopify-extension-implementer.legacy.md` agent: the cart-transformer Function's exact metafield/attribute schema, bundle-pricing logic (percentage vs. fixed discount math), and Shopify Function purity constraints, plus a shorter section on theme-extension (Liquid block) conventions.
- Adds `skills/backend-frontend-conventions.md`, salvaging the Express/Mongoose/React/Redux/Polaris conventions from `busybuddy-implementer.legacy.md` and `busybuddy-tester.legacy.md`. Confirmed with the agent-ops session this stays repo-local rather than going into `project-conventions` (`applies_to: all` reaches every future project regardless of stack — stack-specific conventions don't belong there).
- Both files were verified against the actual current code rather than carried forward verbatim. The legacy docs' example snippets were generic placeholders that didn't always match reality:
  - cart-transformer: didn't mention the `busy-buddy` metafield namespace or the attribute-vs-metafield distinction for `bundleVariantIds`
  - backend conventions: claimed a single uniform shop-scoping field (`shop: String`) across all models, but two patterns actually coexist (`shopId` ObjectId ref vs. `myshopify_domain` string), depending on the model

## Test plan
- [ ] Merge this PR
- [ ] Confirm from the agent-ops side that a `plan`/`implement` run actually picks up both `skills/*.md` files
