### PR TITLE
Add server-side product search to the standalone editors' picker

### DIFF
--- a/web/backend/controller/products/index.js
+++ b/web/backend/controller/products/index.js
@@ -8,11 +8,11 @@ async function getProducts(req, res) {
     apiVersion: "2025-10",
   });
 
-  const { cursor } = req.query;
+  const { cursor, search } = req.query;
   console.log("Cursor received in getProducts:", cursor);
   const query = `
-    query getProducts {
-      products(first: 10, after: ${cursor?`"${cursor}"`:null}, sortKey: CREATED_AT, reverse: true, query: "bundles:false AND tag_not:busybuddybundles") {
+    query getProducts($cursor: String, $searchQuery: String!) {
+      products(first: 10, after: $cursor, sortKey: CREATED_AT, reverse: true, query: $searchQuery) {
         edges {
           node {
             id
@@ -44,8 +44,18 @@ async function getProducts(req, res) {
     }
   `;
 
+  // Product search is a merchant browsing their own catalog, not a trust
+  // boundary - but it's still interpolated into Shopify's search query DSL,
+  // so quotes/backslashes are escaped to keep the term from breaking out of
+  // the title:*...* clause.
+  const baseFilter = "bundles:false AND tag_not:busybuddybundles";
+  const escapedSearch = typeof search === "string" ? search.trim().replace(/["\\]/g, "\\$&") : "";
+  const searchQuery = escapedSearch ? `${baseFilter} AND title:*${escapedSearch}*` : baseFilter;
+
   try {
-    const response = await client.request(query);
+    const response = await client.request(query, {
+      variables: { cursor: cursor || null, searchQuery },
+    });
     const { edges, pageInfo } = response.data.products;
     res.status(200).json({
       status: true,

--- a/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
+++ b/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
@@ -289,10 +289,22 @@ export const StandardBundleEditor = () => {
     fetchStoreProducts();
   }, []);
 
-  const fetchStoreProducts = async () => {
+  // The picker only ever holds one page (10 products, newest first) - without
+  // this, searching for an older product that isn't in that page can never
+  // find it no matter what's typed, since filtering below only runs over
+  // what's already been fetched. Re-fetching with the search term lets the
+  // backend query the full catalog instead.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      fetchStoreProducts(productSearchQuery);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [productSearchQuery]);
+
+  const fetchStoreProducts = async (search = '') => {
     setProductsLoading(true);
     try {
-      const response = await editorFetch("/api/products", {
+      const response = await editorFetch(`/api/products${search ? `?search=${encodeURIComponent(search)}` : ''}`, {
         method: "GET",
         headers: {
           "Content-Type": "application/json",

--- a/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
+++ b/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
@@ -294,6 +294,18 @@ export const BuyXGetYEditor = () => {
     fetchStoreProducts();
   }, []);
 
+  // The picker only ever holds one page (10 products, newest first) - without
+  // this, searching for an older product that isn't in that page can never
+  // find it no matter what's typed, since filtering below only runs over
+  // what's already been fetched. Re-fetching with the search term lets the
+  // backend query the full catalog instead.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      fetchStoreProducts(productSearchQuery);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [productSearchQuery]);
+
   // Countdown timer effect
   useEffect(() => {
     if (!showCountdown) return;
@@ -320,10 +332,10 @@ export const BuyXGetYEditor = () => {
     return () => clearInterval(timer);
   }, [showCountdown]);
 
-  const fetchStoreProducts = async () => {
+  const fetchStoreProducts = async (search = '') => {
     setProductsLoading(true);
     try {
-      const response = await editorFetch("/api/products", {
+      const response = await editorFetch(`/api/products${search ? `?search=${encodeURIComponent(search)}` : ''}`, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });

--- a/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
@@ -302,10 +302,22 @@ export const MixAndMatchEditor = () => {
     fetchStoreProducts();
   }, []);
 
-  const fetchStoreProducts = async () => {
+  // The picker only ever holds one page (10 products, newest first) - without
+  // this, searching for an older product that isn't in that page can never
+  // find it no matter what's typed, since filtering below only runs over
+  // what's already been fetched. Re-fetching with the search term lets the
+  // backend query the full catalog instead.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      fetchStoreProducts(productSearchQuery);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [productSearchQuery]);
+
+  const fetchStoreProducts = async (search = '') => {
     setProductsLoading(true);
     try {
-      const response = await editorFetch("/api/products", {
+      const response = await editorFetch(`/api/products${search ? `?search=${encodeURIComponent(search)}` : ''}`, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });

--- a/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
@@ -277,33 +277,46 @@ export const VolumeDiscountEditor = () => {
   }, [id]);
 
   // Fetch store products
-  useEffect(() => {
-    const fetchProducts = async () => {
-      setProductsLoading(true);
-      try {
-        const response = await editorFetch("/api/products", {
-          method: "GET",
-          headers: { "Content-Type": "application/json" },
-        });
-        if (response.ok) {
-          const data = await response.json();
-          const products = data.data?.edges?.map(edge => ({
-            productId: edge.node.id,
-            title: edge.node.title,
-            price: edge.node.variants?.nodes?.[0]?.price || '0',
-            media: edge.node.images?.edges?.[0]?.node?.url || tshirt,
-            variants: edge.node.variants?.nodes || [],
-          })) || [];
-          setStoreProducts(products);
-        }
-      } catch (error) {
-        console.error("Error fetching products:", error);
-      } finally {
-        setProductsLoading(false);
+  const fetchStoreProducts = async (search = '') => {
+    setProductsLoading(true);
+    try {
+      const response = await editorFetch(`/api/products${search ? `?search=${encodeURIComponent(search)}` : ''}`, {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        const products = data.data?.edges?.map(edge => ({
+          productId: edge.node.id,
+          title: edge.node.title,
+          price: edge.node.variants?.nodes?.[0]?.price || '0',
+          media: edge.node.images?.edges?.[0]?.node?.url || tshirt,
+          variants: edge.node.variants?.nodes || [],
+        })) || [];
+        setStoreProducts(products);
       }
-    };
-    fetchProducts();
+    } catch (error) {
+      console.error("Error fetching products:", error);
+    } finally {
+      setProductsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStoreProducts();
   }, []);
+
+  // The picker only ever holds one page (10 products, newest first) - without
+  // this, searching for an older product that isn't in that page can never
+  // find it no matter what's typed, since filtering below only runs over
+  // what's already been fetched. Re-fetching with the search term lets the
+  // backend query the full catalog instead.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      fetchStoreProducts(productSearchQuery);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [productSearchQuery]);
 
   // Countdown timer effect
   useEffect(() => {


### PR DESCRIPTION
## Summary
- `getProducts` (`web/backend/controller/products/index.js`) only ever fetched the 10 most-recently-created products (`first: 10`, sorted `CREATED_AT` descending, no server-side search). All 4 shared-picker standalone editors filtered client-side over that single fetched page.
- Result: any product older than the 10 most recently created could never be found or added through the picker, no matter what was typed in the search box - the "+ Add" button would simply never appear.
- Confirmed via a live CI run: `bundle-discounts/02-create-bundle.spec.js` timed out searching for "Game Boy" (seeded 14th/15th of 25 products) because exactly 10 newer products existed, pushing it out of the only page ever fetched. Deploy of the prior response-shape fix (PR #261) was independently confirmed live and correct before this was diagnosed, ruling out a stale-deploy explanation.

## Fix
- Backend: `getProducts` now accepts a `search` query param and folds it into the Shopify product query filter (`title:*term*`) via a GraphQL variable (not string interpolation, to avoid breaking out of the search DSL).
- Frontend (`StandardBundleEditor.jsx`, `BuyXGetYEditor.jsx`, `MixAndMatchEditor.jsx`, `VolumeDiscountEditor.jsx`): added a debounced effect that re-fetches from `/api/products?search=...` whenever the search box changes, instead of only filtering whatever was fetched on mount.

## Test plan
- [ ] Deploy to production
- [ ] Re-run `busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js` and confirm the "Game Boy" / "Game Boy Color" search now finds and adds both products
- [ ] Re-run the other previously-failing specs (buy-one-get-one/02, mix-and-match/02+07, volume-discounts/02)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_