### PR TITLE
Point dev-pipeline caller at pipeline-orchestrator's reusable workflow

### DIFF
--- a/.github/workflows/dev-pipeline.yml
+++ b/.github/workflows/dev-pipeline.yml
@@ -7,15 +7,21 @@ on:
     types: [created]
   repository_dispatch:
     types: [agent-trigger]
-
 jobs:
   dispatch:
+    # Reusable-workflow permissions are the intersection of what this caller job
+    # grants and what dev-pipeline-reusable.yml's own jobs request — id-token: write
+    # must be granted here too, or the callee's own id-token: write (needed by
+    # anthropics/claude-code-action@v1's OIDC request) has no effect.
     permissions:
       contents: read
       packages: read
       id-token: write
-    uses: HeyItsChloe/agent-ops/.github/workflows/dev-pipeline-reusable.yml@main
+    uses: HeyItsChloe/pipeline-orchestrator/.github/workflows/dev-pipeline-reusable.yml@main
     with:
+      skills_repo_owner: HeyItsChloe
+      skills_repo_name: agent-ops
+      skills_repo_branch: main
       project_language: typescript
       test_command: "npm test -- --coverage"
       coverage_type: cobertura
@@ -29,8 +35,4 @@ jobs:
           (contains(github.event.comment.body, '@dev-agent implement') && 'implement') ||
           github.event.client_payload.action
         }}
-    secrets:
-      LITELLM_PROXY_URL: ${{ secrets.LITELLM_PROXY_URL }}
-      LITELLM_VIRTUAL_KEY: ${{ secrets.LITELLM_VIRTUAL_KEY }}
-      GH_APP_ID: ${{ secrets.GH_APP_ID }}
-      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+    secrets: inherit


### PR DESCRIPTION
## Problem

The dev-ticket-pipeline engine that used to live in `HeyItsChloe/agent-ops/orchestrator` was extracted into a new public, self-hosted repo, `HeyItsChloe/pipeline-orchestrator`, and generalized to work with any registered pipeline (not hardcoded to this one). Its reusable GitHub Actions workflow (`dev-pipeline-reusable.yml`) moved with it, and now takes new required inputs since it no longer assumes `agent-ops` as its skills source.

`BusyBuddy_v2`'s caller workflow (`.github/workflows/dev-pipeline.yml`) was never updated to match. Until now, labeling an issue `approach-ready`/`approved` or commenting `@dev-agent plan`/`@dev-agent implement` on this repo would fail at trigger time - it would try to call a reusable workflow at a location that no longer has it, and/or fail GitHub Actions' input validation.

## Solution

- `uses:` now points at `HeyItsChloe/pipeline-orchestrator/.github/workflows/dev-pipeline-reusable.yml@main` instead of `agent-ops`.
- Added the three new required inputs (`skills_repo_owner`, `skills_repo_name`, `skills_repo_branch`) telling the reusable workflow where to fetch skills from, since it no longer hardcodes `agent-ops` internally.
- Switched to `secrets: inherit`, matching the reusable workflow's new contract (previously enumerated `LITELLM_PROXY_URL`/`LITELLM_VIRTUAL_KEY`/`GH_APP_ID`/`GH_APP_PRIVATE_KEY` individually).
- Confirmed the pre-existing `skill_folder` input problem (removed from the reusable workflow earlier, since skills are now matched by `applies_to` tag) was **not** present in this repo's file already - nothing to remove there.

## Test Plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Trigger a real run (comment `@dev-agent plan` on a test issue, or apply the `approach-ready` label) and confirm the Actions run resolves `HeyItsChloe/pipeline-orchestrator/.github/workflows/dev-pipeline-reusable.yml@main` without a "workflow not found" or input-validation error
- [ ] Confirm the run's skill-checkout step pulls from `HeyItsChloe/agent-ops` and finds `skills/shared/dev/project-conventions/SKILL.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BxPh9C7z6fKHqN3tZwkzuW)_