### PR TITLE
Bump waitForSaveAndClose timeout to 30s

### DIFF
--- a/busybuddy-demos/fixtures/app.js
+++ b/busybuddy-demos/fixtures/app.js
@@ -156,7 +156,7 @@ export async function saveEditor(popup) {
  * on its own IS the confirmation.
  */
 export async function waitForSaveAndClose(popup) {
-  await popup.waitForEvent('close', { timeout: 15_000 });
+  await popup.waitForEvent('close', { timeout: 30_000 });
 }
 
 export async function gotoStorefrontHome(page) {


### PR DESCRIPTION
## Summary
- After the Volume Discounts `optionSelections` fix (PR #278) deployed, `volume-discounts/02-create-volume-discount.spec.js` still failed at `waitForSaveAndClose`, but the failure screenshot shows the Save button reading **"Saving..."** at the moment of timeout.
- `setIsSaving(true)` in `VolumeDiscountEditor.jsx`'s `handleSave` only runs after all client-side validations pass, so this proves the fetch actually fired and was genuinely in flight - not blocked by validation like the earlier Mix and Match case (PR #275).
- Creating a real Shopify Bundle via their Bundles API (component mapping + purchase options) is a heavier operation than the other bundle types - 15s was too tight.

## Fix
Bumped `waitForSaveAndClose`'s timeout from 15s to 30s. This is shared by all 11 create/edit specs, so it also gives more headroom generally without masking real failures (a genuinely broken save still times out and fails).

## Test plan
- [ ] Re-run `volume-discounts/02-create-volume-discount.spec.js` and confirm it passes end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01PPFHAtum1ReeYdWSsWhaA2)_