### PR TITLE
Make seed script idempotent via productByHandle lookup

### DIFF
--- a/scripts/seed-demo-store/seed.mjs
+++ b/scripts/seed-demo-store/seed.mjs
@@ -121,6 +121,12 @@ const LOCATIONS_QUERY = `
   }
 `;
 
+const PRODUCT_BY_HANDLE_QUERY = `
+  query productByHandle($handle: String!) {
+    productByHandle(handle: $handle) { id }
+  }
+`;
+
 const PUBLICATIONS_QUERY = `
   {
     publications(first: 20) {
@@ -170,7 +176,12 @@ async function main() {
       console.warn(`⚠️  No images configured for "${product.title}" — skipping images.`);
     }
 
+    const { productByHandle } = await shopifyGraphql(PRODUCT_BY_HANDLE_QUERY, {
+      handle: product.handle,
+    });
+
     const input = {
+      ...(productByHandle ? { id: productByHandle.id } : {}),
       title: product.title,
       handle: product.handle,
       descriptionHtml: `<p>${product.description}</p>`,


### PR DESCRIPTION
## Problem

Closes #

Run #7 (after the publications-scope fix landed) failed all 25 products with "Handle already in use" — the products already exist from run #4, and `productSet` without an `id` always attempts to create a new product.

## Solution

Query `productByHandle` before building the mutation input and pass the existing product's `id` when found, so the script is a true upsert and safe to re-run (which matters since we're about to re-run it again just to pick up the new publish step).

## Test Results

N/A — standalone tooling, no app-code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_