### PR TITLE
Fix demo store seeder: avoid read_locations scope requirement

### DIFF
--- a/scripts/seed-demo-store/seed.mjs
+++ b/scripts/seed-demo-store/seed.mjs
@@ -116,7 +116,7 @@ const PRODUCT_SET_MUTATION = `
 const LOCATIONS_QUERY = `
   {
     locations(first: 1) {
-      nodes { id name }
+      nodes { id }
     }
   }
 `;
@@ -142,7 +142,7 @@ async function main() {
   const { locations } = await shopifyGraphql(LOCATIONS_QUERY);
   const locationId = locations.nodes[0]?.id;
   if (!locationId) throw new Error("No fulfillment location found on this store.");
-  console.log(`Using location: ${locations.nodes[0].name} (${locationId})`);
+  console.log(`Using location: ${locationId}`);
 
   for (const product of products) {
     const imageUrls = images[product.handle] || [];


### PR DESCRIPTION
## Problem

Closes #

The first live run of the seed workflow (#237) failed with an `ACCESS_DENIED` GraphQL error requesting the fulfillment location's `name` field, which requires a `read_locations` scope the custom app wasn't granted.

## Solution

Drop the unused `name` field from the locations query — only the location `id` is actually needed to target inventory.

## Test Results

N/A — standalone tooling, no app-code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_