### PR TITLE
Crop demo store images to uniform Shopify-recommended size

### DIFF
--- a/scripts/seed-demo-store/fetch-images.mjs
+++ b/scripts/seed-demo-store/fetch-images.mjs
@@ -63,8 +63,18 @@ async function searchOne(handle, query) {
     console.warn(`${handle}: no results for "${query}"`);
     return null;
   }
-  console.log(`${handle}: ${first.urls.regular}`);
-  return first.urls.regular;
+
+  // Build a uniform square crop (Shopify's recommended product image size)
+  // from the raw asset instead of Unsplash's default arbitrary-aspect thumbnail.
+  const squareUrl = new URL(first.urls.raw);
+  squareUrl.searchParams.set("fit", "crop");
+  squareUrl.searchParams.set("crop", "entropy");
+  squareUrl.searchParams.set("w", "2048");
+  squareUrl.searchParams.set("h", "2048");
+  squareUrl.searchParams.set("q", "80");
+
+  console.log(`${handle}: ${squareUrl.toString()}`);
+  return squareUrl.toString();
 }
 
 async function main() {


### PR DESCRIPTION
## Problem

Closes #

All 24 sourced images are `READY` on the storefront now, but each came from Unsplash's default `urls.regular`, which preserves the original photo's aspect ratio — so featured images vary in size/shape across products.

## Solution

Build each image URL from `urls.raw` with explicit `fit=crop&crop=entropy&w=2048&h=2048` params instead of the API's canned `regular` size, producing a uniform square crop at 2048x2048 — Shopify's recommended product image size.

## Test Results

N/A — tooling only, no app-code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_