### PR TITLE
Disambiguate strict-mode violations in sidepane/tier-preset clicks

### DIFF
--- a/busybuddy-demos/fixtures/app.js
+++ b/busybuddy-demos/fixtures/app.js
@@ -119,9 +119,15 @@ export async function gotoStorefrontProduct(page, handle) {
   await page.goto(`https://${STORE_DOMAIN}/products/${handle}`);
 }
 
-/** Editor sidepane items (components/Editor/EditorSidepane.jsx) open a config panel by label. */
+/**
+ * Editor sidepane items (components/Editor/EditorSidepane.jsx) open a
+ * config panel by label. The same label text can also appear in the
+ * config panel's own heading once selected, so .first() (the sidepane nav
+ * item, which renders above the panel) disambiguates the strict-mode
+ * violation rather than picking an arbitrary match.
+ */
 export async function clickSidepaneItem(popup, label) {
-  await popup.getByText(label, { exact: true }).click();
+  await popup.getByText(label, { exact: true }).first().click();
 }
 
 /** Fills the first visible text input/textarea in the current config panel. */

--- a/busybuddy-demos/scripts/mix-and-match/07-tier-preset-switching.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/07-tier-preset-switching.spec.js
@@ -5,9 +5,9 @@ test('Mix and Match: switch across all Buy 2/3/4/5 tier presets', async ({ page,
     dashboardTile(app, 'Mix & Match').getByRole('button', { name: /create/i }).click()
   );
 
-  await popup.getByText('Tier Settings', { exact: true }).click();
+  await popup.getByText('Tier Settings', { exact: true }).first().click();
   for (const tier of ['Buy 2', 'Buy 3', 'Buy 4', 'Buy 5']) {
-    await popup.getByText(tier, { exact: true }).click();
-    await expect(popup.getByText(tier, { exact: true })).toBeVisible();
+    await popup.getByText(tier, { exact: true }).first().click();
+    await expect(popup.getByText(tier, { exact: true }).first()).toBeVisible();
   }
 });


### PR DESCRIPTION
## Problem

First full-suite run against the live store: 17/40 passed, with real videos/traces/screenshots committed to `busybuddy-demos/`. Of the 23 failures, several were `strict mode violation: getByText(...) resolved to 2 elements` for sidepane item labels (e.g. "Select Products") and tier-preset labels (e.g. "Buy 2") - the label text also appears in the config panel's own heading once that item is selected.

## Solution

`.first()` on those locators to consistently pick the sidepane/preset nav item.

## Test Results

N/A - being validated against the live store, not local/CI unit tests.

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_