### PR TITLE
chore: ignore .claude/ local tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ shopify.app.toml
 
 # Playwright
 extensions/bogo-shopify-app/tests/e2e/.playwright-output/
+
+# Claude Code local tooling state (worktrees, local settings) — never project source
+.claude/


### PR DESCRIPTION
## Problem

Claude Code sessions leave worktree checkouts and local settings under `.claude/` (in this case a 422MB leftover agent worktree). It's environment-local tooling state, not project source, and wasn't gitignored — so it shows up as untracked on every session that used a worktree-isolated subagent.

## Solution

Add `.claude/` to `.gitignore`.

## Checklist

- [x] No `console.log` in production paths
- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] ES modules only — no `require()`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01RwYNchxsiaH54huqH1em4y)_