### PR TITLE
chore: rename node-ci.yml to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Install, Test, Build & E2E
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ gh issue edit <ISSUE_NUMBER> --add-label "ready-to-implement-legacy"
 
 ### CI
 
-`.github/workflows/node-ci.yml` runs on every PR targeting `main`:
+`.github/workflows/ci.yml` runs on every PR targeting `main`:
 - Installs all dependency trees (root, `web/`, `web/frontend/`, `extensions/cart-transformer/`)
 - Runs all 3 Vitest suites
 - Builds frontend with `CI=true`


### PR DESCRIPTION
## Problem

`node-ci.yml` undersold what the workflow actually does: installs across every workspace, runs backend/frontend/extension unit tests, builds the frontend + docs site, and runs a Playwright e2e job — not just "Node CI."

## Solution

Renamed the file to `ci.yml` and its display name to "Install, Test, Build & E2E". Updated the one doc reference (`README.md`).

## Checklist

- [x] No functional change — filename + display name only


---
_Generated by [Claude Code](https://claude.ai/code/session_01RwYNchxsiaH54huqH1em4y)_