### PR TITLE
Docs site: fix Tailwind design tokens and GitHub Pages deep-link 404s

### DIFF
--- a/docs/frontend/index.html
+++ b/docs/frontend/index.html
@@ -8,6 +8,22 @@
     <title>BusyBuddy Docs</title>
   </head>
   <body>
+    <script type="text/javascript">
+      // Reverses the redirect in 404.html: turns "/?/api" back into a real
+      // "/BusyBuddy_v2/api" history entry before React Router mounts.
+      (function (l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search
+            .slice(1)
+            .split('&')
+            .map(function (s) {
+              return s.replace(/~and~/g, '&');
+            })
+            .join('?');
+          window.history.replaceState(null, '', l.pathname.slice(0, -1) + decoded + l.hash);
+        }
+      })(window.location);
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/docs/frontend/public/404.html
+++ b/docs/frontend/public/404.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>BusyBuddy Docs</title>
+    <script type="text/javascript">
+      // GitHub Pages serves this file for any path with no matching static
+      // file - i.e. every deep link into the SPA (/api, /getting-started,
+      // ...). It re-encodes the path into a query string and redirects to
+      // index.html, which decodes it back into a real history entry (see
+      // the inline script in index.html) before React Router ever sees it.
+      // Standard GH Pages SPA fallback: https://github.com/rafgraph/spa-github-pages
+      var pathSegmentsToKeep = 1; // keep "/BusyBuddy_v2"
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/docs/frontend/src/App.tsx
+++ b/docs/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { HashRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { useEffect } from 'react';
 import { Home } from './pages/Home';
 import { GettingStarted } from './pages/GettingStarted';
@@ -17,13 +17,13 @@ function ScrollToTop() {
   return null;
 }
 
-// HashRouter, not BrowserRouter: this site is served from a GitHub Pages
-// project path (/BusyBuddy_v2/), which has no server to rewrite deep-link
-// requests back to index.html. Hash-based routes never hit the server on
-// navigation, so they work with zero extra GH Pages configuration.
+// BrowserRouter with real paths (/BusyBuddy_v2/api, not /#/api). GitHub
+// Pages has no server-side rewrite, so deep links are made to work via the
+// 404.html + index.html redirect pair (see public/404.html) instead of
+// falling back to hash routing.
 function App() {
   return (
-    <HashRouter>
+    <BrowserRouter basename="/BusyBuddy_v2">
       <ScrollToTop />
       <Routes>
         <Route path="/" element={<Home />} />
@@ -41,7 +41,7 @@ function App() {
         <Route path="/stretch-features" element={<StretchFeatures />} />
         <Route path="*" element={<Home />} />
       </Routes>
-    </HashRouter>
+    </BrowserRouter>
   );
 }
 

--- a/docs/frontend/src/components/ApiReference/Sandbox.tsx
+++ b/docs/frontend/src/components/ApiReference/Sandbox.tsx
@@ -1,32 +1,54 @@
 import { useState } from 'react';
-import { Play, AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Play } from 'lucide-react';
 import type { EndpointDoc } from '../../types';
 import { CodeBlock } from '../ui/CodeBlock';
+import { cn } from '../../lib/cn';
 
 interface SandboxProps {
   endpoint: EndpointDoc;
 }
 
 type Result = { status: number; body: string } | { error: string };
+type CodeLang = 'curl' | 'fetch';
 
 export function Sandbox({ endpoint }: SandboxProps) {
   const [shop, setShop] = useState('');
   const [paramValues, setParamValues] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<Result | null>(null);
+  const [codeLang, setCodeLang] = useState<CodeLang>('curl');
 
   const queryParams = endpoint.params.filter((p) => p.in === 'query');
   const bodyParams = endpoint.params.filter((p) => p.in === 'body' && p.type !== 'file');
 
-  const buildUrl = () => {
-    if (!shop) return '';
-    const base = `https://${shop}${endpoint.path}`;
+  const buildUrl = (placeholder = false) => {
+    const host = shop || (placeholder ? 'your-store.myshopify.com' : '');
+    if (!host) return '';
+    const base = `https://${host}${endpoint.path}`;
     if (endpoint.method !== 'GET' || queryParams.length === 0) return base;
     const qs = queryParams
-      .filter((p) => paramValues[p.name])
-      .map((p) => `${p.name}=${encodeURIComponent(paramValues[p.name])}`)
+      .filter((p) => paramValues[p.name] || placeholder)
+      .map((p) => `${p.name}=${encodeURIComponent(paramValues[p.name] || `{${p.name}}`)}`)
       .join('&');
     return qs ? `${base}?${qs}` : base;
+  };
+
+  const bodyJson = () => {
+    const body: Record<string, string> = {};
+    for (const p of bodyParams) body[p.name] = paramValues[p.name] || `{${p.name}}`;
+    return JSON.stringify(body, null, 2);
+  };
+
+  const curlSnippet = () => {
+    const url = buildUrl(true);
+    if (endpoint.method === 'GET') return `curl "${url}"`;
+    return `curl -X ${endpoint.method} "${url}" \\\n  -H "Content-Type: application/json" \\\n  -d '${bodyJson().replace(/\n\s*/g, ' ')}'`;
+  };
+
+  const fetchSnippet = () => {
+    const url = buildUrl(true);
+    if (endpoint.method === 'GET') return `fetch("${url}")\n  .then((res) => res.json())\n  .then(console.log);`;
+    return `fetch("${url}", {\n  method: "${endpoint.method}",\n  headers: { "Content-Type": "application/json" },\n  body: JSON.stringify(${bodyJson()}),\n})\n  .then((res) => res.json())\n  .then(console.log);`;
   };
 
   const send = async () => {
@@ -58,12 +80,7 @@ export function Sandbox({ endpoint }: SandboxProps) {
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2 text-sm font-semibold text-white">
-        <Play size={15} className="text-brand" />
-        Try it
-      </div>
-
+    <div className="space-y-5">
       <div className="flex items-start gap-2 rounded-input border border-status-warning/30 bg-status-warning/5 p-3 text-xs text-content-secondary">
         <AlertTriangle size={14} className="mt-0.5 shrink-0 text-status-warning" />
         <span>
@@ -99,14 +116,11 @@ export function Sandbox({ endpoint }: SandboxProps) {
       <button
         onClick={send}
         disabled={!shop || loading}
-        className="w-full rounded-button bg-brand px-4 py-2.5 text-sm font-semibold text-white shadow-button transition-fast hover:bg-brand-hover disabled:opacity-40 disabled:cursor-not-allowed"
+        className="flex w-full items-center justify-center gap-2 rounded-button bg-brand px-4 py-2.5 text-sm font-semibold text-white shadow-button transition-fast hover:bg-brand-hover disabled:opacity-40 disabled:cursor-not-allowed"
       >
-        {loading ? 'Sending...' : `Send ${endpoint.method} request`}
+        <Play size={14} />
+        {loading ? 'Sending...' : 'Try it'}
       </button>
-
-      {shop && (
-        <div className="text-xs text-content-muted break-all font-mono">{buildUrl()}</div>
-      )}
 
       {result && (
         <div>
@@ -124,6 +138,25 @@ export function Sandbox({ endpoint }: SandboxProps) {
           )}
         </div>
       )}
+
+      <div>
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-muted">Code examples</div>
+        <div className="mb-2 flex gap-1.5">
+          {(['curl', 'fetch'] as const).map((lang) => (
+            <button
+              key={lang}
+              onClick={() => setCodeLang(lang)}
+              className={cn(
+                'rounded-md px-2.5 py-1 text-xs font-medium transition-fast',
+                codeLang === lang ? 'bg-surface-active text-white' : 'text-content-muted hover:text-content-secondary'
+              )}
+            >
+              {lang === 'curl' ? 'cURL' : 'fetch'}
+            </button>
+          ))}
+        </div>
+        <CodeBlock code={codeLang === 'curl' ? curlSnippet() : fetchSnippet()} language={codeLang === 'curl' ? 'bash' : 'javascript'} />
+      </div>
     </div>
   );
 }

--- a/docs/frontend/src/components/Layout/Breadcrumbs.tsx
+++ b/docs/frontend/src/components/Layout/Breadcrumbs.tsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom';
+
+export interface Crumb {
+  title: string;
+  href?: string;
+}
+
+export function Breadcrumbs({ items }: { items: Crumb[] }) {
+  return (
+    <div className="flex items-center gap-1.5 text-sm text-content-muted">
+      <Link to="/" className="hover:text-content-secondary transition-fast">
+        Docs
+      </Link>
+      {items.map((item, i) => (
+        <span key={i} className="flex items-center gap-1.5">
+          <span>/</span>
+          {item.href ? (
+            <Link to={item.href} className="hover:text-content-secondary transition-fast">
+              {item.title}
+            </Link>
+          ) : (
+            <span className="text-content-secondary">{item.title}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/docs/frontend/src/index.css
+++ b/docs/frontend/src/index.css
@@ -1,9 +1,21 @@
 @import 'tailwindcss';
+@config "../tailwind.config.js";
 
 @theme {
-  --color-brand-DEFAULT: #5169DD;
-  --color-brand-hover: #4257c4;
-  --color-brand-dark: #3a4bb0;
+  --radius-card: 1rem;
+  --radius-button: 0.5rem;
+  --radius-input: 0.5rem;
+
+  --text-heading-lg: 2.25rem;
+  --text-heading-lg--font-weight: 700;
+  --text-heading-lg--line-height: 1.25;
+  --text-heading-sm: 1.25rem;
+  --text-heading-sm--font-weight: 700;
+  --text-heading-sm--line-height: 1.4;
+}
+
+@utility transition-fast {
+  transition: all 150ms ease;
 }
 
 html {

--- a/docs/frontend/src/pages/ApiReference.tsx
+++ b/docs/frontend/src/pages/ApiReference.tsx
@@ -1,10 +1,19 @@
 import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import { Layout } from '../components/Layout/Layout';
+import { Breadcrumbs } from '../components/Layout/Breadcrumbs';
 import { endpointGroups, getGroup } from '../data/endpoints';
 import { EndpointDoc } from '../components/ApiReference/EndpointDoc';
 import { Sandbox } from '../components/ApiReference/Sandbox';
+import { MethodBadge } from '../components/ui/Badge';
 import { cn } from '../lib/cn';
+
+// Scroll directly to the element rather than using <a href="#slug">, since
+// a plain hash anchor would push a new history entry the router has to
+// reconcile against the real path-based routes.
+function scrollToEndpoint(slug: string) {
+  document.getElementById(slug)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
 
 export function ApiReference() {
   const { group: slug = endpointGroups[0].slug } = useParams();
@@ -16,6 +25,7 @@ export function ApiReference() {
   const rightPanel =
     liveEndpoints.length > 0 && activeEndpoint ? (
       <div>
+        <div className="mb-4 text-sm font-semibold text-white">Try it out</div>
         {liveEndpoints.length > 1 && (
           <div className="mb-4 flex flex-wrap gap-1.5">
             {liveEndpoints.map((e) => (
@@ -40,8 +50,28 @@ export function ApiReference() {
 
   return (
     <Layout rightPanel={rightPanel}>
-      <h1 className="text-heading-lg font-bold text-white">{group.title}</h1>
+      <Breadcrumbs items={[{ title: 'API Reference', href: '/api' }, { title: group.title }]} />
+      <h1 className="mt-4 text-heading-lg font-bold text-white">{group.title}</h1>
       <p className="mt-2 prose-body">{group.description}</p>
+
+      {group.endpoints.length > 1 && (
+        <div className="mt-6 rounded-card border border-surface-border bg-white/[0.02] p-5">
+          <div className="mb-3 text-xs font-semibold uppercase tracking-wider text-content-muted">On this page</div>
+          <div className="grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
+            {group.endpoints.map((e) => (
+              <button
+                key={e.slug}
+                onClick={() => scrollToEndpoint(e.slug)}
+                className="flex items-center gap-2 text-left text-sm text-content-secondary hover:text-white transition-fast"
+              >
+                <MethodBadge method={e.method} />
+                {e.title}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mt-8">
         {group.endpoints.map((endpoint) => (
           <EndpointDoc key={endpoint.slug} endpoint={endpoint} />

--- a/docs/frontend/src/pages/AppList.tsx
+++ b/docs/frontend/src/pages/AppList.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
+import { Breadcrumbs } from '../components/Layout/Breadcrumbs';
 import { apps, getApp } from '../data/apps';
 import { Badge } from '../components/ui/Badge';
 
@@ -10,7 +11,8 @@ export function AppList() {
 
   return (
     <Layout>
-      <div className="flex items-center gap-3">
+      <Breadcrumbs items={[{ title: 'App List', href: '/apps' }, { title: app.name }]} />
+      <div className="mt-4 flex items-center gap-3">
         <div
           className="flex h-10 w-10 items-center justify-center rounded-xl"
           style={{ background: `${app.color}22`, color: app.color }}

--- a/docs/frontend/src/pages/Architecture.tsx
+++ b/docs/frontend/src/pages/Architecture.tsx
@@ -1,4 +1,5 @@
 import { Layout } from '../components/Layout/Layout';
+import { Breadcrumbs } from '../components/Layout/Breadcrumbs';
 
 function Box({ title, detail, className }: { title: string; detail: string; className?: string }) {
   return (
@@ -12,7 +13,8 @@ function Box({ title, detail, className }: { title: string; detail: string; clas
 export function Architecture() {
   return (
     <Layout>
-      <h1 className="text-heading-lg font-bold text-white">System Architecture</h1>
+      <Breadcrumbs items={[{ title: 'Architecture' }]} />
+      <h1 className="mt-4 text-heading-lg font-bold text-white">System Architecture</h1>
       <p className="mt-2 prose-body">
         BusyBuddy is a monorepo: an Express backend, a React admin frontend embedded in Shopify
         Admin via App Bridge, a Shopify Theme App Extension for storefront widgets, and a

--- a/docs/frontend/src/pages/CiCd.tsx
+++ b/docs/frontend/src/pages/CiCd.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
+import { Breadcrumbs } from '../components/Layout/Breadcrumbs';
 import { workflows, getWorkflow } from '../data/workflows';
 import { Badge } from '../components/ui/Badge';
 
@@ -9,7 +10,8 @@ export function CiCd() {
 
   return (
     <Layout>
-      <h1 className="text-heading-lg font-bold text-white">{workflow.title}</h1>
+      <Breadcrumbs items={[{ title: 'CI/CD', href: '/ci-cd' }, { title: workflow.title }]} />
+      <h1 className="mt-4 text-heading-lg font-bold text-white">{workflow.title}</h1>
       <code className="mt-2 block font-mono text-sm text-content-muted">{workflow.file}</code>
 
       <div className="mt-4">

--- a/docs/frontend/src/pages/Features.tsx
+++ b/docs/frontend/src/pages/Features.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { Layout } from '../components/Layout/Layout';
+import { Breadcrumbs } from '../components/Layout/Breadcrumbs';
 import { features, getFeature } from '../data/features';
 
 export function Features() {
@@ -9,7 +10,8 @@ export function Features() {
 
   return (
     <Layout>
-      <div className="flex items-center gap-3">
+      <Breadcrumbs items={[{ title: 'Features', href: '/features' }, { title: feature.title }]} />
+      <div className="mt-4 flex items-center gap-3">
         <div
           className="flex h-10 w-10 items-center justify-center rounded-xl"
           style={{ background: `${feature.color}22`, color: feature.color }}

--- a/docs/frontend/src/pages/GettingStarted.tsx
+++ b/docs/frontend/src/pages/GettingStarted.tsx
@@ -1,10 +1,33 @@
 import { useParams } from 'react-router-dom';
+import { CheckCircle2 } from 'lucide-react';
 import { Layout } from '../components/Layout/Layout';
+import { Breadcrumbs } from '../components/Layout/Breadcrumbs';
 import { Badge } from '../components/ui/Badge';
 
-const SECTIONS: Record<string, { title: string; body: React.ReactNode }> = {
+function StepCard({ number, title, children }: { number: number; title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-card border border-surface-border bg-white/[0.02] p-5">
+      <div className="font-semibold text-white">
+        {number}. {title}
+      </div>
+      <div className="mt-2 text-sm text-content-secondary">{children}</div>
+    </div>
+  );
+}
+
+function CheckItem({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-center gap-2.5 text-sm text-content-secondary">
+      <CheckCircle2 size={16} className="shrink-0 text-status-success" />
+      {children}
+    </li>
+  );
+}
+
+const SECTIONS: Record<string, { title: string; subtitle: string; body: React.ReactNode }> = {
   introduction: {
     title: 'Introduction',
+    subtitle: 'What BusyBuddy is and how it\'s put together.',
     body: (
       <>
         <p className="prose-body">
@@ -24,65 +47,64 @@ const SECTIONS: Record<string, { title: string; body: React.ReactNode }> = {
   },
   install: {
     title: 'Install & Choose a Plan',
+    subtitle: 'Get BusyBuddy running on a shop in a few minutes.',
     body: (
       <>
-        <p className="prose-body">Install BusyBuddy from the Shopify App Store like any other app. On first install, the shop starts on the <Badge tone="brand">Free</Badge> plan automatically.</p>
-        <div className="mt-6 space-y-3">
-          <div className="rounded-input border border-surface-border p-4">
-            <div className="flex items-center justify-between">
-              <span className="font-semibold text-white">Free</span>
-              <span className="text-content-secondary">$0/mo</span>
+        <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-content-muted">Prerequisites</div>
+        <ul className="mb-6 space-y-2">
+          <CheckItem>A Shopify store (development or live)</CheckItem>
+          <CheckItem>Store owner or staff access with app-install permission</CheckItem>
+        </ul>
+
+        <div className="space-y-4">
+          <StepCard number={1} title="Install from the Shopify App Store">
+            Installing starts the shop on the <Badge tone="muted">Free</Badge> plan automatically - no
+            payment info needed until you choose to upgrade.
+          </StepCard>
+          <StepCard number={2} title="Choose a plan">
+            <div className="mt-1 space-y-2">
+              <div className="flex items-center justify-between rounded-input border border-surface-border px-3 py-2">
+                <span className="font-medium text-white">Free</span>
+                <span className="text-content-secondary">$0/mo · Announcement Bar + Inactive Tab, 1 app at a time</span>
+              </div>
+              <div className="flex items-center justify-between rounded-input border border-surface-border px-3 py-2">
+                <span className="font-medium text-white">Starter</span>
+                <span className="text-content-secondary">$30/mo · +3 discount apps, up to 3 apps at once</span>
+              </div>
+              <div className="flex items-center justify-between rounded-input border border-surface-border px-3 py-2">
+                <span className="font-medium text-white">Advanced</span>
+                <span className="text-content-secondary">$60/mo · +Mix & Match, up to 6 apps at once</span>
+              </div>
             </div>
-            <p className="mt-1 text-sm text-content-secondary">Announcement Bar + Inactive Tab Message. 1 app enabled at a time.</p>
-          </div>
-          <div className="rounded-input border border-surface-border p-4">
-            <div className="flex items-center justify-between">
-              <span className="font-semibold text-white">Starter</span>
-              <span className="text-content-secondary">$30/mo</span>
-            </div>
-            <p className="mt-1 text-sm text-content-secondary">Adds Bundle Discounts, Buy One Get One, Volume Discounts. Up to 3 apps enabled at once.</p>
-          </div>
-          <div className="rounded-input border border-surface-border p-4">
-            <div className="flex items-center justify-between">
-              <span className="font-semibold text-white">Advanced</span>
-              <span className="text-content-secondary">$60/mo</span>
-            </div>
-            <p className="mt-1 text-sm text-content-secondary">Adds Mix &amp; Match. Up to 6 apps enabled at once.</p>
-          </div>
+          </StepCard>
+          <StepCard number={3} title="Confirm billing">
+            Plan changes - including switching directly between two paid plans - always go
+            through Shopify's real billing confirmation screen before anything changes.
+          </StepCard>
         </div>
-        <p className="mt-6 prose-body">
-          Changing plans always goes through Shopify's real billing confirmation screen before
-          anything changes - including switching directly between two paid plans.
-        </p>
       </>
     ),
   },
   'enable-extension': {
     title: 'Enable the Theme Extension',
+    subtitle: 'Installing the app doesn\'t make widgets appear on the storefront by itself.',
     body: (
       <>
         <p className="prose-body">
-          Installing the app and configuring a widget in the admin dashboard doesn't make it
-          appear on the storefront by itself - the corresponding block/embed also needs to be
-          turned on in the Shopify Theme Editor. There are two distinct flows, and BusyBuddy
-          apps split across both:
+          Configuring a widget in the admin dashboard is one step - the corresponding
+          block/embed also needs to be turned on in the Shopify Theme Editor. There are two
+          distinct flows, and BusyBuddy apps split across both:
         </p>
         <div className="mt-6 space-y-4">
-          <div className="rounded-input border border-surface-border p-4">
-            <div className="font-semibold text-white">Add Block (section-based)</div>
-            <p className="mt-1 text-sm text-content-secondary">
-              Announcement Bar and all four discount/bundle apps render via section blocks.
-              In the Theme Editor: <code className="font-mono text-brand">Add block → Apps → BusyBuddy Announcement</code> (or the
-              relevant bundle block). <code className="font-mono">?context=apps</code> in a deep link does <em>not</em> open this panel.
-            </p>
-          </div>
-          <div className="rounded-input border border-surface-border p-4">
-            <div className="font-semibold text-white">App Embeds</div>
-            <p className="mt-1 text-sm text-content-secondary">
-              Inactive Tab Message is a true app embed (target: "body"). In the Theme Editor:
-              the <code className="font-mono">App embeds</code> panel, reachable via <code className="font-mono">?context=apps</code>.
-            </p>
-          </div>
+          <StepCard number={1} title="Add Block (section-based)">
+            Announcement Bar and all four discount/bundle apps render via section blocks.
+            In the Theme Editor: <code className="font-mono text-brand">Add block → Apps → BusyBuddy Announcement</code> (or
+            the relevant bundle block). <code className="font-mono">?context=apps</code> in a deep link does <em>not</em> open this panel.
+          </StepCard>
+          <StepCard number={2} title="App Embeds">
+            Inactive Tab Message is a true app embed (target: "body"). In the Theme Editor:
+            the <code className="font-mono">App embeds</code> panel, reachable via <code className="font-mono">?context=apps</code>.
+          </StepCard>
         </div>
         <p className="mt-6 prose-body">
           The admin dashboard's "Enable BusyBuddy" banner links to the correct flow for the app
@@ -99,7 +121,9 @@ export function GettingStarted() {
 
   return (
     <Layout>
-      <h1 className="text-heading-lg font-bold text-white">{content.title}</h1>
+      <Breadcrumbs items={[{ title: 'Getting Started', href: '/getting-started' }, { title: content.title }]} />
+      <h1 className="mt-4 text-heading-lg font-bold text-white">{content.title}</h1>
+      <p className="mt-2 text-content-secondary">{content.subtitle}</p>
       <div className="mt-6">{content.body}</div>
     </Layout>
   );

--- a/docs/frontend/src/pages/Home.tsx
+++ b/docs/frontend/src/pages/Home.tsx
@@ -1,120 +1,100 @@
 import { Link } from 'react-router-dom';
-import { ArrowRight, LayoutGrid, DollarSign, BarChart3, Sparkles } from 'lucide-react';
-import { Header } from '../components/Layout/Header';
-import { apps } from '../data/apps';
-import { features } from '../data/features';
+import { ArrowRight, BookOpen, LayoutGrid, Code2, Workflow, Boxes, Sparkles } from 'lucide-react';
+import { Layout } from '../components/Layout/Layout';
+
+const TOPICS = [
+  {
+    title: 'Getting Started',
+    description: 'Install BusyBuddy, choose a plan, and enable the theme extension.',
+    href: '/getting-started',
+    icon: BookOpen,
+    color: '#5169DD',
+  },
+  {
+    title: 'App List',
+    description: 'All six apps - what they do, how to configure them, and how they render.',
+    href: '/apps/announcement-bar',
+    icon: LayoutGrid,
+    color: '#e67e00',
+  },
+  {
+    title: 'Features',
+    description: 'Multi-app suite, easy editor, competitive pricing, analytics, and more.',
+    href: '/features/multi-app',
+    icon: Sparkles,
+    color: '#34c759',
+  },
+  {
+    title: 'API Reference',
+    description: 'Every endpoint, sourced from the real routes - with a live sandbox for public ones.',
+    href: '/api/storefront',
+    icon: Code2,
+    color: '#af52de',
+  },
+  {
+    title: 'CI/CD',
+    description: 'The three real pipelines: PR checks, production deploy, and the AI dev-agent.',
+    href: '/ci-cd/node-ci',
+    icon: Workflow,
+    color: '#ff2d55',
+  },
+  {
+    title: 'Architecture',
+    description: 'How the backend, admin frontend, theme extension, and Cart Transform Function fit together.',
+    href: '/architecture',
+    icon: Boxes,
+    color: '#5856d6',
+  },
+];
 
 export function Home() {
   return (
-    <div className="min-h-screen bg-background text-content">
-      <Header />
-      <main className="pt-16">
-        <section className="relative overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-glow pointer-events-none" />
-          <div className="relative mx-auto max-w-container px-6 py-24 text-center">
-            <h1 className="text-display-lg font-extrabold tracking-tight text-white">
-              <span className="text-brand">Busy</span>Buddy Documentation
-            </h1>
-            <p className="mx-auto mt-5 max-w-2xl text-body-lg text-content-secondary">
-              Six storefront apps, one install. Announcement bars, tab re-engagement, and four
-              product-bundling apps for Shopify - all documented here, generated from the real
-              codebase.
-            </p>
-            <div className="mt-8 flex items-center justify-center gap-3">
-              <Link
-                to="/getting-started"
-                className="flex items-center gap-2 rounded-button bg-brand px-5 py-3 text-sm font-semibold text-white shadow-button transition-fast hover:bg-brand-hover"
+    <Layout>
+      <div className="text-sm text-content-muted">Documentation</div>
+      <h1 className="mt-2 text-display-sm font-extrabold text-white">
+        <span className="text-brand">Busy</span>Buddy Docs
+      </h1>
+      <p className="mt-3 max-w-content prose-body">
+        Everything you need to work with BusyBuddy: the six-app suite, the admin API, the
+        storefront theme extension, and the CI/CD pipelines that ship it - all documented
+        straight from the codebase.
+      </p>
+
+      <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {TOPICS.map((topic) => {
+          const Icon = topic.icon;
+          return (
+            <Link
+              key={topic.href}
+              to={topic.href}
+              className="rounded-card border border-surface-border bg-white/[0.02] p-5 transition-fast hover:border-surface-border-hover hover:bg-surface-hover"
+            >
+              <div
+                className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg"
+                style={{ background: `${topic.color}22`, color: topic.color }}
               >
-                Get Started <ArrowRight size={16} />
-              </Link>
-              <Link
-                to="/api"
-                className="rounded-button border border-surface-border bg-surface px-5 py-3 text-sm font-semibold text-content-secondary transition-fast hover:text-white hover:border-surface-border-hover"
-              >
-                API Reference
-              </Link>
-            </div>
-          </div>
-        </section>
-
-        <section className="mx-auto max-w-container px-6 py-16">
-          <h2 className="text-heading-lg font-bold text-white text-center">Why BusyBuddy</h2>
-          <div className="mt-10 grid grid-cols-1 gap-4 md:grid-cols-3">
-            {features.map((f) => {
-              const Icon = f.icon;
-              return (
-                <Link
-                  key={f.slug}
-                  to={`/features/${f.slug}`}
-                  className="group rounded-card border border-surface-border bg-surface p-6 transition-fast hover:border-surface-border-hover hover:bg-surface-hover"
-                >
-                  <div
-                    className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl"
-                    style={{ background: `${f.color}22`, color: f.color }}
-                  >
-                    <Icon size={20} />
-                  </div>
-                  <h3 className="font-semibold text-white">{f.title}</h3>
-                  <p className="mt-1.5 text-sm text-content-secondary">{f.tagline}</p>
-                </Link>
-              );
-            })}
-          </div>
-        </section>
-
-        <section className="mx-auto max-w-container px-6 py-16">
-          <h2 className="text-heading-lg font-bold text-white text-center">The Six Apps</h2>
-          <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {apps.map((app) => {
-              const Icon = app.icon;
-              return (
-                <Link
-                  key={app.slug}
-                  to={`/apps/${app.slug}`}
-                  className="group rounded-card border border-surface-border bg-surface p-6 transition-fast hover:border-surface-border-hover hover:bg-surface-hover"
-                >
-                  <div
-                    className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl"
-                    style={{ background: `${app.color}22`, color: app.color }}
-                  >
-                    <Icon size={20} />
-                  </div>
-                  <h3 className="font-semibold text-white">{app.name}</h3>
-                  <p className="mt-1.5 text-sm text-content-secondary">{app.tagline}</p>
-                  <div className="mt-3 flex gap-1.5">
-                    {app.plans.map((p) => (
-                      <span key={p} className="rounded-full bg-white/5 px-2 py-0.5 text-xs text-content-muted">
-                        {p}
-                      </span>
-                    ))}
-                  </div>
-                </Link>
-              );
-            })}
-          </div>
-        </section>
-
-        <section className="mx-auto max-w-container px-6 py-16 pb-24">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <Link to="/ci-cd/node-ci" className="flex items-center gap-3 rounded-card border border-surface-border bg-surface p-5 transition-fast hover:border-surface-border-hover">
-              <BarChart3 className="text-brand" size={20} />
-              <span className="text-sm font-medium text-white">CI/CD Pipelines</span>
+                <Icon size={17} />
+              </div>
+              <div className="font-semibold text-white">{topic.title}</div>
+              <p className="mt-1 text-sm text-content-secondary">{topic.description}</p>
             </Link>
-            <Link to="/architecture" className="flex items-center gap-3 rounded-card border border-surface-border bg-surface p-5 transition-fast hover:border-surface-border-hover">
-              <LayoutGrid className="text-brand" size={20} />
-              <span className="text-sm font-medium text-white">Architecture</span>
-            </Link>
-            <Link to="/stretch-features" className="flex items-center gap-3 rounded-card border border-surface-border bg-surface p-5 transition-fast hover:border-surface-border-hover">
-              <Sparkles className="text-brand" size={20} />
-              <span className="text-sm font-medium text-white">Stretch Features</span>
-            </Link>
-          </div>
-        </section>
-      </main>
-      <footer className="border-t border-surface-border py-8 text-center text-xs text-content-muted">
-        <DollarSign className="mx-auto mb-2 text-content-muted" size={16} />
-        BusyBuddy · Documentation generated from the live BusyBuddy_v2 codebase
-      </footer>
-    </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-8 rounded-card border border-surface-border bg-white/[0.02] p-6">
+        <div className="text-heading-sm font-bold text-white">Quick Start</div>
+        <p className="mt-2 max-w-content text-sm text-content-secondary">
+          New to BusyBuddy? Start with the install &amp; plan guide, then enable the theme
+          extension on your storefront - most setup questions come from that second step.
+        </p>
+        <Link
+          to="/getting-started/install"
+          className="mt-4 inline-flex items-center gap-2 rounded-button bg-brand px-4 py-2.5 text-sm font-semibold text-white shadow-button transition-fast hover:bg-brand-hover"
+        >
+          Get Started <ArrowRight size={15} />
+        </Link>
+      </div>
+    </Layout>
   );
 }

--- a/docs/frontend/src/pages/Home.tsx
+++ b/docs/frontend/src/pages/Home.tsx
@@ -51,7 +51,7 @@ export function Home() {
   return (
     <Layout>
       <div className="text-sm text-content-muted">Documentation</div>
-      <h1 className="mt-2 text-display-sm font-extrabold text-white">
+      <h1 className="mt-2 text-heading-lg font-bold text-white">
         <span className="text-brand">Busy</span>Buddy Docs
       </h1>
       <p className="mt-3 max-w-content prose-body">

--- a/docs/frontend/src/pages/StretchFeatures.tsx
+++ b/docs/frontend/src/pages/StretchFeatures.tsx
@@ -1,10 +1,12 @@
 import { AlertTriangle } from 'lucide-react';
 import { Layout } from '../components/Layout/Layout';
+import { Breadcrumbs } from '../components/Layout/Breadcrumbs';
 
 export function StretchFeatures() {
   return (
     <Layout>
-      <h1 className="text-heading-lg font-bold text-white">Stretch Features</h1>
+      <Breadcrumbs items={[{ title: 'Stretch Features' }]} />
+      <h1 className="mt-4 text-heading-lg font-bold text-white">Stretch Features</h1>
 
       <div className="mt-4 flex items-start gap-2 rounded-input border border-status-warning/30 bg-status-warning/5 p-4 text-sm text-content-secondary">
         <AlertTriangle size={16} className="mt-0.5 shrink-0 text-status-warning" />

--- a/docs/frontend/vite.config.ts
+++ b/docs/frontend/vite.config.ts
@@ -2,11 +2,13 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // Served from the default GitHub Pages project path
-// (11thandorange.github.io/BusyBuddy_v2/), so assets must resolve
-// relative to that subpath rather than the domain root.
+// (11thandorange.github.io/BusyBuddy_v2/). An absolute base (rather than
+// relative) is required so that BrowserRouter deep links (e.g. /api,
+// /getting-started) still resolve asset URLs correctly, since those pages
+// are not one level deep from index.html the way a relative base assumes.
 export default defineConfig({
   plugins: [react()],
-  base: './',
+  base: '/BusyBuddy_v2/',
   build: {
     outDir: 'dist',
     sourcemap: false,


### PR DESCRIPTION
## Problem

The GitHub Pages docs site (`docs/frontend`) shipped in #229 rendered without any real styling — headings had no font size/weight, cards had no borders/backgrounds — and direct navigation to deep links like `/api` or `/getting-started` hit GitHub's raw unstyled 404 page instead of the app.

## Solution

- **Design tokens**: `docs/frontend/tailwind.config.js` already had the full, correct color/shadow system (matching the intended visual design), but Tailwind v4's CSS-first engine ignores JS config files unless explicitly loaded via `@config`. It was never wired in, so every custom utility class used across the site (`bg-surface`, `text-content-secondary`, `rounded-card`, `shadow-button`, `text-heading-lg`, etc.) silently compiled to zero CSS. Added `@config "../tailwind.config.js";` to `src/index.css`, plus the handful of tokens the JS config didn't cover (border radii, heading font sizes, a `transition-fast` utility).
- **Deep-link 404s**: switched routing from `HashRouter` to `BrowserRouter` with the standard GitHub Pages SPA-fallback pattern (`public/404.html` redirect + a small decode script in `index.html`), so paths like `/BusyBuddy_v2/api` resolve to the real app on first load instead of GitHub's native 404.
- Restyle pass to match the intended reference layout: added breadcrumbs across all pages, rebuilt the home page as a compact docs-home, added an "On this page" endpoint summary to API Reference pages, restyled the API sandbox as a "Try it out" panel with cURL/fetch code examples, and restyled Getting Started with numbered step cards.

## Approach

Verified visually with Playwright screenshots against a local script that reproduces GitHub Pages' real 404-then-redirect behavior (not just `vite preview`), confirming both the compiled CSS and the deep-link redirect actually work end-to-end before pushing.

## Test Results

| Suite | Status | Count |
|-------|--------|-------|
| `docs/frontend` typecheck (`tsc -b`) | ✅ | — |
| `docs/frontend` build (`npm run build`) | ✅ | — |
| Deep-link routing (Playwright, local GH-Pages-behavior sim) | ✅ | 5 routes |

Frontend/backend/extension suites are unaffected (no changes outside `docs/frontend`).

## Checklist

- [x] Tests pass locally before every commit
- [x] No `console.log` in production paths
- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] New routes registered in `web/backend/routes/index.js` (N/A — no backend routes changed)
- [x] Polaris components used for all admin UI (N/A — static docs site, not the admin app)
- [x] ES modules only — no `require()`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01K6RUbSo463fYNgWBvCxoVw)_