### PR TITLE
Fix product picker response-shape mismatch in standalone editors

### DIFF
--- a/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
+++ b/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
@@ -302,7 +302,7 @@ export const StandardBundleEditor = () => {
         throw new Error("Failed to fetch products");
       }
       const data = await response.json();
-      const edges = data.data?.products?.edges || [];
+      const edges = data.data?.edges || [];
       // Transform products to match production bundle format
       const transformedProducts = edges.map(edge => {
         const product = edge.node;

--- a/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
+++ b/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
@@ -330,7 +330,7 @@ export const BuyXGetYEditor = () => {
       if (!response.ok) throw new Error("Failed to fetch products");
       
       const data = await response.json();
-      const edges = data.data?.products?.edges || [];
+      const edges = data.data?.edges || [];
       
       // Transform products to match production bundle format
       const transformedProducts = edges.map(edge => {

--- a/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
@@ -312,7 +312,7 @@ export const MixAndMatchEditor = () => {
       if (!response.ok) throw new Error("Failed to fetch products");
 
       const data = await response.json();
-      const products = data.data?.products?.edges || [];
+      const products = data.data?.edges || [];
 
       const formattedProducts = products.map((edge) => {
         const product = edge.node;

--- a/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
@@ -287,7 +287,7 @@ export const VolumeDiscountEditor = () => {
         });
         if (response.ok) {
           const data = await response.json();
-          const products = data.data?.products?.edges?.map(edge => ({
+          const products = data.data?.edges?.map(edge => ({
             productId: edge.node.id,
             title: edge.node.title,
             price: edge.node.variants?.nodes?.[0]?.price || '0',


### PR DESCRIPTION
## Summary
- The `/api/products` backend returns `{ data: { edges, pageInfo } }`, but all 4 shared-picker standalone editors (Bundle Discounts, BOGO, Volume Discounts, Mix and Match) read `data.data.products.edges` - a path that never exists on that response shape.
- `storeProducts` was therefore always set to an empty array, so the product picker showed "No products found in your store" regardless of actual store inventory.
- This was a separate, deeper bug than the earlier standalone-editor auth issue (PR #260) - that fix made `/api/products` return real 200 data (confirmed via diagnostic probe), which is what surfaced this response-shape bug in the live UI.

## Fix
Changed `data.data?.products?.edges` to `data.data?.edges` (and the equivalent for Volume Discounts' inline map) in:
- `web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx`
- `web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx`
- `web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx`
- `web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx`

## Test plan
- [ ] Deploy to production
- [ ] Re-run `busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js` (the spec that surfaced this bug via a `120s` timeout waiting for a product row's `+ Add` button) and confirm it passes end-to-end
- [ ] Re-run the other previously-failing specs (buy-one-get-one/02, mix-and-match/02+07, volume-discounts/02)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_