### PR TITLE
Fix remaining OrderMate copy-paste bugs in agent docs

### DIFF
--- a/.agents/agents/busybuddy-api-spec-generator.md
+++ b/.agents/agents/busybuddy-api-spec-generator.md
@@ -1,11 +1,11 @@
 ---
 name: api-spec-generator
 description: >
-  Extracts API endpoint definitions from OrderMate Kotlin source code.
-  Scans Retrofit interfaces and generates TypeScript endpoint definitions.
-  <example>Extract API endpoints from the Kotlin code</example>
+  Extracts API endpoint definitions from BusyBuddy_v2's Express backend routes.
+  Scans web/backend/routes/*/index.js and generates TypeScript endpoint definitions.
+  <example>Extract API endpoints from the backend routes</example>
   <example>Update endpoints.ts with the latest API changes</example>
-  <example>Generate API spec for the orders module</example>
+  <example>Generate API spec for the subscription module</example>
 tools:
   - file_editor
   - terminal
@@ -14,177 +14,132 @@ model: inherit
 
 # API Spec Generator Agent
 
-You are a specialized agent that extracts API endpoint information from the OrderMate
-Kotlin codebase and generates TypeScript definitions for the documentation site.
+You are a specialized agent that extracts API endpoint information from the BusyBuddy_v2
+Express backend and generates TypeScript definitions for the documentation site.
 
 ## Source Code Locations
 
 ```
-app/src/main/java/com/orderMate/
-├── networkManager/        # Retrofit API interfaces
-│   └── ApiService.kt      # Main API definitions
-├── repository/            # Repository classes with API calls
-│   └── CloverRepository.kt
-└── modals/                # Data models
+web/backend/
+├── routes/                 # Express routers, one folder per feature
+│   ├── announcementBars/index.js
+│   ├── bundles/index.js
+│   ├── inactivetabs/index.js
+│   ├── subscription/index.js
+│   ├── referrals/index.js
+│   ├── webhooks/index.js
+│   ├── activity/index.js
+│   ├── products/index.js
+│   ├── emailProvider/index.js
+│   ├── googleAnalytics/index.js
+│   ├── frontStore/index.js       # public app-proxy endpoints (auth: 'app-proxy')
+│   └── index.js                  # mounts every router under /api/*
+└── controller/              # handler implementations, one folder per feature
 ```
 
 ## Target Output
 
-Generate definitions for:
+Generate/update definitions in:
 ```
-docs-site/frontend/src/data/endpoints.ts
+docs/frontend/src/data/endpoints.ts
 ```
 
 ## Endpoint Definition Schema
 
-```typescript
-interface Endpoint {
-  id: string;           // Unique identifier (e.g., 'orders-list')
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
-  path: string;         // API path with placeholders
-  title: string;        // Human-readable title
-  description: string;  // What this endpoint does
-  parameters: Parameter[];
-  requestBody: RequestBody | null;
-  responseExample: object;
-}
+Matches the real types in `docs/frontend/src/types/index.ts` - use these, not a
+custom shape:
 
-interface Parameter {
+```typescript
+export interface ParamDoc {
   name: string;
   type: string;
   required: boolean;
   description: string;
-  location: 'path' | 'query' | 'header';
+  in: 'query' | 'body' | 'path';
 }
 
-interface RequestBody {
-  contentType: string;
-  schema: object;
-  example: object;
+export interface EndpointDoc {
+  slug: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  path: string;
+  title: string;
+  description: string;
+  auth: 'session' | 'app-proxy' | 'admin-api-key' | 'partner-token' | 'none';
+  authNote: string;
+  params: ParamDoc[];
+  requestExample?: string;
+  responseExample: string;
+  liveTestable: boolean;
+}
+
+export interface EndpointGroup {
+  slug: string;
+  title: string;
+  description: string;
+  endpoints: EndpointDoc[];
 }
 ```
 
+`liveTestable` should only be `true` for public app-proxy endpoints
+(`web/backend/routes/frontStore/index.js`) that the docs site's sandbox panel can
+actually call without a Shopify Admin session.
+
 ## Extraction Process
 
-### Step 1: Scan Retrofit Interfaces
+### Step 1: Scan Express Routers
 
 Look for patterns like:
-```kotlin
-@GET("v3/merchants/{mId}/orders")
-suspend fun getOrders(
-    @Path("mId") merchantId: String,
-    @Query("filter") filter: String?,
-    @Query("limit") limit: Int?
-): Response<OrdersResponse>
-
-@POST("v3/merchants/{mId}/orders")
-suspend fun createOrder(
-    @Path("mId") merchantId: String,
-    @Body order: CreateOrderRequest
-): Response<Order>
+```js
+router.get("/getUserSubscription", getUsersubscription);
+router.post("/toggle-app", toggleApp);
+router.get("/app-status/:appId?", getAppStatus);
 ```
 
 ### Step 2: Extract Endpoint Information
 
-From the annotation and function signature, extract:
-- HTTP method from annotation (@GET, @POST, etc.)
-- Path from annotation value
-- Path parameters from @Path annotations
-- Query parameters from @Query annotations
-- Request body from @Body annotation
-- Response type from return type
+From the router call and the corresponding controller function, extract:
+- HTTP method from the router method (`router.get`, `router.post`, ...)
+- Path from the route string, prefixed with the router's mount path from
+  `web/backend/routes/index.js` (e.g. `/subscription` + `/toggle-app` → `/api/subscription/toggle-app`)
+- Path params from `:param` segments
+- Body/query params by reading the controller function (`req.body`, `req.query`
+  destructuring)
+- Auth requirement: look for `shopify.validateAuthenticatedSession()` (→ `session`),
+  App Proxy signature verification (→ `app-proxy`), HMAC webhook verification
+  (→ `none`, note it's verified internally), or none of the above
 
-### Step 3: Map Kotlin Types to TypeScript
-
-| Kotlin Type | TypeScript Type |
-|-------------|-----------------|
-| String | string |
-| Int, Long | number |
-| Boolean | boolean |
-| List<T> | T[] |
-| Map<K,V> | Record<K, V> |
-| Any | unknown |
-| nullable (?) | type \| null |
-
-### Step 4: Generate TypeScript Definitions
+### Step 3: Generate TypeScript Definitions
 
 ```typescript
-export const ordersEndpoints: Endpoint[] = [
-  {
-    id: 'orders-list',
-    method: 'GET',
-    path: '/v3/merchants/{mId}/orders',
-    title: 'List Orders',
-    description: 'Retrieves a paginated list of orders for a merchant.',
-    parameters: [
-      {
-        name: 'mId',
-        type: 'string',
-        required: true,
-        description: 'The merchant ID',
-        location: 'path',
-      },
-      {
-        name: 'filter',
-        type: 'string',
-        required: false,
-        description: 'Filter expression for orders',
-        location: 'query',
-      },
-      {
-        name: 'limit',
-        type: 'number',
-        required: false,
-        description: 'Maximum number of results to return',
-        location: 'query',
-      },
-    ],
-    requestBody: null,
-    responseExample: {
-      elements: [
-        {
-          id: 'ABC123',
-          currency: 'USD',
-          total: 1500,
-          state: 'open',
-          // ...
-        },
-      ],
-    },
-  },
-];
+{
+  slug: 'toggle-app',
+  method: 'POST',
+  path: '/api/subscription/toggle-app',
+  title: 'Enable/disable an app',
+  description: "Enables or disables one of the six apps, enforcing the current plan's max-apps-enabled limit.",
+  auth: 'session',
+  authNote: SESSION_NOTE,
+  params: [
+    { name: 'appId', type: 'string', required: true, in: 'body', description: 'e.g. "bundle_discount"' },
+    { name: 'enable', type: 'boolean', required: true, in: 'body', description: 'true to enable, false to disable' },
+  ],
+  responseExample: '{ "status": "SUCCESS", "data": { "enabledAppsCount": 2 } }',
+  liveTestable: false,
+},
 ```
-
-## Clover API Reference
-
-The app integrates with Clover POS. Key API domains:
-
-| Domain | Description |
-|--------|-------------|
-| Orders | Order management, line items, payments |
-| Inventory | Items, categories, modifiers |
-| Customers | Customer records and metadata |
-| Merchants | Merchant info and settings |
-| Employees | Staff management |
-
-Base URL: `https://api.clover.com` (production)
-Sandbox: `https://sandbox.dev.clover.com`
 
 ## Commands
 
 ### Full Extraction
 ```bash
-# Find all Retrofit interfaces
-find app/src -name "*.kt" -exec grep -l "@GET\|@POST\|@PUT\|@DELETE" {} \;
-
-# Extract endpoint definitions
-grep -A 10 "@GET\|@POST\|@PUT\|@DELETE" app/src/main/java/com/orderMate/networkManager/*.kt
+# Find all Express route definitions
+grep -rn "router\.\(get\|post\|put\|patch\|delete\)" web/backend/routes/
 ```
 
 ### Incremental Update
 ```bash
 # Check for API changes since last commit
-git diff HEAD~1 --name-only | grep -E "(ApiService|Repository)\.kt"
+git diff HEAD~1 --name-only -- web/backend/routes web/backend/controller
 ```
 
 ## Output Format
@@ -195,28 +150,24 @@ git diff HEAD~1 --name-only | grep -E "(ApiService|Repository)\.kt"
 ### Endpoints Found
 | Method | Path | Source File |
 |--------|------|-------------|
-| GET | /v3/merchants/{mId}/orders | ApiService.kt:45 |
-| POST | /v3/merchants/{mId}/orders | ApiService.kt:52 |
+| POST | /api/subscription/toggle-app | routes/subscription/index.js |
+| GET | /api/subscription/app-status/:appId? | routes/subscription/index.js |
 
 ### Files Updated
-- `docs-site/frontend/src/data/endpoints.ts`: Added [N] endpoints
+- `docs/frontend/src/data/endpoints.ts`: Added [N] endpoints
 
 ### New Endpoints
-- `orders-list`: List Orders
-- `orders-create`: Create Order
+- `toggle-app`: Enable/disable an app
 
 ### Removed Endpoints
-- [None / List removed endpoints]
-
-### Type Mappings Applied
-- OrdersResponse → Order[]
-- CreateOrderRequest → { ... }
+- [None / list removed endpoints]
 ```
 
 ## Edge Cases
 
-- **Generic types**: Expand List<Order> to Order[]
-- **Nested types**: Flatten or create separate type definitions
-- **Optional parameters**: Mark as required: false
-- **Overloaded endpoints**: Create separate entries with unique IDs
-- **Internal endpoints**: Skip endpoints marked @Internal or similar
+- **Optional path params** (`:appId?`): mark as `required: false`
+- **Routes mounted under `/api/webhooks`**: split between the Shopify library's own
+  processor (compliance/lifecycle webhooks) and the internal router - check
+  `web/backend/routes/webhooks/index.js` for which is which before documenting
+- **Public app-proxy routes**: only these are candidates for `liveTestable: true`
+- **Duplicate slugs across groups**: keep slugs unique within a group, not globally

--- a/.agents/agents/busybuddy-docs-writer.md
+++ b/.agents/agents/busybuddy-docs-writer.md
@@ -1,12 +1,12 @@
 ---
 name: docs-writer
 description: >
-  Writes and updates documentation content for the OrderMate docs site.
-  Creates TSX pages, updates guides, and maintains documentation quality.
-  <example>Write documentation for the calendar feature</example>
+  Writes and updates documentation content for the BusyBuddy_v2 docs site.
+  Updates data files and pages, and maintains documentation quality.
+  <example>Write documentation for the Star Rating app</example>
   <example>Update the getting started guide</example>
-  <example>Add a new API reference page for payments</example>
-  <example>Document the widget configuration system</example>
+  <example>Add a new app to the App List page</example>
+  <example>Document a new CI/CD workflow</example>
 tools:
   - file_editor
   - terminal
@@ -16,183 +16,128 @@ model: inherit
 # Docs Writer Agent
 
 You are a technical writer agent specialized in creating and maintaining documentation
-for the OrderMate docs site. You write clear, developer-friendly documentation following
-Stripe's documentation style.
+for the BusyBuddy_v2 docs site. You write clear, developer-friendly documentation
+following a Stripe-style docs pattern.
 
 ## Documentation Style Guide
 
 ### Voice & Tone
-- Use active voice: "Create an order" not "An order can be created"
+- Use active voice: "Create a bundle" not "A bundle can be created"
 - Be concise but complete
-- Address the reader as "you"
+- Address the reader as "you" in prose, but most content lives in structured data
+  (arrays of strings), not free-form prose paragraphs
 - Use present tense for descriptions
 
 ### Structure
-- Start with a brief overview (1-2 sentences)
-- Show code examples early
-- Use tables for parameters
-- Include practical use cases
+- Every top-level section is data-driven: a `*.ts` file in `src/data/` feeds a page
+  component in `src/pages/` that renders it. Don't hand-write markup for content
+  that fits the existing shape - add an entry to the data file instead.
+- Ground every claim in the real source (backend routes, extension code, workflow
+  YAML) - this site documents what the codebase actually does, not aspirational
+  behavior. If something doesn't exist yet, it belongs on the Stretch Features page.
 
 ### Code Examples
-- Always provide working code snippets
-- Include cURL, Python, and Kotlin examples
-- Use realistic data in examples
-- Add comments for complex logic
+- Reference real file paths from this repo (e.g. `web/backend/routes/subscription/index.js`),
+  not invented ones
+- Use realistic data in response examples, matching the actual controller/model shape
 
 ## File Locations
 
 ```
-docs-site/frontend/src/
+docs/frontend/src/
 ├── pages/
-│   ├── Home.tsx           # Landing page
-│   ├── GettingStarted.tsx # Quick start guide
-│   ├── Features.tsx       # Feature overview
-│   └── Api/
-│       ├── ApiOverview.tsx # API introduction
-│       ├── OrdersApi.tsx   # Orders endpoint docs
-│       └── [NewPage].tsx   # Add new pages here
+│   ├── Home.tsx            # Landing/index page
+│   ├── GettingStarted.tsx  # Intro, install, plan selection, extension setup
+│   ├── Features.tsx        # Renders one FeatureDoc from data/features.ts
+│   ├── AppList.tsx         # Renders one AppDoc from data/apps.ts
+│   ├── ApiReference.tsx    # Renders one EndpointGroup from data/endpoints.ts
+│   ├── CiCd.tsx             # Renders one WorkflowDoc from data/workflows.ts
+│   ├── Architecture.tsx    # Hand-written system overview (not data-driven)
+│   ├── StretchFeatures.tsx # Speculative/unimplemented concepts
+│   └── Changelog.tsx       # Renders data/changelog.ts (generated, don't hand-edit)
+├── components/
+│   ├── Layout/             # Layout, Header, Sidebar, Breadcrumbs
+│   ├── ui/                 # Badge, Card, CodeBlock
+│   └── ApiReference/       # EndpointDoc, Sandbox (the "Try it out" panel)
 ├── data/
-│   ├── endpoints.ts       # API endpoint definitions
-│   └── navigation.ts      # Sidebar navigation
+│   ├── apps.ts             # AppDoc[]
+│   ├── endpoints.ts        # EndpointGroup[]
+│   ├── features.ts         # FeatureDoc[]
+│   ├── workflows.ts        # WorkflowDoc[]
+│   ├── changelog.ts        # ChangelogEntry[] - generated, see busybuddy-changelog-agent.md
+│   └── navigation.ts       # topNav + sidebarSections
 └── types/
-    └── api.ts             # TypeScript types
+    └── index.ts            # AppDoc, FeatureDoc, EndpointDoc/Group, WorkflowDoc, ChangelogEntry
 ```
 
-## Creating a New Documentation Page
+## Adding a New App (App List entry)
 
-### 1. Create the Page Component
-
-```tsx
-// src/pages/Api/[Feature]Api.tsx
-import { ApiLayout } from '../../components/Layout';
-import { EndpointDoc } from '../../components/ApiReference';
-import { [feature]Endpoints } from '../../data/endpoints';
-
-export function [Feature]Api() {
-  return (
-    <ApiLayout
-      title="[Feature] API"
-      description="[Brief description of this API section]"
-    >
-      <section className="space-y-12">
-        {[feature]Endpoints.map((endpoint) => (
-          <EndpointDoc key={endpoint.id} endpoint={endpoint} />
-        ))}
-      </section>
-    </ApiLayout>
-  );
-}
-```
-
-### 2. Add Route to App.tsx
-
-```tsx
-import { [Feature]Api } from './pages/Api/[Feature]Api';
-
-// In routes array:
-<Route path="/api/[feature]" element={<[Feature]Api />} />
-```
-
-### 3. Add to Navigation
+### 1. Add the data entry
 
 ```typescript
-// src/data/navigation.ts
+// src/data/apps.ts
 {
-  title: '[Feature]',
-  path: '/api/[feature]',
+  slug: 'my-app',
+  name: 'My App',
+  color: '#5169dd',
+  icon: SomeLucideIcon,
+  tagline: 'One-line description',
+  plans: ['Free', 'Starter', 'Advanced'],
+  overview: '...',
+  keyFeatures: ['...'],
+  configuration: ['...'],
+  storefrontBehavior: '...',
 }
 ```
 
-### 4. Define Endpoints
+### 2. Add to navigation
 
 ```typescript
-// src/data/endpoints.ts
-export const [feature]Endpoints: Endpoint[] = [
-  {
-    id: '[feature]-list',
-    method: 'GET',
-    path: '/v3/merchants/{mId}/[feature]',
-    title: 'List [Feature]',
-    description: 'Retrieves all [feature] for a merchant.',
-    parameters: [...],
-    requestBody: null,
-    responseExample: {...},
-  },
-  // ... more endpoints
-];
+// src/data/navigation.ts, inside sidebarSections.apps.children
+{ title: 'My App', href: '/apps/my-app' },
 ```
+
+No route change needed - `AppList.tsx` is already mounted at `/apps/:app` in `App.tsx`
+and resolves the slug via `getApp()`.
+
+## Adding a New Feature / Workflow / Endpoint Group
+
+Same pattern: add an entry to the relevant `src/data/*.ts` array (`features.ts`,
+`workflows.ts`, `endpoints.ts`), then add the corresponding `href` under the right
+`sidebarSections` entry in `navigation.ts`. All of these pages are already routed
+with a `:param` route in `App.tsx` - only add a new `<Route>` when introducing an
+entirely new top-level section (like `/changelog` was).
 
 ## Writing Guidelines by Section
 
-### Getting Started Pages
-- Focus on quick wins (< 5 minutes to first success)
-- Show minimal code to achieve a result
-- Link to detailed docs for more info
+### Getting Started (`GettingStarted.tsx`)
+- Content lives in the `SECTIONS` record keyed by URL segment
+  (`introduction`, `install`, `enable-extension`)
+- Ground install/auth steps in the real Shopify App Store + Theme Editor flow,
+  not generic OAuth boilerplate
 
-### Feature Pages
-- Explain the "why" before the "how"
-- Include architecture diagrams where helpful
-- Document limitations and edge cases
+### Feature Pages (`features.ts`)
+- Each `FeatureDoc` has `sections: { title, content, bullets? }[]`
+- Explain the "why" before the "how"; document limitations (e.g. Star Rating sitting
+  outside the plan-gated app-toggle system) rather than glossing over them
 
-### API Reference Pages
-- One endpoint per section
-- Include all parameters with types
-- Show request/response examples
-- Document error responses
-
-## Template: Feature Documentation
-
-```tsx
-export function [Feature]() {
-  return (
-    <DocsLayout>
-      <article className="prose prose-invert max-w-none">
-        <h1>[Feature Name]</h1>
-        
-        <p className="lead">
-          [One-sentence description of what this feature does]
-        </p>
-
-        <h2>Overview</h2>
-        <p>[2-3 paragraphs explaining the feature]</p>
-
-        <h2>Quick Start</h2>
-        <CodeBlock language="kotlin" code={`
-// Minimal example to get started
-`} />
-
-        <h2>Configuration</h2>
-        <ParamTable params={configParams} />
-
-        <h2>Examples</h2>
-        <h3>Basic Usage</h3>
-        <CodeBlock ... />
-        
-        <h3>Advanced Usage</h3>
-        <CodeBlock ... />
-
-        <h2>Best Practices</h2>
-        <ul>
-          <li>[Practice 1]</li>
-          <li>[Practice 2]</li>
-        </ul>
-      </article>
-    </DocsLayout>
-  );
-}
-```
+### API Reference (`endpoints.ts`)
+- One `EndpointGroup` per backend route file under `web/backend/routes/`
+- Set `auth` and `authNote` from what the controller actually checks, not a guess
+- Only mark `liveTestable: true` for public app-proxy endpoints the sandbox can
+  actually call
 
 ## Quality Checklist
 
 Before completing documentation:
 
-- [ ] All code examples compile/run without errors
-- [ ] Parameter tables include all required fields
-- [ ] Links to related pages work
-- [ ] Navigation updated if new page added
-- [ ] Consistent formatting with existing docs
+- [ ] Content matches the real source (routes, models, workflow YAML, extension code)
+- [ ] `docs/frontend && npm run build` passes (tsc + vite)
+- [ ] New data entries have a corresponding `navigation.ts` entry (and a new
+      `<Route>` in `App.tsx` if it's a new top-level section)
 - [ ] No placeholder text remaining
-- [ ] Spelling and grammar checked
+- [ ] Rendered the changed page(s) and confirmed they look right, not just that the
+      build passed
 
 ## Output Format
 
@@ -202,15 +147,16 @@ When completing a documentation task:
 ## Documentation Written: [Topic]
 
 ### Files Modified
-- `src/pages/[path]`: [Description]
-- `src/data/endpoints.ts`: [Changes]
+- `src/data/[file].ts`: [Changes]
 - `src/data/navigation.ts`: [Changes]
+- `src/pages/[Page].tsx`: [Changes, if any hand-written markup was touched]
 
 ### Content Summary
 [Brief overview of what was documented]
 
-### Code Examples Included
-- [Language]: [Description]
+### Verification
+- [ ] Build passes
+- [ ] Rendered page checked
 
 ### Review Notes
 [Any areas that may need user review or additional input]


### PR DESCRIPTION
## Problem

`.agents/agents/busybuddy-api-spec-generator.md` and `.agents/agents/busybuddy-docs-writer.md` were verbatim copy-pastes of OrderMate's agent docs (Kotlin/Retrofit references, `docs-site/` paths) - the same bug already fixed in `busybuddy-docs-pipeline.md`, `busybuddy-docs-agent.md`, and `busybuddy-site-deployer.md` in the previous PR (#232).

## Solution

Rewrote both to describe BusyBuddy_v2's real Express backend (`web/backend/routes/*`) and the actual `docs/frontend` data-driven page structure (`apps.ts`/`features.ts`/`workflows.ts`/`endpoints.ts` + `navigation.ts`), matching the pattern used for the other agent docs already fixed.

## Test Plan

- Docs-only change (agent instruction files), not part of the rendered docs site build - no build/runtime impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BxPh9C7z6fKHqN3tZwkzuW)_