### PR TITLE
Add theme inspector for hero image editing

### DIFF
--- a/.github/workflows/inspect-demo-theme.yml
+++ b/.github/workflows/inspect-demo-theme.yml
@@ -1,0 +1,26 @@
+name: Inspect Demo Store Theme
+
+on:
+  workflow_dispatch:
+    inputs:
+      store_domain:
+        description: 'Target store domain'
+        required: true
+        default: 'daisys-electronics-9kihd5yl.myshopify.com'
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Inspect theme structure
+        run: node scripts/seed-demo-store/inspect-theme.mjs
+        env:
+          SHOPIFY_STORE_DOMAIN: ${{ inputs.store_domain }}
+          SHOPIFY_CLIENT_ID: ${{ secrets.SHOPIFY_DEMO_CLIENT_ID }}
+          SHOPIFY_CLIENT_SECRET: ${{ secrets.SHOPIFY_DEMO_CLIENT_SECRET }}

--- a/scripts/seed-demo-store/inspect-theme.mjs
+++ b/scripts/seed-demo-store/inspect-theme.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Diagnostic: finds the published theme, then prints the homepage template's
+// section structure so we can identify the hero/image-banner section's
+// settings key before attempting to edit it.
+//
+// Usage: node scripts/seed-demo-store/inspect-theme.mjs
+
+const STORE_DOMAIN = process.env.SHOPIFY_STORE_DOMAIN;
+const API_VERSION = "2025-10";
+
+if (!STORE_DOMAIN) {
+  console.error("Missing SHOPIFY_STORE_DOMAIN environment variable.");
+  process.exit(1);
+}
+
+async function getAccessToken() {
+  if (process.env.SHOPIFY_ADMIN_TOKEN) {
+    return process.env.SHOPIFY_ADMIN_TOKEN;
+  }
+  const clientId = process.env.SHOPIFY_CLIENT_ID;
+  const clientSecret = process.env.SHOPIFY_CLIENT_SECRET;
+  const res = await fetch(`https://${STORE_DOMAIN}/admin/oauth/access_token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+  const { access_token } = await res.json();
+  return access_token;
+}
+
+async function restGet(token, path) {
+  const res = await fetch(`https://${STORE_DOMAIN}/admin/api/${API_VERSION}/${path}`, {
+    headers: { "X-Shopify-Access-Token": token },
+  });
+  if (!res.ok) {
+    throw new Error(`GET ${path} -> HTTP ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const token = await getAccessToken();
+
+  const { themes } = await restGet(token, "themes.json");
+  const mainTheme = themes.find((t) => t.role === "main");
+  if (!mainTheme) throw new Error("No main/published theme found.");
+  console.log(`Main theme: ${mainTheme.name} (id=${mainTheme.id})`);
+
+  const { asset: indexTemplate } = await restGet(
+    token,
+    `themes/${mainTheme.id}/assets.json?asset[key]=templates/index.json`
+  );
+  console.log("\n--- templates/index.json ---");
+  console.log(indexTemplate.value);
+
+  const { asset: settingsData } = await restGet(
+    token,
+    `themes/${mainTheme.id}/assets.json?asset[key]=config/settings_data.json`
+  );
+  const settingsParsed = JSON.parse(settingsData.value);
+  const currentSections = settingsParsed.current?.sections || {};
+  const heroLike = Object.entries(currentSections).filter(([, s]) =>
+    /banner|hero|image/i.test(s.type || "")
+  );
+  console.log(`\n--- config/settings_data.json: ${Object.keys(currentSections).length} sections total, image/banner/hero-like: ---`);
+  console.log(JSON.stringify(Object.fromEntries(heroLike), null, 2));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

Closes #

Need to update the homepage hero banner image, which lives in theme JSON (templates/index.json + config/settings_data.json), not in product data. Editing that blind risks the same multi-round-trip guessing we hit with product images.

## Solution

Add `inspect-theme.mjs`, which finds the main theme, dumps `templates/index.json`, and filters `config/settings_data.json` sections for banner/hero/image-like types so we know the exact settings key before writing an update script.

## Approach

Requires `read_themes` scope on the custom app (new — will likely need the same reinstall/re-approve step as the earlier `read_locations`/`read_publications` additions).

## Test Results

N/A — diagnostic tooling only, no app-code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_