### PR TITLE
Fix mix-and-match tier-preset bugs; add diagnostic for Palm Pilot search

### DIFF
--- a/busybuddy-demos/scripts/_diagnostics/palm-pilot-probe.spec.js
+++ b/busybuddy-demos/scripts/_diagnostics/palm-pilot-probe.spec.js
@@ -1,0 +1,29 @@
+import { test, dashboardTile, openEditorPopup, clickSidepaneItem } from '../../fixtures/app.js';
+
+// TEMPORARY DIAGNOSTIC - volume-discounts/02-create-volume-discount.spec.js
+// times out searching for "Palm Pilot" even though nothing in today's runs
+// should have consumed it. Captures the raw /api/products?search=Palm+Pilot
+// response to settle whether it's a tag exclusion, a multi-word search
+// issue, or something else. Safe to delete once resolved.
+test('DIAGNOSTIC: search for "Palm Pilot"', async ({ page, app }) => {
+  const popup = await openEditorPopup(page, () =>
+    dashboardTile(app, 'Volume Discounts').getByRole('button', { name: /create/i }).click()
+  );
+
+  await clickSidepaneItem(popup, 'Select Products');
+  const addProductsButton = popup.getByRole('button', { name: '+ Add Products' });
+  if (await addProductsButton.isVisible().catch(() => false)) {
+    await addProductsButton.click();
+  }
+
+  const responsePromise = popup.waitForResponse(
+    (res) => res.url().includes('/api/products') && res.url().includes('search='),
+    { timeout: 15_000 }
+  );
+  await popup.getByPlaceholder('Search by product name...').fill('Palm Pilot');
+  const response = await responsePromise;
+  const body = await response.text();
+  console.log('SEARCH_URL', response.url());
+  console.log('SEARCH_STATUS', response.status());
+  console.log('SEARCH_BODY', body.slice(0, 2000));
+});

--- a/busybuddy-demos/scripts/mix-and-match/02-create-offer.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/02-create-offer.spec.js
@@ -1,7 +1,9 @@
 import { test, dashboardTile, openEditorPopup, saveEditor, waitForSaveAndClose, clickSidepaneItem, addProductViaPicker, refreshAndVerifyInList } from '../../fixtures/app.js';
 
 // 1. Click "Create" on the Mix and Match tile - opens the standalone editor
-// 2. Open "Select Products", add "Sega Game Gear" via the product picker
+// 2. Open "Select Products", add 3 products via the product picker (the
+//    "Buy 3" tier requires at least 3 selected products - MixAndMatchEditor.jsx
+//    validates selectedProducts.length >= selectedTier before saving)
 // 3. Open Tier Settings, click the "Buy 3" preset button in the live preview
 // 4. Click Save and wait for the save confirmation
 // 5. Go back to the app, open the Discounts list tab, confirm the new offer is in the list
@@ -13,10 +15,12 @@ test('Mix and Match: create an offer with a Buy 3 tier preset', async ({ page, a
   // "Cassette" was never a seeded product title at all - see
   // scripts/seed-demo-store/products.json. Products also get tagged
   // busybuddybundles once used in any bundle-type discount (across every
-  // app), permanently excluding them from the picker afterward - so this
-  // needs to be a name confirmed currently available, not just real.
+  // app), permanently excluding them from the picker afterward - so these
+  // need to be names confirmed currently available, not just real.
   await clickSidepaneItem(popup, 'Select Products');
   await addProductViaPicker(popup, 'Sega Game Gear');
+  await addProductViaPicker(popup, 'CRT Television');
+  await addProductViaPicker(popup, 'MiniDV Camcorder');
 
   await clickSidepaneItem(popup, 'Tier Settings');
   // "Buy 3" also appears as a plain (non-interactive) form-group label in

--- a/busybuddy-demos/scripts/mix-and-match/07-tier-preset-switching.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/07-tier-preset-switching.spec.js
@@ -3,8 +3,8 @@ import { test, expect, dashboardTile, openEditorPopup, clickSidepaneItem, addPro
 // 1. Click "Create" on the Mix and Match tile
 // 2. Open "Select Products", add "BlackBerry Bold" (needed for the tier preview to render at all)
 // 3. Open Tier Settings
-// 4. Click through all four preset buttons in order: Buy 2, Buy 3, Buy 4, Buy 5
-test('Mix and Match: switch across all Buy 2/3/4/5 tier presets', async ({ page, app }) => {
+// 4. Click through all three preset buttons in order: Buy 2, Buy 3, Buy 4
+test('Mix and Match: switch across all Buy 2/3/4 tier presets', async ({ page, app }) => {
   const popup = await openEditorPopup(page, () =>
     dashboardTile(app, 'Mix & Match').getByRole('button', { name: /create/i }).click()
   );
@@ -19,7 +19,9 @@ test('Mix and Match: switch across all Buy 2/3/4/5 tier presets', async ({ page,
   await addProductViaPicker(popup, 'BlackBerry Bold');
 
   await clickSidepaneItem(popup, 'Tier Settings');
-  for (const tier of ['Buy 2', 'Buy 3', 'Buy 4', 'Buy 5']) {
+  // The live-preview tier presets object (MixAndMatchEditor.jsx) only
+  // defines tiers 2, 3, and 4 - there is no "Buy 5" preset button to click.
+  for (const tier of ['Buy 2', 'Buy 3', 'Buy 4']) {
     const tierButton = popup.getByRole('button', { name: tier });
     await tierButton.click();
     await expect(tierButton).toBeVisible();


### PR DESCRIPTION
## Summary

Re-running the 4 previously-failing specs after PR #274 showed BOGO now passes, but surfaced two new, distinct, genuine bugs in the mix-and-match specs (unmasked now that the earlier "Cassette doesn't exist" failure is gone):

### `mix-and-match/02-create-offer.spec.js`
`MixAndMatchEditor.jsx`'s `handleSave` validates `selectedProducts.length >= selectedTier` before saving. The spec only ever added 1 product then selected the "Buy 3" tier preset - validation silently blocked the save (the toast now safely no-ops per PR #270, so it just `return`s), meaning the POST never fired and the popup never closed. This bug existed even before today's fixes; it was simply masked by the earlier failure.

### `mix-and-match/07-tier-preset-switching.spec.js`
The live-preview `tiers` object in `MixAndMatchEditor.jsx` only defines tiers 2, 3, and 4 - there is no "Buy 5" preset button to click at all.

### `volume-discounts/02-create-volume-discount.spec.js`
Still times out searching for "Palm Pilot", but nothing in today's runs should have consumed that specific product. Added a temporary diagnostic to check the raw search response directly instead of guessing further.

## Fix
- `mix-and-match/02`: now adds 3 products before selecting the "Buy 3" tier.
- `mix-and-match/07`: drops "Buy 5" from the loop (only 2/3/4 exist).
- Added `palm-pilot-probe.spec.js` (temporary) to get direct evidence on the Palm Pilot search issue.

## Test plan
- [ ] Re-run `mix-and-match/02` and `mix-and-match/07` and confirm they pass
- [ ] Run `palm-pilot-probe.spec.js` to determine the Palm Pilot search issue


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_