### PR TITLE
Fix standalone editor auth, journey comments, and list-verification checks

### DIFF
--- a/busybuddy-demos/fixtures/app.js
+++ b/busybuddy-demos/fixtures/app.js
@@ -108,6 +108,20 @@ export async function gotoTab(app, tabName) {
   await app.getByText(tabName, { exact: true }).click();
 }
 
+/**
+ * DiscountList/BundelDiscountList.jsx only refetches its items when
+ * `selectedTab` actually *changes* (its useEffect deps are
+ * [refreshTrigger, selectedTab]), so clicking a tab you're already on
+ * won't pick up something just saved in the editor popup. Bouncing
+ * through Overview first forces a real refetch before landing back on
+ * the list tab.
+ */
+export async function refreshAndVerifyInList(app, listTabName, textMatcher) {
+  await gotoTab(app, 'Overview');
+  await gotoTab(app, listTabName);
+  await expect(app.getByText(textMatcher)).toBeVisible({ timeout: 15_000 });
+}
+
 /** Scopes down to a single widget tile on the dashboard by its visible title. */
 export function dashboardTile(app, widgetTitle) {
   return app.locator('.widget-tile').filter({ hasText: widgetTitle });

--- a/busybuddy-demos/scripts/announcement-bar/01-tabs-navigation.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/01-tabs-navigation.spec.js
@@ -1,5 +1,8 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Announcement Bar app from the dashboard
+// 2. Click through each tab in turn: Overview, Announcement Bars, Settings, Analytics
+// 3. Confirm each tab actually loads
 test('Announcement Bar: navigate Overview -> Announcement Bars -> Settings -> Analytics', async ({ page, app }) => {
   await dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /manage/i }).click();
 
@@ -7,5 +10,6 @@ test('Announcement Bar: navigate Overview -> Announcement Bars -> Settings -> An
 
   for (const tab of ['Overview', 'Announcement Bars', 'Settings', 'Analytics']) {
     await gotoTab(app, tab);
+    await page.waitForTimeout(4000); // pacing so the recorded video shows each tab's content, not just a flash
   }
 });

--- a/busybuddy-demos/scripts/announcement-bar/02-create-bar.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/02-create-bar.spec.js
@@ -1,6 +1,12 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Announcement Bar tile - opens the standalone editor
+// 2. Set the message text to "New arrivals just dropped - 20% off today only!"
+// 3. Switch to the Appearance tab, open the Background color option
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the app, open the Announcement Bars list tab, confirm the new bar is in the list
 test('Announcement Bar: create a new bar from the dashboard', async ({ page, app }) => {
+  const message = 'New arrivals just dropped - 20% off today only!';
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /create/i }).click()
   );
@@ -8,11 +14,15 @@ test('Announcement Bar: create a new bar from the dashboard', async ({ page, app
   await expect(popup.getByText('Content', { exact: true })).toBeVisible();
 
   await clickSidepaneItem(popup, 'Message Text');
-  await fillActiveConfigField(popup, "New arrivals just dropped - 20% off today only!");
+  await fillActiveConfigField(popup, message);
 
   await popup.getByText('Appearance', { exact: true }).click();
   await clickSidepaneItem(popup, 'Background');
 
   await saveEditor(popup);
   await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /manage/i }).click();
+  await refreshAndVerifyInList(app, 'Announcement Bars', message);
 });

--- a/busybuddy-demos/scripts/announcement-bar/03-edit-bar.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/03-edit-bar.spec.js
@@ -1,6 +1,12 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Open the Announcement Bar app, go to the Announcement Bars list tab
+// 2. Open the first existing bar in the list
+// 3. Change its message to "Updated: Free shipping over $50!"
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the Announcement Bars list tab, confirm the updated message is there
 test('Announcement Bar: edit an existing bar', async ({ page, app }) => {
+  const updatedMessage = 'Updated: Free shipping over $50!';
   await dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Announcement Bars');
 
@@ -10,7 +16,11 @@ test('Announcement Bar: edit an existing bar', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () => firstRow.getByRole('button').first().click());
 
   await clickSidepaneItem(popup, 'Message Text');
-  await fillActiveConfigField(popup, 'Updated: Free shipping over $50!');
+  await fillActiveConfigField(popup, updatedMessage);
 
   await saveEditor(popup);
+  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await refreshAndVerifyInList(app, 'Announcement Bars', updatedMessage);
 });

--- a/busybuddy-demos/scripts/announcement-bar/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/04-storefront-live.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, gotoStorefrontHome } from '../../fixtures/app.js';
 
+// 1. Load the live Daisy's Electronics storefront homepage
+// 2. Confirm the announcement bar actually renders on the page
 test('Announcement Bar: renders live on the Daisy\'s Electronics storefront', async ({ page }) => {
   await gotoStorefrontHome(page);
   await expect(page.locator('#busybuddy-announcement-bar')).toBeVisible({ timeout: 15_000 });

--- a/busybuddy-demos/scripts/announcement-bar/05-analytics.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/05-analytics.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Announcement Bar app, go to the Analytics tab
+// 2. Confirm Total Views, Total Clicks, and Active Bars stats are visible
 test('Announcement Bar: Analytics tab shows stat cards and charts', async ({ page, app }) => {
   await dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Analytics');

--- a/busybuddy-demos/scripts/announcement-bar/06-settings.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/06-settings.spec.js
@@ -1,5 +1,8 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Announcement Bar app, go to the Settings tab
+// 2. Toggle the "Enable close button" checkbox
+// 3. Confirm the Email Integration section is visible
 test('Announcement Bar: toggle close button and view email integration settings', async ({ page, app }) => {
   await dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Settings');

--- a/busybuddy-demos/scripts/announcement-bar/07-timer-email-variant.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/07-timer-email-variant.spec.js
@@ -1,5 +1,10 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Announcement Bar tile
+// 2. Open the Countdown Timer option and turn it on
+// 3. Open the Email Form option (email-capture bar variant)
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the app, confirm the new bar (default "Summer Sale" text) is in the Announcement Bars list
 test('Announcement Bar: countdown timer and email-capture bar variants', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /create/i }).click()
@@ -13,4 +18,12 @@ test('Announcement Bar: countdown timer and email-capture bar variants', async (
   await expect(popup.getByText(/email form/i)).toBeVisible();
 
   await saveEditor(popup);
+  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  // No custom message is set in this variant - AnnouncementBarEditor.jsx's
+  // own default title/message ("Summer Sale Banner" / "Summer Sale") is
+  // what should show up in the list.
+  await dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /manage/i }).click();
+  await refreshAndVerifyInList(app, 'Announcement Bars', /summer sale/i);
 });

--- a/busybuddy-demos/scripts/bundle-discounts/01-tabs-navigation.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/01-tabs-navigation.spec.js
@@ -1,9 +1,13 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Bundle Discounts app from the dashboard
+// 2. Click through each tab in turn: Overview, Discounts, Settings, Analytics
+// 3. Confirm each tab actually loads
 test('Bundle Discounts: navigate Overview -> Discounts -> Settings -> Analytics', async ({ page, app }) => {
   await dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /manage/i }).click();
 
   for (const tab of ['Overview', 'Discounts', 'Settings', 'Analytics']) {
     await gotoTab(app, tab);
+    await page.waitForTimeout(4000); // pacing so the recorded video shows each tab's content, not just a flash
   }
 });

--- a/busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js
@@ -1,5 +1,10 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, selectConfigOption } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, selectConfigOption, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Bundle Discounts tile - opens the standalone editor
+// 2. Open "Select Products", add "Game Boy" and "Game Boy Color" via the product picker
+// 3. Go to Discount Settings, select "Percentage", enter 15
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the app, open the Discounts list tab, confirm the new bundle is in the list
 test('Bundle Discounts: create a bundle from 2 seeded products', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /create/i }).click()
@@ -15,4 +20,8 @@ test('Bundle Discounts: create a bundle from 2 seeded products', async ({ page, 
 
   await saveEditor(popup);
   await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /manage/i }).click();
+  await refreshAndVerifyInList(app, 'Discounts', /Game Boy/i);
 });

--- a/busybuddy-demos/scripts/bundle-discounts/03-edit-bundle.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/03-edit-bundle.spec.js
@@ -1,5 +1,10 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Open the Bundle Discounts app, go to the Discounts list tab
+// 2. Open the first existing bundle in the list
+// 3. Change its discount to 25%, then set a new message ("Now 25% off - Bundle and Save!")
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the Discounts list tab, confirm the bundle is still there
 test('Bundle Discounts: edit an existing bundle\'s discount and message', async ({ page, app }) => {
   await dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Discounts');
@@ -16,6 +21,15 @@ test('Bundle Discounts: edit an existing bundle\'s discount and message', async 
 
   await popup.getByText('Content', { exact: true }).click();
   await clickSidepaneItem(popup, 'Message Text');
+  await fillActiveConfigField(popup, 'Now 25% off - Bundle and Save!');
 
   await saveEditor(popup);
+  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  // The Discounts list row shows each bundle's product-title badges, not
+  // its message text (see BundelDiscountList.jsx), so verify presence via
+  // the product this bundle was created with rather than the message just
+  // set above.
+  await refreshAndVerifyInList(app, 'Discounts', /Game Boy/i);
 });

--- a/busybuddy-demos/scripts/bundle-discounts/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/04-storefront-live.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
 
+// 1. Load the Nintendo Game Boy product page on the live storefront
+// 2. Confirm the bundle widget renders on that page
 test('Bundle Discounts: bundle widget renders on a bundled product\'s page', async ({ page }) => {
   await gotoStorefrontProduct(page, 'nintendo-game-boy');
   await expect(page.locator('[id*="star_rating"], [class*="busybuddy-bundle"]').first()).toBeVisible({ timeout: 15_000 });

--- a/busybuddy-demos/scripts/bundle-discounts/05-analytics.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/05-analytics.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Bundle Discounts app, go to the Analytics tab
+// 2. Confirm Total Bundle Revenue, Orders with Bundles, and Top Bundles are visible
 test('Bundle Discounts: Analytics tab shows revenue, orders, and top bundles', async ({ page, app }) => {
   await dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Analytics');

--- a/busybuddy-demos/scripts/bundle-discounts/06-settings.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/06-settings.spec.js
@@ -1,5 +1,8 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Bundle Discounts app, go to the Settings tab
+// 2. Click the "Disabled" then "Enabled" radio for Smart Bundle Detection
+// 3. Confirm the Discount Combination section is visible
 test('Bundle Discounts: Smart Bundle Detection priority setting', async ({ page, app }) => {
   await dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Settings');

--- a/busybuddy-demos/scripts/bundle-discounts/07-timer-skip-offer-variant.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/07-timer-skip-offer-variant.spec.js
@@ -1,5 +1,9 @@
 import { test, expect, dashboardTile, openEditorPopup, clickSidepaneItem } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Bundle Discounts tile
+// 2. Open the Content tab, turn on the Countdown Timer option
+// 3. Open the Skip Offer Button option, set its label to "No thanks"
+// 4. Confirm the live preview panel is visible showing these variants
 test('Bundle Discounts: countdown timer + skip-offer button live preview', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /create/i }).click()

--- a/busybuddy-demos/scripts/buy-one-get-one/01-tabs-navigation.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/01-tabs-navigation.spec.js
@@ -1,9 +1,13 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Buy One Get One app from the dashboard
+// 2. Click through each tab in turn: Overview, Discounts, Settings, Analytics
+// 3. Confirm each tab actually loads
 test('BOGO: navigate Overview -> Discounts -> Settings -> Analytics', async ({ page, app }) => {
   await dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /manage/i }).click();
 
   for (const tab of ['Overview', 'Discounts', 'Settings', 'Analytics']) {
     await gotoTab(app, tab);
+    await page.waitForTimeout(4000); // pacing so the recorded video shows each tab's content, not just a flash
   }
 });

--- a/busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js
@@ -1,5 +1,11 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductToPool, selectConfigOption } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductToPool, selectConfigOption, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Buy One Get One tile - opens the standalone editor
+// 2. Open "Customer Buys (X)", add "Sony Walkman" to the buy-side pool
+// 3. Open "Customer Gets (Y)", add "Polaroid" to the get-side pool
+// 4. Go to Discount Settings, select "Percentage Discount", enter 50
+// 5. Click Save and wait for the save confirmation
+// 6. Go back to the app, open the Discounts list tab, confirm the new offer is in the list
 test('BOGO: create a Buy X Get Y offer', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /create/i }).click()
@@ -21,4 +27,8 @@ test('BOGO: create a Buy X Get Y offer', async ({ page, app }) => {
 
   await saveEditor(popup);
   await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /manage/i }).click();
+  await refreshAndVerifyInList(app, 'Discounts', /Sony Walkman/i);
 });

--- a/busybuddy-demos/scripts/buy-one-get-one/03-edit-bogo.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/03-edit-bogo.spec.js
@@ -1,5 +1,10 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Open the Buy One Get One app, go to the Discounts list tab
+// 2. Open the first existing offer in the list
+// 3. Change its discount to 30%
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the Discounts list tab, confirm the offer is still there
 test('BOGO: edit the "get" product selection and discount', async ({ page, app }) => {
   await dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Discounts');
@@ -15,4 +20,8 @@ test('BOGO: edit the "get" product selection and discount', async ({ page, app }
   await popup.getByPlaceholder(/e\.g\., 20/).fill('30');
 
   await saveEditor(popup);
+  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await refreshAndVerifyInList(app, 'Discounts', /Sony Walkman/i);
 });

--- a/busybuddy-demos/scripts/buy-one-get-one/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/04-storefront-live.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
 
+// 1. Load the Sony Walkman product page on the live storefront
+// 2. Confirm the offer widget renders on that page
 test('BOGO: offer widget renders on the trigger product\'s page', async ({ page }) => {
   await gotoStorefrontProduct(page, 'sony-walkman');
   await expect(page.locator('[id*="star_rating"], [class*="busybuddy-bundle"]').first()).toBeVisible({ timeout: 15_000 });

--- a/busybuddy-demos/scripts/buy-one-get-one/05-analytics.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/05-analytics.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Buy One Get One app, go to the Analytics tab
+// 2. Confirm Total Bundle Revenue and Orders with Bundles are visible
 test('BOGO: Analytics tab shows revenue, orders, and top offers', async ({ page, app }) => {
   await dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Analytics');

--- a/busybuddy-demos/scripts/buy-one-get-one/06-settings.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/06-settings.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Buy One Get One app, go to the Settings tab
+// 2. Confirm the Smart Bundle Detection and Discount Combination sections are visible
 test('BOGO: Smart Bundle Detection / Discount Combination settings', async ({ page, app }) => {
   await dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Settings');

--- a/busybuddy-demos/scripts/buy-one-get-one/07-xy-pool-toggle.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/07-xy-pool-toggle.spec.js
@@ -1,5 +1,8 @@
 import { test, expect, dashboardTile, openEditorPopup, clickSidepaneItem } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Buy One Get One tile
+// 2. Click into "Customer Buys (X)", confirm its product search field appears
+// 3. Click into "Customer Gets (Y)", confirm its product search field appears
 test('BOGO: toggle between the X (buy) and Y (get) product pools', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /create/i }).click()

--- a/busybuddy-demos/scripts/inactive-tab-message/01-tabs-navigation.spec.js
+++ b/busybuddy-demos/scripts/inactive-tab-message/01-tabs-navigation.spec.js
@@ -1,10 +1,14 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Inactive Tab Message app from the dashboard
+// 2. Click through the Overview and Settings tabs (this app has no Discounts/Analytics tab)
+// 3. Confirm there's no Discounts or Analytics tab present
 test('Inactive Tab Message: navigate Overview -> Settings (no Discounts/Analytics tab)', async ({ page, app }) => {
   await dashboardTile(app, 'Inactive Tab Message').getByRole('button', { name: /manage/i }).click();
 
   for (const tab of ['Overview', 'Settings']) {
     await gotoTab(app, tab);
+    await page.waitForTimeout(4000); // pacing so the recorded video shows each tab's content, not just a flash
   }
 
   await expect(app.getByText('Discounts', { exact: true })).toHaveCount(0);

--- a/busybuddy-demos/scripts/inactive-tab-message/02-configure.spec.js
+++ b/busybuddy-demos/scripts/inactive-tab-message/02-configure.spec.js
@@ -1,5 +1,8 @@
 import { test, expect, dashboardTile } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Inactive Tab Message tile (jumps straight to Settings, no popup editor)
+// 2. Fill in the inactive-tab message text ("Come back! Your cart is waiting 🛒")
+// 3. Click "Save Settings"
 test('Inactive Tab Message: configure via Create (same-window, no standalone editor)', async ({ page, app }) => {
   // Unlike the other 5 apps, "Create" navigates straight to
   // /inactive-tab-message?tab=settings in the same window rather than

--- a/busybuddy-demos/scripts/inactive-tab-message/03-edit-configuration.spec.js
+++ b/busybuddy-demos/scripts/inactive-tab-message/03-edit-configuration.spec.js
@@ -1,5 +1,8 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Inactive Tab Message app, go to the Settings tab
+// 2. Change the message text to "Don't leave yet - 15% off waiting for you! 🎁"
+// 3. Click "Save Settings"
 test('Inactive Tab Message: edit the existing message text', async ({ page, app }) => {
   await dashboardTile(app, 'Inactive Tab Message').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Settings');

--- a/busybuddy-demos/scripts/inactive-tab-message/04-storefront-tab-switch-and-schedule.spec.js
+++ b/busybuddy-demos/scripts/inactive-tab-message/04-storefront-tab-switch-and-schedule.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab, gotoStorefrontHome } from '../../fixtures/app.js';
 
+// 1. Open the Inactive Tab Message app, go to the Settings tab
+// 2. Toggle the enable/disable switch off then back on, click "Save Settings"
 test('Inactive Tab Message: date-window gating and enable/disable toggle', async ({ page, app }) => {
   await dashboardTile(app, 'Inactive Tab Message').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Settings');
@@ -12,6 +14,9 @@ test('Inactive Tab Message: date-window gating and enable/disable toggle', async
   await app.getByRole('button', { name: /save settings/i }).click();
 });
 
+// 1. Load the live storefront homepage
+// 2. Simulate switching away to another browser tab
+// 3. Confirm the page title actually changes to the configured inactive-tab message
 test('Inactive Tab Message: swaps the browser tab title when the tab goes inactive', async ({ page }) => {
   await gotoStorefrontHome(page);
   const originalTitle = await page.title();

--- a/busybuddy-demos/scripts/mix-and-match/01-tabs-navigation.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/01-tabs-navigation.spec.js
@@ -1,9 +1,13 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Mix and Match app from the dashboard
+// 2. Click through each tab in turn: Overview, Discounts, Settings, Analytics
+// 3. Confirm each tab actually loads
 test('Mix and Match: navigate Overview -> Discounts -> Settings -> Analytics', async ({ page, app }) => {
   await dashboardTile(app, 'Mix & Match').getByRole('button', { name: /manage/i }).click();
 
   for (const tab of ['Overview', 'Discounts', 'Settings', 'Analytics']) {
     await gotoTab(app, tab);
+    await page.waitForTimeout(4000); // pacing so the recorded video shows each tab's content, not just a flash
   }
 });

--- a/busybuddy-demos/scripts/mix-and-match/02-create-offer.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/02-create-offer.spec.js
@@ -1,5 +1,10 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Mix and Match tile - opens the standalone editor
+// 2. Open "Select Products", add "Cassette" via the product picker
+// 3. Open Tier Settings, click the "Buy 3" preset button in the live preview
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the app, open the Discounts list tab, confirm the new offer is in the list
 test('Mix and Match: create an offer with a Buy 3 tier preset', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Mix & Match').getByRole('button', { name: /create/i }).click()
@@ -16,4 +21,8 @@ test('Mix and Match: create an offer with a Buy 3 tier preset', async ({ page, a
 
   await saveEditor(popup);
   await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await dashboardTile(app, 'Mix & Match').getByRole('button', { name: /manage/i }).click();
+  await refreshAndVerifyInList(app, 'Discounts', /Cassette/i);
 });

--- a/busybuddy-demos/scripts/mix-and-match/03-edit-offer.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/03-edit-offer.spec.js
@@ -1,5 +1,10 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Open the Mix and Match app, go to the Discounts list tab
+// 2. Open the first existing offer in the list
+// 3. Go to Tier Settings, click the "Buy 4" preset button
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the Discounts list tab, confirm the offer is still there
 test('Mix and Match: switch tier preset and change a tier discount', async ({ page, app }) => {
   await dashboardTile(app, 'Mix & Match').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Discounts');
@@ -17,4 +22,8 @@ test('Mix and Match: switch tier preset and change a tier discount', async ({ pa
   await popup.getByRole('button', { name: 'Buy 4' }).click();
 
   await saveEditor(popup);
+  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await refreshAndVerifyInList(app, 'Discounts', /Cassette/i);
 });

--- a/busybuddy-demos/scripts/mix-and-match/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/04-storefront-live.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
 
+// 1. Load the Cassette Player product page on the live storefront
+// 2. Confirm the offer widget renders on that page
 test('Mix and Match: offer widget renders on a grouped product\'s page', async ({ page }) => {
   await gotoStorefrontProduct(page, 'cassette-player');
   await expect(page.locator('[id*="star_rating"], [class*="busybuddy-bundle"]').first()).toBeVisible({ timeout: 15_000 });

--- a/busybuddy-demos/scripts/mix-and-match/05-analytics.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/05-analytics.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Mix and Match app, go to the Analytics tab
+// 2. Confirm Total Bundle Revenue is visible
 test('Mix and Match: Analytics tab shows revenue and distribution', async ({ page, app }) => {
   await dashboardTile(app, 'Mix & Match').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Analytics');

--- a/busybuddy-demos/scripts/mix-and-match/06-settings.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/06-settings.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Mix and Match app, go to the Settings tab
+// 2. Confirm the Smart Bundle Detection section is visible
 test('Mix and Match: shared Settings tab is reachable', async ({ page, app }) => {
   await dashboardTile(app, 'Mix & Match').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Settings');

--- a/busybuddy-demos/scripts/mix-and-match/07-tier-preset-switching.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/07-tier-preset-switching.spec.js
@@ -1,5 +1,9 @@
 import { test, expect, dashboardTile, openEditorPopup, clickSidepaneItem, addProductViaPicker } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Mix and Match tile
+// 2. Open "Select Products", add "Cassette" (needed for the tier preview to render at all)
+// 3. Open Tier Settings
+// 4. Click through all four preset buttons in order: Buy 2, Buy 3, Buy 4, Buy 5
 test('Mix and Match: switch across all Buy 2/3/4/5 tier presets', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Mix & Match').getByRole('button', { name: /create/i }).click()

--- a/busybuddy-demos/scripts/volume-discounts/01-tabs-navigation.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/01-tabs-navigation.spec.js
@@ -1,9 +1,13 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Volume Discounts app from the dashboard
+// 2. Click through each tab in turn: Overview, Discounts, Settings, Analytics
+// 3. Confirm each tab actually loads
 test('Volume Discounts: navigate Overview -> Discounts -> Settings -> Analytics', async ({ page, app }) => {
   await dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /manage/i }).click();
 
   for (const tab of ['Overview', 'Discounts', 'Settings', 'Analytics']) {
     await gotoTab(app, tab);
+    await page.waitForTimeout(4000); // pacing so the recorded video shows each tab's content, not just a flash
   }
 });

--- a/busybuddy-demos/scripts/volume-discounts/02-create-volume-discount.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/02-create-volume-discount.spec.js
@@ -1,5 +1,10 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Volume Discounts tile - opens the standalone editor
+// 2. Open "Select Products", add "Discman" via the product picker
+// 3. Open Quantity Breaks, confirm the default "Buy 2, get 10% OFF" tier is visible
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the app, open the Discounts list tab, confirm the new discount is in the list
 test('Volume Discounts: create a discount with quantity-break tiers', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /create/i }).click()
@@ -13,4 +18,8 @@ test('Volume Discounts: create a discount with quantity-break tiers', async ({ p
 
   await saveEditor(popup);
   await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /manage/i }).click();
+  await refreshAndVerifyInList(app, 'Discounts', /Discman/i);
 });

--- a/busybuddy-demos/scripts/volume-discounts/03-edit-volume-discount.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/03-edit-volume-discount.spec.js
@@ -1,5 +1,10 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, refreshAndVerifyInList } from '../../fixtures/app.js';
 
+// 1. Open the Volume Discounts app, go to the Discounts list tab
+// 2. Open the first existing discount in the list
+// 3. Go to Quantity Breaks, change the first tier's Discount % to 25
+// 4. Click Save and wait for the save confirmation
+// 5. Go back to the Discounts list tab, confirm the discount is still there
 test('Volume Discounts: adjust a quantity-break threshold and percentage', async ({ page, app }) => {
   await dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Discounts');
@@ -23,4 +28,8 @@ test('Volume Discounts: adjust a quantity-break threshold and percentage', async
   await discountInput.fill('25');
 
   await saveEditor(popup);
+  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
+  await popup.close();
+
+  await refreshAndVerifyInList(app, 'Discounts', /Discman/i);
 });

--- a/busybuddy-demos/scripts/volume-discounts/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/04-storefront-live.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
 
+// 1. Load the Discman product page on the live storefront
+// 2. Confirm the quantity-break widget renders on that page
 test('Volume Discounts: quantity-break tiers render on the product page', async ({ page }) => {
   await gotoStorefrontProduct(page, 'discman');
   await expect(page.locator('[id*="star_rating"], [class*="busybuddy-bundle"]').first()).toBeVisible({ timeout: 15_000 });

--- a/busybuddy-demos/scripts/volume-discounts/05-analytics.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/05-analytics.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Volume Discounts app, go to the Analytics tab
+// 2. Confirm Total Bundle Revenue and Top Bundles are visible
 test('Volume Discounts: Analytics tab shows revenue and quantity distribution', async ({ page, app }) => {
   await dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Analytics');

--- a/busybuddy-demos/scripts/volume-discounts/06-settings.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/06-settings.spec.js
@@ -1,5 +1,7 @@
 import { test, expect, dashboardTile, gotoTab } from '../../fixtures/app.js';
 
+// 1. Open the Volume Discounts app, go to the Settings tab
+// 2. Confirm the Smart Bundle Detection section is visible
 test('Volume Discounts: shared Settings tab is reachable', async ({ page, app }) => {
   await dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /manage/i }).click();
   await gotoTab(app, 'Settings');

--- a/busybuddy-demos/scripts/volume-discounts/07-quantity-tier-editor.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/07-quantity-tier-editor.spec.js
@@ -1,5 +1,9 @@
 import { test, expect, dashboardTile, openEditorPopup } from '../../fixtures/app.js';
 
+// 1. Click "Create" on the Volume Discounts tile
+// 2. Open Quantity Breaks, count the existing tiers
+// 3. Click "+ Add Another Quantity Break", confirm the tier count increased
+// 4. Click the "✕" on the newly-added tier to remove it
 test('Volume Discounts: add and remove a quantity-break tier', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /create/i }).click()

--- a/web/frontend/apps/announcement-bar/AnnouncementBarEditor.jsx
+++ b/web/frontend/apps/announcement-bar/AnnouncementBarEditor.jsx
@@ -16,6 +16,7 @@ import {
   EditorRightContent
 } from '../../components/Editor';
 import { useEditorNavigation } from '../../hooks';
+import { editorFetch } from '../../utils/editorAuth';
 
 // Announcement Bar specific settings configuration
 // Settings configuration for AnnouncementBar editor - Animation removed
@@ -277,7 +278,7 @@ export const AnnouncementBarEditor = () => {
 
     const fetchBar = async () => {
       try {
-        const response = await fetch(`/api/announcement-bars/${id}`);
+        const response = await editorFetch(`/api/announcement-bars/${id}`);
         if (!response.ok) throw new Error('Failed to fetch bar');
         const data = await response.json();
         const bar = data?.data;
@@ -412,7 +413,7 @@ export const AnnouncementBarEditor = () => {
       const url = id ? `/api/announcement-bars/${id}` : '/api/announcement-bars';
       const method = id ? 'PUT' : 'POST';
 
-      const response = await fetch(url, {
+      const response = await editorFetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),

--- a/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
+++ b/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
@@ -17,6 +17,7 @@ import {
   EditorRightContent
 } from '../../components/Editor';
 import { useEditorNavigation } from '../../hooks';
+import { editorFetch } from '../../utils/editorAuth';
 import tshirt from "./tshirt.png";
 
 // Bundle Discounts specific settings configuration
@@ -229,7 +230,7 @@ export const StandardBundleEditor = () => {
 
     const fetchBundle = async () => {
       try {
-        const response = await fetch(`/api/bundles/${id}`);
+        const response = await editorFetch(`/api/bundles/${id}`);
         if (!response.ok) throw new Error('Failed to fetch bundle');
         const data = await response.json();
         const bundle = data?.data || data;
@@ -291,7 +292,7 @@ export const StandardBundleEditor = () => {
   const fetchStoreProducts = async () => {
     setProductsLoading(true);
     try {
-      const response = await fetch("/api/products", {
+      const response = await editorFetch("/api/products", {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
@@ -490,7 +491,7 @@ export const StandardBundleEditor = () => {
       const url = isEditing ? `/api/bundles/${id}` : "/api/bundles";
       const method = isEditing ? "PUT" : "POST";
 
-      const response = await fetch(url, {
+      const response = await editorFetch(url, {
         method: method,
         headers: {
           "Content-Type": "application/json",

--- a/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
+++ b/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
@@ -17,6 +17,7 @@ import {
   EditorRightContent
 } from '../../components/Editor';
 import { useEditorNavigation } from '../../hooks';
+import { editorFetch } from '../../utils/editorAuth';
 import tshirt from "./tshirt.png";
 
 // Buy X Get Y specific settings configuration
@@ -213,7 +214,7 @@ export const BuyXGetYEditor = () => {
 
     const fetchBundle = async () => {
       try {
-        const response = await fetch(`/api/bundles/${id}`);
+        const response = await editorFetch(`/api/bundles/${id}`);
         if (!response.ok) throw new Error('Failed to fetch bundle');
         const data = await response.json();
         const bundle = data?.data || data;
@@ -322,7 +323,7 @@ export const BuyXGetYEditor = () => {
   const fetchStoreProducts = async () => {
     setProductsLoading(true);
     try {
-      const response = await fetch("/api/products", {
+      const response = await editorFetch("/api/products", {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });
@@ -513,7 +514,7 @@ export const BuyXGetYEditor = () => {
       const url = isEditing ? `/api/bundles/${id}` : "/api/bundles";
       const method = isEditing ? "PUT" : "POST";
 
-      const response = await fetch(url, {
+      const response = await editorFetch(url, {
         method: method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(bundleData),

--- a/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
@@ -16,6 +16,7 @@ import {
   EditorRightContent
 } from '../../components/Editor';
 import { useEditorNavigation } from '../../hooks';
+import { editorFetch } from '../../utils/editorAuth';
 import tshirt from "./tshirt.png";
 
 // Mix and Match settings configuration
@@ -220,7 +221,7 @@ export const MixAndMatchEditor = () => {
 
     const fetchBundle = async () => {
       try {
-        const response = await fetch(`/api/bundles/${id}`);
+        const response = await editorFetch(`/api/bundles/${id}`);
         if (!response.ok) throw new Error('Failed to fetch bundle');
         const data = await response.json();
         const bundle = data?.data || data;
@@ -304,7 +305,7 @@ export const MixAndMatchEditor = () => {
   const fetchStoreProducts = async () => {
     setProductsLoading(true);
     try {
-      const response = await fetch("/api/products", {
+      const response = await editorFetch("/api/products", {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });
@@ -468,7 +469,7 @@ export const MixAndMatchEditor = () => {
       const url = isEditing ? `/api/bundles/mix-and-match/${id}` : "/api/bundles/mix-and-match";
       const method = "POST";
 
-      const response = await fetch(url, {
+      const response = await editorFetch(url, {
         method: method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(bundleData),

--- a/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
@@ -16,6 +16,7 @@ import {
   EditorRightContent
 } from '../../components/Editor';
 import { useEditorNavigation } from '../../hooks';
+import { editorFetch } from '../../utils/editorAuth';
 import tshirt from "./tshirt.png";
 
 // Volume Discount settings configuration
@@ -208,7 +209,7 @@ export const VolumeDiscountEditor = () => {
 
     const fetchBundle = async () => {
       try {
-        const response = await fetch(`/api/bundles/${id}`);
+        const response = await editorFetch(`/api/bundles/${id}`);
         if (!response.ok) throw new Error('Failed to fetch bundle');
         const data = await response.json();
         const bundle = data?.data || data;
@@ -280,7 +281,7 @@ export const VolumeDiscountEditor = () => {
     const fetchProducts = async () => {
       setProductsLoading(true);
       try {
-        const response = await fetch("/api/products", {
+        const response = await editorFetch("/api/products", {
           method: "GET",
           headers: { "Content-Type": "application/json" },
         });
@@ -482,7 +483,7 @@ export const VolumeDiscountEditor = () => {
       const url = isEditing ? `/api/bundles/${id}` : "/api/bundles";
       const method = isEditing ? "PUT" : "POST";
 
-      const response = await fetch(url, {
+      const response = await editorFetch(url, {
         method: method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(bundleData),

--- a/web/frontend/editor.html
+++ b/web/frontend/editor.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Signed shop param so this standalone page's own /api/* calls can
+         authenticate without an App Bridge session token - see
+         web/index.js's serveEditorHtml and web/frontend/utils/editorAuth.js -->
+    <meta name="editor-shop" content="%EDITOR_SHOP%" />
+    <meta name="editor-signature" content="%EDITOR_SIGNATURE%" />
     <title>BusyBuddy Editor</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   </head>

--- a/web/frontend/utils/editorAuth.js
+++ b/web/frontend/utils/editorAuth.js
@@ -1,0 +1,26 @@
+/**
+ * The standalone editor (/editor.html, see web/frontend/editor.jsx) runs
+ * outside the App Bridge iframe by design, so it has no session token to
+ * authenticate its own /api/* calls with the way the embedded app's calls
+ * do (shopify.validateAuthenticatedSession() in web/index.js). The server
+ * signs a shop param when it serves this page (see serveEditorHtml in
+ * web/index.js) using the same HMAC that web/middleware/verify-signature.js
+ * already checks - this reads that signed pair back out and attaches it to
+ * every request this page makes, so those existing checks actually pass.
+ */
+const editorShopMeta = document.querySelector('meta[name="editor-shop"]');
+const editorSignatureMeta = document.querySelector('meta[name="editor-signature"]');
+
+export const EDITOR_SHOP = editorShopMeta?.content || '';
+export const EDITOR_SIGNATURE = editorSignatureMeta?.content || '';
+
+/**
+ * Drop-in replacement for fetch() for calls to this app's own /api/* routes
+ * from within the standalone editor. Do not use this for third-party URLs -
+ * it appends the signed shop/signature pair to whatever URL it's given.
+ */
+export function editorFetch(url, options) {
+  const separator = url.includes('?') ? '&' : '?';
+  const authedUrl = `${url}${separator}shop=${encodeURIComponent(EDITOR_SHOP)}&signature=${encodeURIComponent(EDITOR_SIGNATURE)}`;
+  return fetch(authedUrl, options);
+}

--- a/web/index.js
+++ b/web/index.js
@@ -13,7 +13,7 @@ import conditional from "express-conditional-middleware";
 import mongoose from "mongoose";
 import * as dotenv from "dotenv";
 import shopData from "./middleware/shopData.js";
-import { verifySHA256 } from "./middleware/verify-signature.js";
+import { verifySHA256, generateSignature } from "./middleware/verify-signature.js";
 import { verifyShopifyWebhook } from "./middleware/verifyWebhook.js";
 import sessionModel from "./backend/models/shopify_sessions.model.js"
 import { subscriptionUpdate } from "./backend/services/subscription.js"
@@ -195,11 +195,20 @@ const serveFrontendHtml = (_req, res) => {
 };
 
 // Helper function to serve the editor HTML (without App Bridge)
-const serveEditorHtml = (_req, res) => {
+// Injects a shop+signature pair (see verify-signature.js's generateSignature)
+// so the editor's own /api/* calls - which have no App Bridge session token
+// to authenticate with - can use the shop+signature path that web/index.js's
+// /api/* middleware already supports but nothing was previously feeding.
+const serveEditorHtml = (_req, res, shop, signature) => {
   return res
     .status(200)
     .set("Content-Type", "text/html")
-    .send(readFileSync(join(STATIC_PATH, "editor.html")).toString());
+    .send(
+      readFileSync(join(STATIC_PATH, "editor.html"))
+        .toString()
+        .replace("%EDITOR_SHOP%", shop || "")
+        .replace("%EDITOR_SIGNATURE%", signature || "")
+    );
 };
 
 // Editor routes opened in new tab - validate shop session from DB
@@ -208,21 +217,22 @@ app.use("/*", async (_req, res, _next) => {
   const fullPath = _req.originalUrl || _req.url;
   const isEditorRoute = fullPath.includes('/editor');
   const shop = _req.query.shop;
-  
+
   if (isEditorRoute && shop) {
     try {
       // Use sessionModel directly (same approach as API validation)
       const session = await sessionModel.findOne({ shop: shop });
-      
+
       if (session && session.accessToken) {
         // Valid session exists - serve the editor HTML (no App Bridge)
-        return serveEditorHtml(_req, res);
+        const signature = generateSignature({ shop });
+        return serveEditorHtml(_req, res, shop, signature);
       }
     } catch (error) {
       console.log("Editor session error:", error.message);
     }
   }
-  
+
   _next();
 });
 

--- a/web/middleware/verify-signature.js
+++ b/web/middleware/verify-signature.js
@@ -5,7 +5,7 @@ dotenv.config();
 
 const verifySHA256 = (req) => {
     const query = req.query;
-    
+
     var parameters = [];
     for (var key in query) {
         if (key != 'signature') {
@@ -16,8 +16,20 @@ const verifySHA256 = (req) => {
     const message = parameters.sort().join('');
 
     const digest = crypto.createHmac('sha256', process.env.SHOPIFY_API_SECRET).update(message).digest('hex');
-    
+
     return digest === query.signature;
 }
 
-export { verifySHA256 };
+// Server-side counterpart to verifySHA256, using the identical algorithm
+// (sorted "key=value" params, HMAC-SHA256 with SHOPIFY_API_SECRET) so a
+// signature generated here always verifies there. Used to mint a signed
+// shop param for the standalone editor (see web/index.js's serveEditorHtml),
+// which has no App Bridge session token available to authenticate its own
+// /api/* calls with.
+const generateSignature = (params) => {
+    const parameters = Object.entries(params).map(([key, value]) => `${key}=${value}`);
+    const message = parameters.sort().join('');
+    return crypto.createHmac('sha256', process.env.SHOPIFY_API_SECRET).update(message).digest('hex');
+}
+
+export { verifySHA256, generateSignature };


### PR DESCRIPTION
## Problem

Two things bundled in this branch:

1. **App bug**: the standalone editor popup (`/editor.html`, used for Create/Edit on Bundle Discounts, BOGO, Volume Discounts, Mix & Match, and Announcement Bar) runs outside the App Bridge iframe by design, so it has no session token for `web/index.js`'s `shopify.validateAuthenticatedSession()` path. The only other `/api/*` auth path (`shop` + `signature`, HMAC-verified in `web/middleware/verify-signature.js`) was never fed a valid signature by any frontend caller (confirmed via grep - zero occurrences of a `signature=` param anywhere in `web/frontend`). Every fetch from the editor - product picker, bundle/bar fetch, and save - silently failed auth, swallowed by a catch block whose only feedback (`shopify?.toast?.show`) also depends on App Bridge. This is what made the product picker show "No products found in your store" regardless of actual inventory, and is unrelated to which app created the products or which plan/scopes are granted.
2. **Demo pipeline follow-ups**: every script now has a plain-English journey comment, tabs-navigation scripts pace 4s between tab clicks so recordings are watchable, and every create/edit script verifies the saved item actually appears in its list tab afterward.

## Solution

- `web/middleware/verify-signature.js`: added `generateSignature()`, the same HMAC algorithm `verifySHA256` already checks.
- `web/index.js`: `serveEditorHtml` now mints a signed `shop`/`signature` pair once it confirms a real session exists, and injects it into the page.
- `web/frontend/editor.html`: two new meta tags to receive the signed pair.
- `web/frontend/utils/editorAuth.js` (new): reads the signed pair back out, exports `editorFetch()`.
- All 14 `fetch()` call sites across the 5 standalone editor components now go through `editorFetch()` instead of bare `fetch()`. No new backend auth branch was needed - the existing shop+signature path already did the right thing, it just never had a real caller.
- `busybuddy-demos/`: journey comments on all 39 specs, 4s tab-pacing, `refreshAndVerifyInList` fixture helper + usage in every save flow.

## Test Results

N/A - the auth fix is an app-code change that needs deployment before it can be validated against the live store (not something this session can trigger); the demo-pipeline changes will be validated via the existing `record-demos.yml` workflow.

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_