### PR TITLE
Add automatic deploy-to-production workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, busybuddy-prod]
+    steps:
+      - name: Pull latest main and rebuild
+        run: |
+          set -euo pipefail
+          cd /home/bitnami/BusyBuddy_v2
+
+          git fetch origin main
+          git reset --hard origin/main
+
+          cd web
+          npm install
+
+          cd frontend
+          npm install
+          npm run build
+
+          cd /home/bitnami/BusyBuddy_v2
+          pm2 restart BusyBuddy_v2 --update-env
+          pm2 save
+
+      - name: Report deployed commit
+        run: |
+          cd /home/bitnami/BusyBuddy_v2
+          echo "Deployed $(git rev-parse --short HEAD): $(git log -1 --pretty=%s)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, busybuddy-prod]
+    runs-on: self-hosted
     steps:
       - name: Pull latest main and rebuild
         run: |


### PR DESCRIPTION
## Problem

Production changes required manually logging into the Lightsail console, SSHing in, pulling `main`, and rebuilding by hand every time.

## Solution

Adds `.github/workflows/deploy.yml`, which runs on a self-hosted GitHub Actions runner installed directly on the production Lightsail instance (`bitnami@getbusybuddy.com`). On every push to `main` (or manual dispatch), it:

- `git fetch` + `git reset --hard origin/main`
- reinstalls backend (`web/`) and frontend (`web/frontend/`) dependencies
- rebuilds the frontend (`npm run build`)
- restarts the `pm2`-managed `BusyBuddy_v2` process and persists it with `pm2 save`

Using a self-hosted runner (rather than SSH-from-GitHub-hosted-runners) means no inbound port 22 exposure to the internet and no SSH private key stored in GitHub secrets — the runner only makes outbound connections to GitHub to long-poll for jobs.

## Approach

- `runs-on: self-hosted` targets the single runner registered against this repo (labels weren't reliably confirmed during setup, so matching on `self-hosted` alone avoids a job silently queuing forever on a label mismatch).
- Deploy steps operate directly on the existing production checkout at `/home/bitnami/BusyBuddy_v2` rather than using `actions/checkout`, since this workflow only ever runs on the one box that already holds that checkout.

Also fixed separately on the instance itself (not part of this diff, done directly via SSH): the SSL certificate for `getbusybuddy.com` had expired (Shopify's App Store delisting notice), caused by a `certbot` `standalone` authenticator conflicting with the always-running nginx, plus nginx reading from a static cert copy that was never updated on renewal. Deployed the already-renewed cert and added `pre`/`post`/`deploy` renewal hooks so the existing `certbot.timer` renews correctly going forward.

## Test Results

Not applicable — this PR only adds CI configuration; no application code changed. The workflow was validated by confirming the self-hosted runner registers and listens for jobs (`sudo ./svc.sh status` → `Connected to GitHub` / `Listening for Jobs`). The first live run of this workflow will be triggered by merging this PR.

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run
- [ ] N/A — no test suites apply to a workflow-only change


---
_Generated by [Claude Code](https://claude.ai/code/session_01BqW3Kc2kx8Wv6F7XjtvTJm)_