### PR TITLE
Retry on cold-start 502s from the app backend

### DIFF
--- a/busybuddy-demos/fixtures/app.js
+++ b/busybuddy-demos/fixtures/app.js
@@ -36,7 +36,7 @@ export const DASHBOARD_TILES = {
  * Playwright Frame supports the same locator/getByText/getByRole API as
  * Page, so every script below works unmodified against either.
  */
-async function resolveAppScope(page, timeoutMs = 30_000) {
+async function pollForAppScope(page, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   let lastError;
   while (Date.now() < deadline) {
@@ -51,8 +51,25 @@ async function resolveAppScope(page, timeoutMs = 30_000) {
     }
     await page.waitForTimeout(500);
   }
+  return { timedOut: true, lastError };
+}
+
+/**
+ * The app's backend occasionally 502s the embedded iframe on a cold start
+ * (a fresh container hasn't finished booting yet) - that response is
+ * static once loaded, so only a page reload gets a fresh attempt, not more
+ * polling. Retries a couple of full reloads before giving up.
+ */
+async function resolveAppScope(page, { attempts = 3, timeoutPerAttemptMs = 20_000 } = {}) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const result = await pollForAppScope(page, timeoutPerAttemptMs);
+    if (result && !result.timedOut) return result;
+    lastError = result?.lastError;
+    if (attempt < attempts) await page.reload();
+  }
   throw new Error(
-    `Timed out waiting for the BusyBuddy dashboard ('.widget-tile') in the top-level page or any iframe.${lastError ? ` Last error: ${lastError.message}` : ''}`
+    `Timed out waiting for the BusyBuddy dashboard ('.widget-tile') in the top-level page or any iframe after ${attempts} attempts (page reloaded between each - likely a cold-start 502 from the app backend if this persists).${lastError ? ` Last error: ${lastError.message}` : ''}`
   );
 }
 

--- a/busybuddy-demos/playwright.config.js
+++ b/busybuddy-demos/playwright.config.js
@@ -28,7 +28,9 @@ export default defineConfig({
   // descriptive filenames after the run finishes.
   outputDir: './.raw-output',
   reporter: [['list'], ['./fixtures/organize-reporter.js']],
-  timeout: 60_000,
+  // Generous headroom: resolveAppScope (fixtures/app.js) alone can take up
+  // to ~60s across its reload-retry attempts on a cold-start backend.
+  timeout: 120_000,
   fullyParallel: false,
   workers: 1,
   retries: 0,


### PR DESCRIPTION
## Problem

After the iframe-detection fix (#253), the same diagnostic spec got past that issue but hit a new one: the app iframe rendered a static "502 Bad Gateway / nginx" page instead of the dashboard - the BusyBuddy backend hadn't finished a cold start yet. That page doesn't change without a reload, so the fixture's polling loop just timed out waiting on a page that was never going to update.

## Solution

`resolveAppScope` now retries up to 3 full `page.reload()` attempts (20s poll each) before giving up, and the overall test timeout was bumped to 120s to give that retry budget room.

## Test Results

N/A - fixture-only change, being validated by re-running the same diagnostic spec.

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_