### PR TITLE
Fix productSet variant/optionValues schema and CI exit code

### DIFF
--- a/scripts/seed-demo-store/seed.mjs
+++ b/scripts/seed-demo-store/seed.mjs
@@ -144,6 +144,8 @@ async function main() {
   if (!locationId) throw new Error("No fulfillment location found on this store.");
   console.log(`Using location: ${locationId}`);
 
+  let failureCount = 0;
+
   for (const product of products) {
     const imageUrls = images[product.handle] || [];
     if (imageUrls.length === 0) {
@@ -162,8 +164,15 @@ async function main() {
         originalSource: url,
         contentType: "IMAGE",
       })),
+      productOptions: [
+        {
+          name: "Title",
+          values: [{ name: "Default Title" }],
+        },
+      ],
       variants: [
         {
+          optionValues: [{ optionName: "Title", name: "Default Title" }],
           price: product.price,
           inventoryPolicy: "DENY",
           inventoryQuantities: [
@@ -182,15 +191,21 @@ async function main() {
       const errors = data.productSet.userErrors;
       if (errors.length > 0) {
         console.error(`❌ ${product.title}:`, errors);
+        failureCount++;
         continue;
       }
       console.log(`✅ ${product.title} -> ${data.productSet.product.handle}`);
     } catch (err) {
       console.error(`❌ ${product.title} failed:`, err.message);
+      failureCount++;
     }
   }
 
   console.log("\nDone. Review the storefront to confirm images and inventory.");
+  if (failureCount > 0) {
+    console.error(`${failureCount} of ${products.length} products failed.`);
+    process.exitCode = 1;
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Problem

Closes #

Run #3 of the seed workflow reported success but created zero products — every one of the 25 `productSet` calls failed with `Variable $input of type ProductSetInput! was provided invalid value for variants.0.optionValues (Expected value to not be null)`, and the script swallowed the per-product failures without failing the job.

## Solution

- Add an explicit `productOptions` ("Title" / "Default Title") to the input and reference it via `optionValues` on the variant, matching what `productSet` now requires even for a single default variant.
- Track a `failureCount` across the loop and set `process.exitCode = 1` if any product failed, so a fully-failed run shows red in Actions instead of green.

## Test Results

N/A — standalone tooling, no app-code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_