### PR TITLE
Wait for the subscription fetch before clicking Create/Manage

### DIFF
--- a/busybuddy-demos/fixtures/app.js
+++ b/busybuddy-demos/fixtures/app.js
@@ -73,13 +73,31 @@ async function resolveAppScope(page, { attempts = 3, timeoutPerAttemptMs = 20_00
   );
 }
 
+/**
+ * DashboardHome.jsx renders widget tiles immediately (before the plan is
+ * known) and only gates Create/Manage clicks once its subscription fetch
+ * resolves - `if (!loading && !isWidgetAccessible(...))`. A fast Playwright
+ * click can land in that window and either race past the gate (landing in
+ * a real editor while still notionally on the stale/default plan) or get
+ * redirected to /plan with no explanation. Waiting for the subscription
+ * response here makes every script's Create/Manage click deterministic.
+ */
+async function waitForSubscriptionLoaded(subscriptionResponsePromise) {
+  await subscriptionResponsePromise; // best-effort; falls back to proceeding if it never fires (see .catch below)
+}
+
 export const test = base.extend({
   app: async ({ page }, use) => {
     if (!ADMIN_URL) {
       throw new Error('BUSYBUDDY_ADMIN_URL is not set - see busybuddy-demos/README.md');
     }
+    const subscriptionResponsePromise = page
+      .waitForResponse((res) => res.url().includes('/api/subscription/getUserSubscription'), { timeout: 20_000 })
+      .catch(() => null);
     await page.goto(ADMIN_URL);
-    await use(await resolveAppScope(page));
+    const scope = await resolveAppScope(page);
+    await waitForSubscriptionLoaded(subscriptionResponsePromise);
+    await use(scope);
   },
 });
 


### PR DESCRIPTION
## Problem

Investigating the full-suite run's failures surfaced a real bug in test determinism: `DashboardHome.jsx` renders widget tiles immediately (default "Free" state) and only enforces its plan gate once an async subscription fetch resolves - `if (!loading && !isWidgetAccessible(widget.id))`. A fast Playwright click on Create/Manage can land in that window before the gate is armed, producing nondeterministic results independent of the store's actual plan or of any selector correctness: sometimes racing into the real editor, sometimes getting silently redirected to `/plan` with no popup ever opening (explains the `waiting for event "popup"` timeouts seen in the first full run).

Separately, Daisy's Electronics has now been manually upgraded to the Advanced plan, which unlocks the 4 discount apps this test suite depends on (previously Free-tier, which fully blocked them).

## Solution

The `app` fixture now waits for the `/api/subscription/getUserSubscription` response to resolve before handing control to any script, so every Create/Manage click happens after the plan gate has actually settled.

## Test Results

N/A - being validated against the live store next via a single diagnostic spec.

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_