### PR TITLE
Fix editor API auth rejecting requests with extra query params

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -13,7 +13,7 @@ import conditional from "express-conditional-middleware";
 import mongoose from "mongoose";
 import * as dotenv from "dotenv";
 import shopData from "./middleware/shopData.js";
-import { verifySHA256, generateSignature } from "./middleware/verify-signature.js";
+import { verifySHA256, generateSignature, verifyShopSignature } from "./middleware/verify-signature.js";
 import { verifyShopifyWebhook } from "./middleware/verifyWebhook.js";
 import sessionModel from "./backend/models/shopify_sessions.model.js"
 import { subscriptionUpdate } from "./backend/services/subscription.js"
@@ -126,7 +126,7 @@ app.use(
     async (_req, res, next) => {
       // @ts-ignore
       var shop = _req.query.shop.toString();
-      const isValid = verifySHA256(_req);
+      const isValid = verifyShopSignature(shop, _req.query.signature);
       if (!isValid) {
         return res.status(401).send("Unauthorized");
       }

--- a/web/middleware/verify-signature.js
+++ b/web/middleware/verify-signature.js
@@ -32,4 +32,17 @@ const generateSignature = (params) => {
     return crypto.createHmac('sha256', process.env.SHOPIFY_API_SECRET).update(message).digest('hex');
 }
 
-export { verifySHA256, generateSignature };
+// Verifies a signature minted by generateSignature({shop}) - unlike
+// verifySHA256 (which signs every query param present on the request, for
+// verifying Shopify's own outbound redirects where Shopify controls and
+// signs the full param set), this checks only the shop value the token was
+// actually minted for. Editor API calls legitimately carry other
+// business-logic query params (search, cursor, ...) that were never part of
+// what was signed, so including them in the check would reject every editor
+// request that isn't a bare shop-only lookup.
+const verifyShopSignature = (shop, signature) => {
+    if (!shop || !signature) return false;
+    return generateSignature({ shop }) === signature;
+}
+
+export { verifySHA256, generateSignature, verifyShopSignature };


### PR DESCRIPTION
## Summary
- Diagnosed via a live probe: `/api/products?search=Game%20Boy&shop=...&signature=...` returned `401 Unauthorized`, even though a bare `/api/products?shop=...&signature=...` (no `search`) had already been confirmed working (PR #260).
- Root cause: `verifySHA256` (`web/middleware/verify-signature.js`) recomputes its HMAC over **every** query param present on the request except `signature`. The editor's shop+signature token is minted server-side via `generateSignature({shop})` - signing **only** `shop`. Any editor API call carrying an extra query param (like the `search` param added in PR #262) gets verified against a different message than what was actually signed, so it always fails with 401 - independent of the param's value or the search-syntax question that was originally suspected.
- This means the product-search fix (PR #262) was structurally correct but could never have worked until this was fixed too.

## Fix
- Added `verifyShopSignature(shop, signature)` to `verify-signature.js`, which checks only the `shop` value the token was actually minted for.
- Used it in `web/index.js`'s editor `/api/*` auth path instead of the generic `verifySHA256`.
- Left the billing `charge_id` resync path (`web/index.js:175`) on `verifySHA256` unchanged - it verifies Shopify's own outbound redirect signature, which legitimately covers Shopify's full param set, not just `shop`.

## Test plan
- [ ] Deploy to production
- [ ] Re-run `busybuddy-demos/scripts/_diagnostics/product-search-probe.spec.js` and confirm `/api/products?search=Game%20Boy...` now returns 200 with matching products
- [ ] Re-run `busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js` end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_