### PR TITLE
Fix the real bug: serve-static ran before the editor auth handler

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -167,7 +167,6 @@ app.use(
 app.use(shopify.cspHeaders());
 app.use("/api", router);
 
-app.use(serveStatic(STATIC_PATH, { index: false }));
 app.use("/", async (_req, res, _next) => {
   // Shopify redirects here with charge_id+shop after a billing confirmation.
   // Only trust it enough to trigger a resync if the request carries a valid
@@ -211,11 +210,20 @@ const serveEditorHtml = (_req, res, shop, signature) => {
     );
 };
 
-// Editor routes opened in new tab - validate shop session from DB
-// This allows editor to work in standalone tab without Shopify embedded context
+// Editor routes opened in new tab - validate shop session from DB.
+// This allows editor to work in standalone tab without Shopify embedded
+// context. MUST run before the static file server below: the Vite build
+// outputs a real editor.html onto disk, so serve-static would otherwise
+// serve that raw file directly (skipping session validation *and* the
+// %EDITOR_SHOP%/%EDITOR_SIGNATURE% substitution below) for any request
+// that reaches it first - which prior to this comment is exactly what was
+// happening, silently, regardless of what this block below did.
 app.use("/*", async (_req, res, _next) => {
   const fullPath = _req.originalUrl || _req.url;
-  const isEditorRoute = fullPath.includes('/editor');
+  // Exact match (not a substring check) so this never accidentally catches
+  // a built asset whose filename happens to contain "editor" (e.g. Vite's
+  // /assets/editor-<hash>.js chunk for this same entry point).
+  const isEditorRoute = fullPath === '/editor.html' || fullPath.startsWith('/editor.html?');
   const shop = _req.query.shop;
 
   if (isEditorRoute && shop) {
@@ -235,6 +243,8 @@ app.use("/*", async (_req, res, _next) => {
 
   _next();
 });
+
+app.use(serveStatic(STATIC_PATH, { index: false }));
 
 app.use("/*", shopify.ensureInstalledOnShop(), serveFrontendHtml);
 


### PR DESCRIPTION
## Problem

The diagnostic probe (PR #259) proved PR #258's signature-injection fix never actually ran on the live deployed store: `EDITOR_AUTH_META` came back as the literal unreplaced strings `%EDITOR_SHOP%`/`%EDITOR_SIGNATURE%`, and `/api/products` returned `401 Unauthorized`.

Root cause: `app.use(serveStatic(STATIC_PATH, { index: false }))` was registered in `web/index.js` *before* the `isEditorRoute` handler that does the session lookup and signature substitution. The Vite build outputs a real `editor.html` file onto disk, so Express's static file server matched and served that raw file directly on every request, short-circuiting the middleware chain before it ever reached the dynamic handler below it. This was true before PR #258 too - the dynamic handler has likely been dead code since it was introduced, which also explains why the editor always *rendered* fine (its initial UI needs no server-injected data) while every API call underneath silently 401'd regardless of what that handler contained.

## Solution

- Moved `serveStatic` to run *after* the editor-route handler.
- Tightened the route match from a loose `fullPath.includes('/editor')` substring check to an exact `/editor.html` match, so it can never accidentally intercept a built asset chunk whose filename happens to contain "editor" (e.g. Vite's `/assets/editor-<hash>.js`).

## Test Results

N/A - being validated against the live store next via the existing diagnostic probe, once deployed.

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_