### PR TITLE
Pass dev-pipeline secrets explicitly instead of secrets: inherit

### DIFF
--- a/.github/workflows/dev-pipeline.yml
+++ b/.github/workflows/dev-pipeline.yml
@@ -35,4 +35,8 @@ jobs:
           (contains(github.event.comment.body, '@dev-agent implement') && 'implement') ||
           github.event.client_payload.action
         }}
-    secrets: inherit
+    secrets:
+      LITELLM_PROXY_URL: ${{ secrets.LITELLM_PROXY_URL }}
+      LITELLM_VIRTUAL_KEY: ${{ secrets.LITELLM_VIRTUAL_KEY }}
+      GH_APP_ID: ${{ secrets.GH_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

Live-testing #234's fix (commenting `@dev-agent plan` on a test issue, #235) showed the `dev-pipeline` run failing instantly - zero logs, no runner ever assigned. That's the signature of GitHub Actions rejecting a reusable-workflow call before any job starts, most consistent with a required secret not resolving at call time.

## Solution

Fetched `HeyItsChloe/pipeline-orchestrator/.github/workflows/dev-pipeline-reusable.yml`'s actual `on.workflow_call` contract directly to check it against what #234 provides:

- Every input name/type/required-ness matches exactly (including `desired_coverage` as `number`, `action` as `string`) - not the problem.
- `on.workflow_call.secrets` requires `LITELLM_PROXY_URL`, `LITELLM_VIRTUAL_KEY`, `GH_APP_ID`, `GH_APP_PRIVATE_KEY` - the same four secrets the pre-migration file passed explicitly (and which worked, per this repo's prior successful `dev-pipeline` runs).

#234 switched from that explicit passthrough to `secrets: inherit`, which is the one behavioral difference left unaccounted for. Reverting to explicit passing removes that variable - it's a strict superset of what `inherit` would do here, and it's the exact form already proven to work for this repo against the same secret names.

## Test Plan

- [x] YAML syntax validated
- [ ] Re-trigger the pipeline on issue #235 (`@dev-agent plan`) and confirm the run actually starts a runner and produces logs this time, rather than failing instantly
- [ ] Confirm the skill-checkout step pulls from `HeyItsChloe/agent-ops` and finds `skills/shared/dev/project-conventions/SKILL.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BxPh9C7z6fKHqN3tZwkzuW)_