### PR TITLE
Fix save-verification across all 11 create/edit specs

### DIFF
--- a/busybuddy-demos/fixtures/app.js
+++ b/busybuddy-demos/fixtures/app.js
@@ -143,6 +143,18 @@ export async function saveEditor(popup) {
   await popup.locator('button.btn-save').click();
 }
 
+/**
+ * Waits for a successful save. The standalone editor runs without App
+ * Bridge (see useEditorNavigation.js), so every editor's success toast
+ * (shopify?.toast?.show(...)) silently no-ops - there is no "saved" text to
+ * wait for. The actual success signal is closeEditor() calling
+ * window.close() immediately after a successful save, so the popup closing
+ * on its own IS the confirmation.
+ */
+export async function waitForSaveAndClose(popup) {
+  await popup.waitForEvent('close', { timeout: 15_000 });
+}
+
 export async function gotoStorefrontHome(page) {
   await page.goto(`https://${STORE_DOMAIN}`);
 }

--- a/busybuddy-demos/scripts/announcement-bar/02-create-bar.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/02-create-bar.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, fillActiveConfigField, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Click "Create" on the Announcement Bar tile - opens the standalone editor
 // 2. Set the message text to "New arrivals just dropped - 20% off today only!"
@@ -20,8 +20,7 @@ test('Announcement Bar: create a new bar from the dashboard', async ({ page, app
   await clickSidepaneItem(popup, 'Background');
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await dashboardTile(app, 'Announcement Bar').getByRole('button', { name: /manage/i }).click();
   await refreshAndVerifyInList(app, 'Announcement Bars', message);

--- a/busybuddy-demos/scripts/announcement-bar/03-edit-bar.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/03-edit-bar.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, fillActiveConfigField, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Open the Announcement Bar app, go to the Announcement Bars list tab
 // 2. Open the first existing bar in the list
@@ -19,8 +19,7 @@ test('Announcement Bar: edit an existing bar', async ({ page, app }) => {
   await fillActiveConfigField(popup, updatedMessage);
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await refreshAndVerifyInList(app, 'Announcement Bars', updatedMessage);
 });

--- a/busybuddy-demos/scripts/announcement-bar/07-timer-email-variant.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar/07-timer-email-variant.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Click "Create" on the Announcement Bar tile
 // 2. Open the Countdown Timer option and turn it on
@@ -18,8 +18,7 @@ test('Announcement Bar: countdown timer and email-capture bar variants', async (
   await expect(popup.getByText(/email form/i)).toBeVisible();
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   // No custom message is set in this variant - AnnouncementBarEditor.jsx's
   // own default title/message ("Summer Sale Banner" / "Summer Sale") is

--- a/busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, selectConfigOption, fillConfigInput, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, dashboardTile, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, addProductViaPicker, selectConfigOption, fillConfigInput, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Click "Create" on the Bundle Discounts tile - opens the standalone editor
 // 2. Open "Select Products", add "Game Boy" and "Game Boy Color" via the product picker
@@ -24,8 +24,7 @@ test('Bundle Discounts: create a bundle from 2 seeded products', async ({ page, 
   await fillConfigInput(popup, 'Discount Value', '15');
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /manage/i }).click();
   await refreshAndVerifyInList(app, 'Discounts', /Game Boy/i);

--- a/busybuddy-demos/scripts/bundle-discounts/03-edit-bundle.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/03-edit-bundle.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, fillActiveConfigField, fillConfigInput, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, fillActiveConfigField, fillConfigInput, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Open the Bundle Discounts app, go to the Discounts list tab
 // 2. Open the first existing bundle in the list
@@ -24,8 +24,7 @@ test('Bundle Discounts: edit an existing bundle\'s discount and message', async 
   await fillActiveConfigField(popup, 'Now 25% off - Bundle and Save!');
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   // The Discounts list row shows each bundle's product-title badges, not
   // its message text (see BundelDiscountList.jsx), so verify presence via

--- a/busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductToPool, selectConfigOption, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, dashboardTile, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, addProductToPool, selectConfigOption, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Click "Create" on the Buy One Get One tile - opens the standalone editor
 // 2. Open "Customer Buys (X)", add "Sony Walkman" to the buy-side pool
@@ -26,8 +26,7 @@ test('BOGO: create a Buy X Get Y offer', async ({ page, app }) => {
   await popup.getByPlaceholder(/e\.g\., 20/).fill('50');
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /manage/i }).click();
   await refreshAndVerifyInList(app, 'Discounts', /Sony Walkman/i);

--- a/busybuddy-demos/scripts/buy-one-get-one/03-edit-bogo.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/03-edit-bogo.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, clickSidepaneItem, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Open the Buy One Get One app, go to the Discounts list tab
 // 2. Open the first existing offer in the list
@@ -20,8 +20,7 @@ test('BOGO: edit the "get" product selection and discount', async ({ page, app }
   await popup.getByPlaceholder(/e\.g\., 20/).fill('30');
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await refreshAndVerifyInList(app, 'Discounts', /Sony Walkman/i);
 });

--- a/busybuddy-demos/scripts/mix-and-match/02-create-offer.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/02-create-offer.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, dashboardTile, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, addProductViaPicker, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Click "Create" on the Mix and Match tile - opens the standalone editor
 // 2. Open "Select Products", add "Cassette" via the product picker
@@ -20,8 +20,7 @@ test('Mix and Match: create an offer with a Buy 3 tier preset', async ({ page, a
   await popup.getByRole('button', { name: 'Buy 3' }).click();
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await dashboardTile(app, 'Mix & Match').getByRole('button', { name: /manage/i }).click();
   await refreshAndVerifyInList(app, 'Discounts', /Cassette/i);

--- a/busybuddy-demos/scripts/mix-and-match/03-edit-offer.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/03-edit-offer.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, waitForSaveAndClose, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Open the Mix and Match app, go to the Discounts list tab
 // 2. Open the first existing offer in the list
@@ -22,8 +22,7 @@ test('Mix and Match: switch tier preset and change a tier discount', async ({ pa
   await popup.getByRole('button', { name: 'Buy 4' }).click();
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await refreshAndVerifyInList(app, 'Discounts', /Cassette/i);
 });

--- a/busybuddy-demos/scripts/volume-discounts/02-create-volume-discount.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/02-create-volume-discount.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, openEditorPopup, saveEditor, clickSidepaneItem, addProductViaPicker, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, addProductViaPicker, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Click "Create" on the Volume Discounts tile - opens the standalone editor
 // 2. Open "Select Products", add "Discman" via the product picker
@@ -17,8 +17,7 @@ test('Volume Discounts: create a discount with quantity-break tiers', async ({ p
   await expect(popup.getByText(/buy 2, get 10% off/i)).toBeVisible();
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /manage/i }).click();
   await refreshAndVerifyInList(app, 'Discounts', /Discman/i);

--- a/busybuddy-demos/scripts/volume-discounts/03-edit-volume-discount.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/03-edit-volume-discount.spec.js
@@ -1,4 +1,4 @@
-import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, refreshAndVerifyInList } from '../../fixtures/app.js';
+import { test, expect, dashboardTile, gotoTab, openEditorPopup, saveEditor, waitForSaveAndClose, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Open the Volume Discounts app, go to the Discounts list tab
 // 2. Open the first existing discount in the list
@@ -28,8 +28,7 @@ test('Volume Discounts: adjust a quantity-break threshold and percentage', async
   await discountInput.fill('25');
 
   await saveEditor(popup);
-  await expect(popup.getByText(/saved|success/i)).toBeVisible({ timeout: 15_000 });
-  await popup.close();
+  await waitForSaveAndClose(popup);
 
   await refreshAndVerifyInList(app, 'Discounts', /Discman/i);
 });


### PR DESCRIPTION
## Summary
- After the discount-value fix (PR #267), `bundle-discounts/02-create-bundle.spec.js` progressed past everything and failed at `expect(popup.getByText(/saved|success/i)).toBeVisible({timeout: 15_000})` right after `saveEditor(popup)`.
- Root cause, confirmed via source: the standalone editor runs without App Bridge (`useEditorNavigation.js`), so every editor's success toast (`shopify?.toast?.show(...)`) silently no-ops there - there is no "saved" text ever rendered. All 5 apps' `handleSave` immediately call `closeEditor()` -> `window.close()` on a successful save, so **the popup closing on its own is the actual success signal**, not a toast.
- This same broken 3-line pattern (`saveEditor` + wait-for-toast + `popup.close()`) existed identically in all 11 create/edit specs across all 5 apps - not just bundle-discounts.

## Fix
- Added `waitForSaveAndClose(popup)` to `fixtures/app.js`, which waits for the popup's `close` event instead of a toast that can never appear.
- Replaced the broken pattern in all 11 affected specs (Announcement Bar 02/03/07, Bundle Discounts 02/03, BOGO 02/03, Volume Discounts 02/03, Mix and Match 02/03).
- Removed the now-unused `expect` import from the 3 files where it was the only usage.

## Test plan
- [ ] Re-run `busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js` and confirm it passes end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_