### PR TITLE
Fetch demo store images via official Unsplash API

### DIFF
--- a/.github/workflows/fetch-demo-images.yml
+++ b/.github/workflows/fetch-demo-images.yml
@@ -1,0 +1,30 @@
+name: Fetch Demo Store Images (Unsplash API)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Fetch images via Unsplash API
+        run: node scripts/seed-demo-store/fetch-images.mjs
+        env:
+          UNSPLASH_ACCESS_KEY: ${{ secrets.UNSPLASH_ACCESS_KEY }}
+
+      - name: Commit updated images.json
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add scripts/seed-demo-store/images.json
+          git diff --staged --quiet || git commit -m "Update demo store image URLs via Unsplash API"
+          git push

--- a/scripts/seed-demo-store/fetch-images.mjs
+++ b/scripts/seed-demo-store/fetch-images.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Uses the official Unsplash Search Photos API (not scraping) to find one
+// image per product and writes the verified URLs into images.json.
+//
+// Requires UNSPLASH_ACCESS_KEY env var.
+//
+// Usage: node scripts/seed-demo-store/fetch-images.mjs
+
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const ACCESS_KEY = process.env.UNSPLASH_ACCESS_KEY;
+if (!ACCESS_KEY) {
+  console.error("Missing UNSPLASH_ACCESS_KEY environment variable.");
+  process.exit(1);
+}
+
+// Generic/category search terms - avoids searching brand names directly so
+// results skew toward generic product photography rather than official shots.
+const QUERIES = {
+  "vintage-macintosh-laptop": "vintage laptop computer",
+  "imac-g3": "colorful retro desktop computer",
+  "original-ipod": "silver mp3 player",
+  "ipod-mini": "portable music player clip",
+  "ipod-classic": "handheld music player",
+  "ipod-nano": "small clip music player",
+  "iphone-2g": "black touchscreen smartphone",
+  "iphone-3gs": "black smartphone",
+  "motorola-razr": "silver flip phone",
+  "nokia-3310": "retro mobile phone",
+  "sony-walkman": "cassette player headphones",
+  "sony-discman": "portable cd player",
+  "tamagotchi": "digital pet toy keychain",
+  "nintendo-game-boy": "handheld game console grey",
+  "game-boy-color": "colorful handheld game console",
+  "nintendo-ds": "dual screen handheld console",
+  "palm-pilot": "pda organizer stylus",
+  "blackberry-bold": "smartphone physical keyboard",
+  "blackberry-curve": "smartphone qwerty keyboard",
+  "sony-psp": "handheld gaming console widescreen",
+  "sega-game-gear": "retro handheld game console",
+  "flip-video-camera": "pocket video camera",
+  "minidv-camcorder": "camcorder flip screen",
+  "crt-television": "old crt television",
+  "polaroid-instant-camera": "instant film camera",
+};
+
+async function searchOne(handle, query) {
+  const url = `https://api.unsplash.com/search/photos?query=${encodeURIComponent(query)}&per_page=1&content_filter=high`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Client-ID ${ACCESS_KEY}` },
+  });
+  if (!res.ok) {
+    console.error(`${handle}: HTTP ${res.status} - ${await res.text()}`);
+    return null;
+  }
+  const json = await res.json();
+  const first = json.results?.[0];
+  if (!first) {
+    console.warn(`${handle}: no results for "${query}"`);
+    return null;
+  }
+  console.log(`${handle}: ${first.urls.regular}`);
+  return first.urls.regular;
+}
+
+async function main() {
+  const imagesPath = path.join(__dirname, "images.json");
+  const images = JSON.parse(await readFile(imagesPath, "utf-8"));
+
+  for (const [handle, query] of Object.entries(QUERIES)) {
+    const url = await searchOne(handle, query);
+    images[handle] = url ? [url] : [];
+    // Unsplash rate limit is generous for search but be polite anyway.
+    await new Promise((r) => setTimeout(r, 250));
+  }
+
+  await writeFile(imagesPath, JSON.stringify(images, null, 2) + "\n");
+  console.log("\nUpdated images.json");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

Closes #

Scraping Unsplash HTML pages from GitHub Actions got 401'd on every request regardless of headers used - Unsplash blocks the runner IP range as a bot source. That approach is a dead end.

## Solution

Use the official Unsplash Search Photos API (`/search/photos`) with a free `UNSPLASH_ACCESS_KEY`, searching a generic (non-brand) query per product and taking the top verified result URL. The workflow commits the updated `images.json` back to the branch in the same run.

## Test Results

N/A — tooling only, no app-code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_