### PR TITLE
Add temporary diagnostic for the product-search title matching

### DIFF
--- a/busybuddy-demos/scripts/_diagnostics/product-search-probe.spec.js
+++ b/busybuddy-demos/scripts/_diagnostics/product-search-probe.spec.js
@@ -1,0 +1,29 @@
+import { test, expect, dashboardTile, openEditorPopup, clickSidepaneItem } from '../../fixtures/app.js';
+
+// TEMPORARY DIAGNOSTIC - captures the raw /api/products?search=... response
+// for a multi-word title ("Game Boy") to determine whether the backend's
+// title:*term* Shopify search filter actually matches multi-word titles, or
+// whether the space breaks the query into separate tokens. Safe to delete
+// once the product-search bug is resolved.
+test('DIAGNOSTIC: product search response for "Game Boy"', async ({ page, app }) => {
+  const popup = await openEditorPopup(page, () =>
+    dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /create/i }).click()
+  );
+
+  await clickSidepaneItem(popup, 'Select Products');
+  const addProductsButton = popup.getByRole('button', { name: '+ Add Products' });
+  if (await addProductsButton.isVisible().catch(() => false)) {
+    await addProductsButton.click();
+  }
+
+  const responsePromise = popup.waitForResponse(
+    (res) => res.url().includes('/api/products') && res.url().includes('search='),
+    { timeout: 15_000 }
+  );
+  await popup.getByPlaceholder('Search by product name...').fill('Game Boy');
+  const response = await responsePromise;
+  const body = await response.text();
+  console.log('SEARCH_URL', response.url());
+  console.log('SEARCH_STATUS', response.status());
+  console.log('SEARCH_BODY', body.slice(0, 3000));
+});


### PR DESCRIPTION
## Summary
- `bundle-discounts/02-create-bundle.spec.js` is still timing out waiting for a "+ Add" button after searching "Game Boy", even after the product-search/pagination fix (PR #262) deployed and was confirmed live.
- This diagnostic captures the raw `/api/products?search=Game+Boy` response to determine whether the backend's `title:*term*` Shopify search filter actually matches multi-word titles, or whether the space breaks the query into separate tokens.

Temporary - safe to delete once resolved.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_