### PR TITLE
Docs site: sandbox panel on every API page + visible breakpoint fix

### DIFF
--- a/docs/frontend/src/components/ApiReference/Sandbox.tsx
+++ b/docs/frontend/src/components/ApiReference/Sandbox.tsx
@@ -8,7 +8,7 @@ interface SandboxProps {
   endpoint: EndpointDoc;
 }
 
-type Result = { status: number; body: string } | { error: string };
+type Result = { status: number; body: string; mock?: boolean } | { error: string };
 type CodeLang = 'curl' | 'fetch';
 
 export function Sandbox({ endpoint }: SandboxProps) {
@@ -52,6 +52,14 @@ export function Sandbox({ endpoint }: SandboxProps) {
   };
 
   const send = async () => {
+    if (!endpoint.liveTestable) {
+      setLoading(true);
+      setResult(null);
+      await new Promise((r) => setTimeout(r, 350));
+      setResult({ status: 200, body: endpoint.responseExample, mock: true });
+      setLoading(false);
+      return;
+    }
     if (!shop) return;
     setLoading(true);
     setResult(null);
@@ -81,22 +89,34 @@ export function Sandbox({ endpoint }: SandboxProps) {
 
   return (
     <div className="space-y-5">
-      <div className="flex items-start gap-2 rounded-input border border-status-warning/30 bg-status-warning/5 p-3 text-xs text-content-secondary">
-        <AlertTriangle size={14} className="mt-0.5 shrink-0 text-status-warning" />
-        <span>
-          This calls your real store through the Shopify App Proxy. Use a development/test store, not a live production shop.
-        </span>
-      </div>
+      {endpoint.liveTestable ? (
+        <div className="flex items-start gap-2 rounded-input border border-status-warning/30 bg-status-warning/5 p-3 text-xs text-content-secondary">
+          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-status-warning" />
+          <span>
+            This calls your real store through the Shopify App Proxy. Use a development/test store, not a live production shop.
+          </span>
+        </div>
+      ) : (
+        <div className="flex items-start gap-2 rounded-input border border-surface-border bg-surface p-3 text-xs text-content-secondary">
+          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-content-muted" />
+          <span>
+            Not callable from a public docs site: {endpoint.authNote} "Try it" below returns the documented example
+            response instead of a live call.
+          </span>
+        </div>
+      )}
 
-      <div>
-        <label className="mb-1 block text-xs font-medium text-content-secondary">Store domain</label>
-        <input
-          value={shop}
-          onChange={(e) => setShop(e.target.value.trim())}
-          placeholder="your-store.myshopify.com"
-          className="w-full rounded-input border border-surface-border bg-background px-3 py-2 text-sm text-white placeholder:text-content-muted focus:border-brand focus:outline-none"
-        />
-      </div>
+      {endpoint.liveTestable && (
+        <div>
+          <label className="mb-1 block text-xs font-medium text-content-secondary">Store domain</label>
+          <input
+            value={shop}
+            onChange={(e) => setShop(e.target.value.trim())}
+            placeholder="your-store.myshopify.com"
+            className="w-full rounded-input border border-surface-border bg-background px-3 py-2 text-sm text-white placeholder:text-content-muted focus:border-brand focus:outline-none"
+          />
+        </div>
+      )}
 
       {[...queryParams, ...bodyParams].map((p) => (
         <div key={p.name}>
@@ -115,11 +135,11 @@ export function Sandbox({ endpoint }: SandboxProps) {
 
       <button
         onClick={send}
-        disabled={!shop || loading}
+        disabled={(endpoint.liveTestable && !shop) || loading}
         className="flex w-full items-center justify-center gap-2 rounded-button bg-brand px-4 py-2.5 text-sm font-semibold text-white shadow-button transition-fast hover:bg-brand-hover disabled:opacity-40 disabled:cursor-not-allowed"
       >
         <Play size={14} />
-        {loading ? 'Sending...' : 'Try it'}
+        {loading ? 'Sending...' : endpoint.liveTestable ? 'Try it' : 'Try it (mock)'}
       </button>
 
       {result && (
@@ -131,7 +151,13 @@ export function Sandbox({ endpoint }: SandboxProps) {
           ) : (
             <>
               <div className="mb-1.5 text-xs font-medium text-content-secondary">
-                Response · <span className={result.status < 400 ? 'text-status-success' : 'text-status-error'}>{result.status}</span>
+                {result.mock ? (
+                  <span className="text-content-muted">Mocked response</span>
+                ) : (
+                  <>
+                    Response · <span className={result.status < 400 ? 'text-status-success' : 'text-status-error'}>{result.status}</span>
+                  </>
+                )}
               </div>
               <CodeBlock code={result.body} language="json" />
             </>

--- a/docs/frontend/src/components/Layout/Layout.tsx
+++ b/docs/frontend/src/components/Layout/Layout.tsx
@@ -13,7 +13,7 @@ export function Layout({ children, rightPanel }: { children: ReactNode; rightPan
             <div className="px-6 py-8 md:px-10 max-w-content">{children}</div>
           </main>
           {rightPanel && (
-            <aside className="hidden xl:flex flex-col w-96 shrink-0 border-l border-surface-border bg-background-elevated/50">
+            <aside className="hidden lg:flex flex-col w-96 shrink-0 border-l border-surface-border bg-background-elevated/50">
               <div className="sticky top-16 overflow-y-auto max-h-[calc(100vh-64px)] p-6">{rightPanel}</div>
             </aside>
           )}

--- a/docs/frontend/src/pages/ApiReference.tsx
+++ b/docs/frontend/src/pages/ApiReference.tsx
@@ -18,20 +18,20 @@ function scrollToEndpoint(slug: string) {
 export function ApiReference() {
   const { group: slug = endpointGroups[0].slug } = useParams();
   const group = getGroup(slug) ?? endpointGroups[0];
-  const liveEndpoints = group.endpoints.filter((e) => e.liveTestable);
-  const [activeLive, setActiveLive] = useState(liveEndpoints[0]?.slug);
-  const activeEndpoint = liveEndpoints.find((e) => e.slug === activeLive) ?? liveEndpoints[0];
+  const endpoints = group.endpoints;
+  const [activeSlug, setActiveSlug] = useState(endpoints[0]?.slug);
+  const activeEndpoint = endpoints.find((e) => e.slug === activeSlug) ?? endpoints[0];
 
   const rightPanel =
-    liveEndpoints.length > 0 && activeEndpoint ? (
+    endpoints.length > 0 && activeEndpoint ? (
       <div>
         <div className="mb-4 text-sm font-semibold text-white">Try it out</div>
-        {liveEndpoints.length > 1 && (
+        {endpoints.length > 1 && (
           <div className="mb-4 flex flex-wrap gap-1.5">
-            {liveEndpoints.map((e) => (
+            {endpoints.map((e) => (
               <button
                 key={e.slug}
-                onClick={() => setActiveLive(e.slug)}
+                onClick={() => setActiveSlug(e.slug)}
                 className={cn(
                   'rounded-full px-2.5 py-1 text-xs font-medium transition-fast',
                   activeEndpoint.slug === e.slug


### PR DESCRIPTION
## Problem

Two remaining issues after #230:

1. The "Try it out" sandbox panel was hidden below 1280px viewport width (`hidden xl:flex`), so it didn't appear on many normal browser windows.
2. The panel only rendered on API Reference pages that had at least one publicly-callable (app-proxy) endpoint - 4 of ~72 documented endpoints. Every session/webhook/API-key-gated endpoint's page showed no sandbox at all.

## Solution

- Lowered the panel's breakpoint to `lg` (1024px).
- Every API Reference group now renders the panel. Non-live-testable endpoints get a "Try it (mock)" button that returns the endpoint's documented example response (already tracked per-endpoint in `data/endpoints.ts`) instead of attempting a call that can't succeed from a public static site. The explanation banner pulls each endpoint's real `authNote` (session / HMAC webhook / admin API key / partner token) instead of a generic message, so the reason shown is accurate per endpoint.

## Test Results

| Suite | Status | Count |
|-------|--------|-------|
| `docs/frontend` typecheck (`tsc -b`) | ✅ | — |
| `docs/frontend` build (`npm run build`) | ✅ | — |
| Manual verification (Playwright screenshots, mock "Try it" click) | ✅ | — |

## Checklist

- [x] Tests pass locally before every commit
- [x] No `console.log` in production paths
- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] New routes registered in `web/backend/routes/index.js` (N/A — no backend routes changed)
- [x] Polaris components used for all admin UI (N/A — static docs site)
- [x] ES modules only — no `require()`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01K6RUbSo463fYNgWBvCxoVw)_