### PR TITLE
Add diagnostic to list currently available (untagged) products

### DIFF
--- a/busybuddy-demos/scripts/_diagnostics/available-products-probe.spec.js
+++ b/busybuddy-demos/scripts/_diagnostics/available-products-probe.spec.js
@@ -1,0 +1,20 @@
+import { test, dashboardTile, openEditorPopup } from '../../fixtures/app.js';
+
+// TEMPORARY DIAGNOSTIC - lists the currently available (untagged,
+// bundles:false AND tag_not:busybuddybundles) products, to pick replacement
+// search terms for demo specs whose products have since been consumed by
+// earlier bundle-creation runs (products get tagged busybuddybundles once
+// used in any bundle-type discount, permanently excluding them from every
+// app's picker after that). Safe to delete once resolved.
+test('DIAGNOSTIC: currently available products', async ({ page, app }) => {
+  const popup = await openEditorPopup(page, () =>
+    dashboardTile(app, 'Bundle Discounts').getByRole('button', { name: /create/i }).click()
+  );
+
+  const responsePromise = popup.waitForResponse((res) => res.url().includes('/api/products') && !res.url().includes('search='), { timeout: 15_000 });
+  await popup.reload();
+  const response = await responsePromise;
+  const body = await response.json();
+  const titles = (body.data?.edges || []).map((e) => e.node.title);
+  console.log('AVAILABLE_PRODUCTS', JSON.stringify(titles));
+});


### PR DESCRIPTION
## Summary
- Products get tagged `busybuddybundles` once used in any bundle-type discount (`web/backend/controller/bundles/index.js:531`), which permanently excludes them from every app's picker afterward (`tag_not:busybuddybundles` filter in `getProducts`).
- Batch run of the other 4 previously-failing specs surfaced two distinct issues: `mix-and-match/02` and `07` search for `"Cassette"`, which never existed in the 25-product seed data at all; `volume-discounts/02` searches for `"Discman"` (matches "Sony Discman"), which may have been consumed by an earlier bundle creation.
- This diagnostic lists the currently available (untagged) products so replacement search terms can be picked from confirmed-available inventory rather than guessed.

Temporary - safe to delete once resolved.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_