### PR TITLE
Add temporary diagnostic for the standalone editor auth fix

### DIFF
--- a/busybuddy-demos/scripts/_diagnostics/editor-auth-probe.spec.js
+++ b/busybuddy-demos/scripts/_diagnostics/editor-auth-probe.spec.js
@@ -1,0 +1,31 @@
+import { test, expect, dashboardTile, openEditorPopup } from '../../fixtures/app.js';
+
+// TEMPORARY DIAGNOSTIC - not a demo journey. Captures whether the editor's
+// injected shop/signature meta tags are actually populated (proves whether
+// the PR #258 fix reached the live build) and the raw /api/products
+// response status+body (proves whether auth is actually passing now).
+// Safe to delete once the standalone-editor auth issue is resolved.
+test('DIAGNOSTIC: editor auth meta tags + /api/products response', async ({ page, app }) => {
+  const popup = await openEditorPopup(page, () =>
+    dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /create/i }).click()
+  );
+
+  const authMeta = await popup.evaluate(() => ({
+    shop: document.querySelector('meta[name="editor-shop"]')?.content || null,
+    signature: document.querySelector('meta[name="editor-signature"]')?.content || null,
+  }));
+  console.log('EDITOR_AUTH_META', JSON.stringify(authMeta));
+
+  const responsePromise = popup.waitForResponse((res) => res.url().includes('/api/products'), { timeout: 30_000 });
+  // fetchStoreProducts already ran once on mount before we attached this
+  // listener - reload to force a fresh, observable call.
+  await popup.reload();
+  const response = await responsePromise;
+  const body = await response.text();
+  console.log('API_PRODUCTS_STATUS', response.status());
+  console.log('API_PRODUCTS_BODY', body.slice(0, 3000));
+
+  expect(authMeta.shop, 'editor-shop meta tag should be populated').toBeTruthy();
+  expect(authMeta.signature, 'editor-signature meta tag should be populated').toBeTruthy();
+  expect(response.status(), `Expected 200 from /api/products, got ${response.status()}: ${body.slice(0, 500)}`).toBe(200);
+});


### PR DESCRIPTION
## Problem

A live single-spec run after deploying PR #258 still shows "No products found in your store" - identical to before the fix - despite the deploy confirmed pulling the right commit (`c171fde`) and the signature algorithm checking out on re-review. Need real diagnostic data instead of more static analysis.

## Solution

`busybuddy-demos/scripts/_diagnostics/editor-auth-probe.spec.js` - a temporary probe that captures whether the injected `editor-shop`/`editor-signature` meta tags are actually populated (proves whether the fix reached the live build) and the raw `/api/products` response status+body (proves whether auth is actually passing). Not a demo journey - safe to delete once the underlying issue is resolved.

## Test Results

N/A - this is itself a diagnostic tool, being run next via `record-demos.yml`.

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_