### PR TITLE
Fix guessed discount-value placeholder in bundle-discounts specs

### DIFF
--- a/busybuddy-demos/fixtures/app.js
+++ b/busybuddy-demos/fixtures/app.js
@@ -208,3 +208,18 @@ export async function selectConfigOption(popup, groupLabel, optionLabel) {
     .locator('select')
     .selectOption({ label: optionLabel });
 }
+
+/**
+ * Fills the text/number input inside a ConfigFormGroup by its visible label
+ * - avoids guessing placeholder text, which varies by app and by the
+ * currently selected discount type (e.g. StandardBundleEditor.jsx's
+ * "Discount Value" field placeholder is "10" for Percentage or "5.00" for a
+ * fixed amount, neither of which is BOGO's "e.g., 20"/"e.g., 10.00").
+ */
+export async function fillConfigInput(popup, groupLabel, value) {
+  await popup
+    .locator('.form-group')
+    .filter({ has: popup.locator('.form-label', { hasText: groupLabel }) })
+    .locator('input')
+    .fill(value);
+}

--- a/busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, selectConfigOption, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, selectConfigOption, fillConfigInput, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Click "Create" on the Bundle Discounts tile - opens the standalone editor
 // 2. Open "Select Products", add "Game Boy" and "Game Boy Color" via the product picker
@@ -21,7 +21,7 @@ test('Bundle Discounts: create a bundle from 2 seeded products', async ({ page, 
 
   await clickSidepaneItem(popup, 'Discount Settings');
   await selectConfigOption(popup, 'Discount Type', 'Percentage');
-  await popup.getByPlaceholder(/e\.g\., 20/).fill('15');
+  await fillConfigInput(popup, 'Discount Value', '15');
 
   await saveEditor(popup);
   await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });

--- a/busybuddy-demos/scripts/bundle-discounts/03-edit-bundle.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/03-edit-bundle.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField, fillConfigInput, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Open the Bundle Discounts app, go to the Discounts list tab
 // 2. Open the first existing bundle in the list
@@ -17,7 +17,7 @@ test('Bundle Discounts: edit an existing bundle\'s discount and message', async 
   );
 
   await clickSidepaneItem(popup, 'Discount Settings');
-  await popup.getByPlaceholder(/e\.g\., 20/).fill('25');
+  await fillConfigInput(popup, 'Discount Value', '25');
 
   await popup.getByText('Content', { exact: true }).click();
   await clickSidepaneItem(popup, 'Message Text');


### PR DESCRIPTION
## Summary
- After the product-picker fix (PR #266), `bundle-discounts/02-create-bundle.spec.js` progressed past the picker and failed later at `popup.getByPlaceholder(/e\.g\., 20/).fill('15')` - a 120s timeout waiting for that placeholder.
- Confirmed via source: `StandardBundleEditor.jsx`'s Discount Value field uses placeholder `"10"` (Percentage) or `"5.00"` (fixed amount) - `"e.g., 20"` is BOGO's `BuyXGetYEditor.jsx` placeholder text, evidently copy-pasted into the wrong app's specs. Same pattern found in `bundle-discounts/03-edit-bundle.spec.js`.

## Fix
- Added `fillConfigInput(popup, groupLabel, value)` to `fixtures/app.js`, which fills a `ConfigFormGroup`'s input by its visible label instead of guessing placeholder text that varies by app and by the selected discount type.
- Used it in both `bundle-discounts/02-create-bundle.spec.js` and `bundle-discounts/03-edit-bundle.spec.js`.

## Test plan
- [ ] Re-run `busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js` and confirm it passes end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_