### PR TITLE
Fix two real bugs blocking new-discount creation in standalone editors

### DIFF
--- a/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
+++ b/web/frontend/apps/bundle-discounts/StandardBundleEditor.jsx
@@ -122,6 +122,12 @@ export const StandardBundleEditor = () => {
   // Get bundle ID from URL params (if editing existing bundle)
   const { id } = useParams();
   const { closeEditor } = useEditorNavigation();
+  // No App Bridge in the standalone editor (see useEditorNavigation.js), so
+  // there's no toast host to show one on. Declaring shopify as undefined
+  // (rather than leaving it unreferenced) makes every `shopify?.toast?.show`
+  // call below a safe no-op instead of a ReferenceError that aborts
+  // handleSave before it can reach closeEditor().
+  const shopify = undefined;
 
   // Loading state for fetching bundle data
   const [isLoading, setIsLoading] = useState(!!id);
@@ -474,7 +480,7 @@ export const StandardBundleEditor = () => {
       discountType: discountType,
       discountValue: parseFloat(discountValue) || 0,
       status: bundleEnabled,
-      internalName: bundleInternalName,
+      internalName: bundleInternalName && bundleInternalName.trim() !== '' ? bundleInternalName.trim() : bundleTitle.trim(),
       type: "Bundle Discount",
       bundlePriority: parseInt(bundlePriority) || 0,
       widgetAppearance: {

--- a/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
+++ b/web/frontend/apps/buy-one-get-one/BuyXGetYEditor.jsx
@@ -117,6 +117,12 @@ export const BuyXGetYEditor = () => {
   // Get bundle ID from URL params (if editing existing bundle)
   const { id } = useParams();
   const { closeEditor } = useEditorNavigation();
+  // No App Bridge in the standalone editor (see useEditorNavigation.js), so
+  // there's no toast host to show one on. Declaring shopify as undefined
+  // (rather than leaving it unreferenced) makes every `shopify?.toast?.show`
+  // call below a safe no-op instead of a ReferenceError that aborts
+  // handleSave before it can reach closeEditor().
+  const shopify = undefined;
 
   // Loading state for fetching bundle data
   const [isLoading, setIsLoading] = useState(!!id);
@@ -487,7 +493,7 @@ export const BuyXGetYEditor = () => {
       discountType: discountType,
       discountValue: discountType === 'Free Gift' ? 100 : parseFloat(discountValue) || 0,
       status: bundleEnabled,
-      internalName: bundleInternalName,
+      internalName: bundleInternalName && bundleInternalName.trim() !== '' ? bundleInternalName.trim() : bundleTitle.trim(),
       type: "Buy One Get One",
       bundlePriority: parseInt(bundlePriority) || 0,
       widgetAppearance: {

--- a/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixAndMatchEditor.jsx
@@ -122,6 +122,12 @@ export const MixAndMatchEditor = () => {
   // Get bundle ID from URL params (if editing existing bundle)
   const { id } = useParams();
   const { closeEditor } = useEditorNavigation();
+  // No App Bridge in the standalone editor (see useEditorNavigation.js), so
+  // there's no toast host to show one on. Declaring shopify as undefined
+  // (rather than leaving it unreferenced) makes every `shopify?.toast?.show`
+  // call below a safe no-op instead of a ReferenceError that aborts
+  // handleSave before it can reach closeEditor().
+  const shopify = undefined;
 
   // Loading state for fetching bundle data
   const [isLoading, setIsLoading] = useState(!!id);
@@ -442,7 +448,7 @@ export const MixAndMatchEditor = () => {
       discountType: discountType,
       discountValue: parseFloat(discountValue) || 0,
       status: bundleEnabled,
-      internalName: bundleInternalName,
+      internalName: bundleInternalName && bundleInternalName.trim() !== '' ? bundleInternalName.trim() : bundleTitle.trim(),
       type: "Mix and Match",
       bundlePriority: parseInt(bundlePriority) || 0,
       selectedTier: selectedTier,

--- a/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeDiscountEditor.jsx
@@ -114,6 +114,12 @@ export const VolumeDiscountEditor = () => {
   // Get bundle ID from URL params (if editing existing bundle)
   const { id } = useParams();
   const { closeEditor } = useEditorNavigation();
+  // No App Bridge in the standalone editor (see useEditorNavigation.js), so
+  // there's no toast host to show one on. Declaring shopify as undefined
+  // (rather than leaving it unreferenced) makes every `shopify?.toast?.show`
+  // call below a safe no-op instead of a ReferenceError that aborts
+  // handleSave before it can reach closeEditor().
+  const shopify = undefined;
 
   // Loading state for fetching bundle data
   const [isLoading, setIsLoading] = useState(!!id);
@@ -459,7 +465,7 @@ export const VolumeDiscountEditor = () => {
       discountType: discountType,
       discountValue: parseFloat(discountValue) || 0,
       status: bundleEnabled,
-      internalName: bundleInternalName,
+      internalName: bundleInternalName && bundleInternalName.trim() !== '' ? bundleInternalName.trim() : bundleTitle.trim(),
       type: "Volume Discount",
       bundlePriority: parseInt(bundlePriority) || 0,
       widgetAppearance: {


### PR DESCRIPTION
## Summary

Found via a diagnostic (`save-flow-probe.spec.js`) that captured the actual `/api/bundles` response and browser console output during a real create-bundle flow. **These are real production bugs, not test-script issues** - every merchant using the standalone editor (opened in a new tab, outside the App Bridge iframe) to create a new Bundle, BOGO, Volume, or Mix and Match discount hits this today.

### Bug 1: `internalName` never populated for new discounts
`bundleInternalName` is only set when loading an *existing* discount for editing (`setBundleInternalName(bundle.internalName)`). For a new discount it stays `''` from `useState('')`, and the backend's Mongoose schema requires it - so every new-discount save fails with `500: "internalName: Path \`internalName\` is required."` The original embedded (App Bridge) editors already handle this with a fallback-to-title expression; it was dropped when the standalone editors were split out. Restored the same fallback (`bundleInternalName || bundleTitle`) in all 4 shared-picker editors.

### Bug 2: `shopify?.toast?.show(...)` throws `ReferenceError`
`shopify` is never imported or declared in the standalone editors (the embedded editors get it via `const shopify = useAppBridge()`, which needs an App Bridge provider the standalone editor deliberately doesn't have). Optional chaining only guards a declared-but-falsy value, not a fully unbound identifier, so this threw `ReferenceError: shopify is not defined` on every validation message *and* on the success path - aborting execution before `closeEditor()` (→ `window.close()`) could ever run. Declared `const shopify = undefined;` so every `shopify?.toast?.show(...)` call becomes the safe no-op it was clearly intended to be.

Announcement Bar's editor isn't affected by either bug: its `internalName` has a real default value and it never references `shopify` at all.

## Test plan
- [ ] Deploy to production
- [ ] Re-run `busybuddy-demos/scripts/_diagnostics/save-flow-probe.spec.js` and confirm `/api/bundles` now returns 200/201 and the popup closes
- [ ] Re-run `busybuddy-demos/scripts/bundle-discounts/02-create-bundle.spec.js` end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_