### PR TITLE
Fix product-picker and tier-selector selectors from real source

### DIFF
--- a/busybuddy-demos/fixtures/app.js
+++ b/busybuddy-demos/fixtures/app.js
@@ -153,3 +153,44 @@ export async function fillActiveConfigField(popup, value) {
   const field = popup.locator('.config-panel textarea, .config-panel input[type="text"]').first();
   await field.fill(value);
 }
+
+/**
+ * Adds a product from the inline "Select Products" picker shared by
+ * StandardBundleEditor.jsx, VolumeDiscountEditor.jsx, and
+ * MixAndMatchEditor.jsx: a "+ Add Products" button reveals a search field
+ * (placeholder "Search by product name...") and a filtered list, each row
+ * with its own "+ Add" button. BOGO's BuyXGetYEditor.jsx does not use this
+ * pattern - see addProductToPool below.
+ */
+export async function addProductViaPicker(popup, productName) {
+  const addProductsButton = popup.getByRole('button', { name: '+ Add Products' });
+  if (await addProductsButton.isVisible().catch(() => false)) {
+    await addProductsButton.click();
+  }
+  await popup.getByPlaceholder('Search by product name...').fill(productName);
+  await popup.getByRole('button', { name: '+ Add', exact: true }).first().click();
+}
+
+/**
+ * BOGO's BuyXGetYEditor.jsx renders its X/Y product pools as directly
+ * clickable rows (onClick={() => addProductToX(product)}) with an inline
+ * "Search products..." field - no separate "+ Add Products" toggle.
+ */
+export async function addProductToPool(popup, productName) {
+  await popup.getByPlaceholder('Search products...').fill(productName);
+  await popup.getByText(productName, { exact: false }).first().click();
+}
+
+/**
+ * Selects an option from a ConfigSelect (components/Editor/EditorConfigPanel.jsx)
+ * by the visible label of its enclosing ConfigFormGroup, e.g. selecting
+ * "Percentage" under "Discount Type" before the percentage/amount input
+ * renders (that field is conditionally shown only once a type is chosen).
+ */
+export async function selectConfigOption(popup, groupLabel, optionLabel) {
+  await popup
+    .locator('.form-group')
+    .filter({ has: popup.locator('.form-label', { hasText: groupLabel }) })
+    .locator('select')
+    .selectOption({ label: optionLabel });
+}

--- a/busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, selectConfigOption } from '../../fixtures/app.js';
 
 test('Bundle Discounts: create a bundle from 2 seeded products', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
@@ -6,12 +6,11 @@ test('Bundle Discounts: create a bundle from 2 seeded products', async ({ page, 
   );
 
   await clickSidepaneItem(popup, 'Select Products');
-  await popup.getByPlaceholder('Search products...').fill('Game Boy');
-  await popup.getByText('Nintendo Game Boy', { exact: false }).first().click();
-  await popup.getByPlaceholder('Search products...').fill('Game Boy Color');
-  await popup.getByText('Game Boy Color', { exact: false }).first().click();
+  await addProductViaPicker(popup, 'Game Boy');
+  await addProductViaPicker(popup, 'Game Boy Color');
 
   await clickSidepaneItem(popup, 'Discount Settings');
+  await selectConfigOption(popup, 'Discount Type', 'Percentage');
   await popup.getByPlaceholder(/e\.g\., 20/).fill('15');
 
   await saveEditor(popup);

--- a/busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js
@@ -1,18 +1,22 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductToPool, selectConfigOption } from '../../fixtures/app.js';
 
 test('BOGO: create a Buy X Get Y offer', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /create/i }).click()
   );
 
-  await clickSidepaneItem(popup, 'Select Products');
-  const searchInputs = popup.getByPlaceholder('Search products...');
-  await searchInputs.first().fill('Sony Walkman');
-  await popup.getByText('Sony Walkman', { exact: false }).first().click();
-  await searchInputs.last().fill('Polaroid');
-  await popup.getByText('Polaroid', { exact: false }).first().click();
+  // BOGO's sidepane doesn't have a "Select Products" item - it splits
+  // into "Customer Buys (X)" and "Customer Gets (Y)" (BuyXGetYEditor.jsx).
+  await clickSidepaneItem(popup, 'Customer Buys (X)');
+  await addProductToPool(popup, 'Sony Walkman');
+
+  await clickSidepaneItem(popup, 'Customer Gets (Y)');
+  await addProductToPool(popup, 'Polaroid');
 
   await clickSidepaneItem(popup, 'Discount Settings');
+  // BOGO's own DISCOUNT_TYPE_OPTIONS label differs from the other 3 apps'
+  // plain "Percentage" - it's "Percentage Discount" here.
+  await selectConfigOption(popup, 'Discount Type', 'Percentage Discount');
   await popup.getByPlaceholder(/e\.g\., 20/).fill('50');
 
   await saveEditor(popup);

--- a/busybuddy-demos/scripts/buy-one-get-one/07-xy-pool-toggle.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/07-xy-pool-toggle.spec.js
@@ -5,9 +5,9 @@ test('BOGO: toggle between the X (buy) and Y (get) product pools', async ({ page
     dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /create/i }).click()
   );
 
-  await clickSidepaneItem(popup, 'Select Products');
-  await expect(popup.getByPlaceholder('Search products...').first()).toBeVisible();
+  await clickSidepaneItem(popup, 'Customer Buys (X)');
+  await expect(popup.getByPlaceholder('Search products...')).toBeVisible();
 
-  await popup.getByText(/^X$|Buy Product/i).first().click().catch(() => {});
-  await popup.getByText(/^Y$|Get Product/i).first().click().catch(() => {});
+  await clickSidepaneItem(popup, 'Customer Gets (Y)');
+  await expect(popup.getByPlaceholder('Search products...')).toBeVisible();
 });

--- a/busybuddy-demos/scripts/mix-and-match/02-create-offer.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/02-create-offer.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker } from '../../fixtures/app.js';
 
 test('Mix and Match: create an offer with a Buy 3 tier preset', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
@@ -6,11 +6,13 @@ test('Mix and Match: create an offer with a Buy 3 tier preset', async ({ page, a
   );
 
   await clickSidepaneItem(popup, 'Select Products');
-  await popup.getByPlaceholder('Search products...').fill('Cassette');
-  await popup.getByText('Cassette', { exact: false }).first().click();
+  await addProductViaPicker(popup, 'Cassette');
 
-  await popup.getByText('Tier Settings', { exact: true }).click();
-  await popup.getByText('Buy 3', { exact: true }).click();
+  await clickSidepaneItem(popup, 'Tier Settings');
+  // "Buy 3" also appears as a plain (non-interactive) form-group label in
+  // the Tier Settings panel itself - the real, clickable tier selector is
+  // a <button> in the live preview pane, so scope by role to land on it.
+  await popup.getByRole('button', { name: 'Buy 3' }).click();
 
   await saveEditor(popup);
   await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });

--- a/busybuddy-demos/scripts/mix-and-match/03-edit-offer.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/03-edit-offer.spec.js
@@ -11,8 +11,10 @@ test('Mix and Match: switch tier preset and change a tier discount', async ({ pa
     firstOffer.locator('..').locator('..').getByRole('button').first().click()
   );
 
-  await popup.getByText('Tier Settings', { exact: true }).click();
-  await popup.getByText('Buy 4', { exact: true }).click();
+  await popup.getByText('Tier Settings', { exact: true }).first().click();
+  // The clickable tier selector is a <button> in the live preview pane;
+  // "Buy 4" also appears as a plain label in the Tier Settings panel.
+  await popup.getByRole('button', { name: 'Buy 4' }).click();
 
   await saveEditor(popup);
 });

--- a/busybuddy-demos/scripts/mix-and-match/07-tier-preset-switching.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/07-tier-preset-switching.spec.js
@@ -1,13 +1,19 @@
-import { test, expect, dashboardTile, openEditorPopup } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, clickSidepaneItem, addProductViaPicker } from '../../fixtures/app.js';
 
 test('Mix and Match: switch across all Buy 2/3/4/5 tier presets', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Mix & Match').getByRole('button', { name: /create/i }).click()
   );
 
-  await popup.getByText('Tier Settings', { exact: true }).first().click();
+  // The tier-selector buttons only render in the live preview once at
+  // least one product is selected (otherwise it shows a placeholder).
+  await clickSidepaneItem(popup, 'Select Products');
+  await addProductViaPicker(popup, 'Cassette');
+
+  await clickSidepaneItem(popup, 'Tier Settings');
   for (const tier of ['Buy 2', 'Buy 3', 'Buy 4', 'Buy 5']) {
-    await popup.getByText(tier, { exact: true }).first().click();
-    await expect(popup.getByText(tier, { exact: true }).first()).toBeVisible();
+    const tierButton = popup.getByRole('button', { name: tier });
+    await tierButton.click();
+    await expect(tierButton).toBeVisible();
   }
 });

--- a/busybuddy-demos/scripts/volume-discounts/02-create-volume-discount.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/02-create-volume-discount.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker } from '../../fixtures/app.js';
 
 test('Volume Discounts: create a discount with quantity-break tiers', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
@@ -6,10 +6,9 @@ test('Volume Discounts: create a discount with quantity-break tiers', async ({ p
   );
 
   await clickSidepaneItem(popup, 'Select Products');
-  await popup.getByPlaceholder('Search products...').fill('Discman');
-  await popup.getByText('Discman', { exact: false }).first().click();
+  await addProductViaPicker(popup, 'Discman');
 
-  await popup.getByText('Quantity Breaks', { exact: true }).click();
+  await clickSidepaneItem(popup, 'Quantity Breaks');
   await expect(popup.getByText(/buy 2, get 10% off/i)).toBeVisible();
 
   await saveEditor(popup);

--- a/busybuddy-demos/scripts/volume-discounts/03-edit-volume-discount.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/03-edit-volume-discount.spec.js
@@ -11,8 +11,15 @@ test('Volume Discounts: adjust a quantity-break threshold and percentage', async
     firstDiscount.locator('..').locator('..').getByRole('button').first().click()
   );
 
-  await popup.getByText('Quantity Breaks', { exact: true }).click();
-  const discountInput = popup.locator('input[type="number"]').first();
+  await popup.getByText('Quantity Breaks', { exact: true }).first().click();
+  // Each tier renders Quantity then Discount % side by side - scope by the
+  // form group's own label rather than input order, since the raw first
+  // number input on the page is the Quantity field, not Discount %.
+  const discountInput = popup
+    .locator('.form-group')
+    .filter({ has: popup.locator('.form-label', { hasText: 'Discount %' }) })
+    .locator('input')
+    .first();
   await discountInput.fill('25');
 
   await saveEditor(popup);

--- a/busybuddy-demos/scripts/volume-discounts/07-quantity-tier-editor.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/07-quantity-tier-editor.spec.js
@@ -5,14 +5,18 @@ test('Volume Discounts: add and remove a quantity-break tier', async ({ page, ap
     dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /create/i }).click()
   );
 
-  await popup.getByText('Quantity Breaks', { exact: true }).click();
-  const tierCountBefore = await popup.locator('[class*="quantity-break"], [class*="tier-row"]').count();
+  await popup.getByText('Quantity Breaks', { exact: true }).first().click();
+  // Tier rows are unstyled divs labeled "Tier N" (optionally "★Tier N" for
+  // the default tier) - count those rather than a nonexistent CSS class.
+  const tierLabel = popup.getByText(/Tier \d+/);
+  const tierCountBefore = await tierLabel.count();
 
-  await popup.getByRole('button', { name: /add.*tier|add.*break/i }).click();
+  await popup.getByRole('button', { name: '+ Add Another Quantity Break' }).click();
   await expect(async () => {
-    const tierCountAfter = await popup.locator('[class*="quantity-break"], [class*="tier-row"]').count();
-    expect(tierCountAfter).toBeGreaterThan(tierCountBefore);
+    expect(await tierLabel.count()).toBeGreaterThan(tierCountBefore);
   }).toPass({ timeout: 10_000 });
 
-  await popup.getByRole('button', { name: /remove|delete/i }).last().click();
+  // Each tier's remove control is a bare "✕" button, only rendered once
+  // there's more than one tier.
+  await popup.getByRole('button', { name: '✕', exact: true }).last().click();
 });


### PR DESCRIPTION
## Problem

The diagnostic run showed `bundle-discounts/02-create-bundle.spec.js` failing on `getByPlaceholder('Search products...')` - a guessed selector. Rather than guess again from another screenshot, read the actual editor components directly (`StandardBundleEditor.jsx`, `VolumeDiscountEditor.jsx`, `MixAndMatchEditor.jsx`, `BuyXGetYEditor.jsx`).

## Solution

- Bundle/Volume/Mix&Match share one product-picker pattern (a "+ Add Products" toggle button reveals a "Search by product name..." field and per-row "+ Add" buttons) - added `addProductViaPicker`.
- BOGO's X/Y pools are directly-clickable rows with an inline "Search products..." field, and no "Select Products" sidepane item at all - it's split into "Customer Buys (X)" / "Customer Gets (Y)" - added `addProductToPool` and fixed the sidepane labels.
- The discount percentage/amount field only renders once a Discount Type is explicitly selected from a `<select>` - added `selectConfigOption`. BOGO's own option label is "Percentage Discount", not the other three apps' "Percentage".
- Mix and Match's "Buy N" tier presets are real `<button>`s in the live preview pane (which only renders once a product is selected); the same text also appears as a non-interactive form-group heading elsewhere, so the earlier `.first()` fix was picking the wrong, non-functional element - now scoped by role instead.
- Volume Discounts' tier add/remove buttons now use their real accessible names instead of guessed regexes, and the discount-% edit targets the field by its own form-group label instead of input order.

## Test Results

N/A - being validated against the live store next via a batch of the edited specs.

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_