### PR TITLE
Fix BOGO list-verification to check title instead of product name

### DIFF
--- a/busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js
@@ -28,6 +28,12 @@ test('BOGO: create a Buy X Get Y offer', async ({ page, app }) => {
   await saveEditor(popup);
   await waitForSaveAndClose(popup);
 
+  // Unlike Bundle/Volume/Mix and Match, BOGO's payload sends its products
+  // as productsX/productsY (BuyXGetYEditor.jsx), not the shared `products`
+  // field the Discounts list badges are rendered from
+  // (BundelDiscountList.jsx) - so no product name ever appears in the
+  // list row for a BOGO offer. Verify via the title shown instead, which
+  // BundelDiscountList.jsx does render.
   await dashboardTile(app, 'Buy One Get One').getByRole('button', { name: /manage/i }).click();
-  await refreshAndVerifyInList(app, 'Discounts', /Sony Walkman/i);
+  await refreshAndVerifyInList(app, 'Discounts', /Buy X Get Y - Save More/i);
 });

--- a/busybuddy-demos/scripts/buy-one-get-one/03-edit-bogo.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/03-edit-bogo.spec.js
@@ -22,5 +22,8 @@ test('BOGO: edit the "get" product selection and discount', async ({ page, app }
   await saveEditor(popup);
   await waitForSaveAndClose(popup);
 
-  await refreshAndVerifyInList(app, 'Discounts', /Sony Walkman/i);
+  // BOGO's payload sends products as productsX/productsY, not the shared
+  // `products` field the Discounts list badges render from - see
+  // 02-create-bogo.spec.js. Verify via the title instead.
+  await refreshAndVerifyInList(app, 'Discounts', /Buy X Get Y - Save More/i);
 });


### PR DESCRIPTION
## Summary
- `buy-one-get-one/02-create-bogo.spec.js` actually succeeded through save/close (both real save bugs from PR #270 fixed), but failed at the final list-verification step waiting for "Sony Walkman" text.
- Root cause: BOGO's payload sends products as `productsX`/`productsY` (`BuyXGetYEditor.jsx`), not the shared `products` field `BundelDiscountList.jsx` renders badges from. Unlike Bundle/Volume/Mix and Match (which all populate `products`), a BOGO offer's Discounts list row never shows a product name - only its title.
- Same pattern existed in `buy-one-get-one/03-edit-bogo.spec.js`.

## Fix
- Both specs now verify via the offer's title (`/Buy X Get Y - Save More/i`, matching `BuyXGetYEditor.jsx`'s default `bundleTitle`) instead of a product name that structurally can't appear in the list.

## Test plan
- [ ] Re-run `busybuddy-demos/scripts/buy-one-get-one/02-create-bogo.spec.js` and confirm it passes end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_