### PR TITLE
ci: extract storefront-e2e into a thin caller onto agent-ops's shared e2e pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Install, Test, Build & E2E
+name: Install, Test & Build
 
 on:
   pull_request:
@@ -78,66 +78,3 @@ jobs:
           path: |
             web/coverage/
             web/frontend/coverage/
-
-  # Browser-driven e2e coverage of the storefront theme extension
-  # (extensions/bogo-shopify-app). There is intentionally no equivalent
-  # suite for the admin app here: it would need to navigate through Vite's
-  # dev-server proxy and shopify.ensureInstalledOnShop(), which requires a
-  # live backend plus a real installed-shop session - infra this workflow
-  # doesn't stand up. (A prior "smoke" suite attempted this without that
-  # infra and, due to a separate testMatch bug, silently ran 0 tests for
-  # a while before being removed.)
-  storefront-e2e:
-    runs-on: ubuntu-latest
-    needs: test-and-build
-    if: github.event.pull_request.draft == false
-    # The default GITHUB_TOKEN in this repo doesn't carry pull-requests:
-    # write, so the "Post PR comment" step below 403'd with "Resource not
-    # accessible by integration" even when all 11 tests passed - the job
-    # showed red for a permissions problem, not a test failure.
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: extensions/bogo-shopify-app/package-lock.json
-
-      - name: Install bogo-shopify-app dependencies
-        run: npm ci
-        working-directory: extensions/bogo-shopify-app
-
-      - name: Install Playwright Chromium
-        run: npx playwright install chromium --with-deps
-        working-directory: extensions/bogo-shopify-app
-
-      - name: Run storefront e2e tests
-        run: npm run test:e2e
-        working-directory: extensions/bogo-shopify-app
-
-      - name: Post PR comment
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const passed = '${{ job.status }}' === 'success';
-            const icon   = passed ? '✅' : '❌';
-            const status = passed ? 'PASSED' : 'FAILED';
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo:  context.repo.repo,
-              issue_number: context.issue.number,
-              body: [
-                `## ${icon} Storefront E2E Tests — ${status}`,
-                '',
-                `See the [CI run](${runUrl}) for details.`,
-                '',
-                `> Covers: announcement bar rendering + enable/disable/date-window gating + email capture, inactive tab title/favicon + enable/disable/date-window gating.`,
-              ].join('\n'),
-            });

--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -1,0 +1,38 @@
+# Thin caller for the shared e2e pipeline (BusyBuddy_v2#285 Phase 6).
+# Browser-driven e2e coverage of the storefront theme extension
+# (extensions/bogo-shopify-app). There is intentionally no equivalent
+# suite for the admin app here: it would need to navigate through Vite's
+# dev-server proxy and shopify.ensureInstalledOnShop(), which requires a
+# live backend plus a real installed-shop session - infra this workflow
+# doesn't stand up. (A prior "smoke" suite attempted this without that
+# infra and, due to a separate testMatch bug, silently ran 0 tests for
+# a while before being removed.)
+#
+# Covers: announcement bar rendering + enable/disable/date-window gating +
+# email capture, inactive tab title/favicon + enable/disable/date-window
+# gating.
+
+name: e2e-pipeline
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      record_video:
+        type: boolean
+        default: false
+
+jobs:
+  playwright:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: 11thandOrange/agent-ops/.github/workflows/e2e-pipeline-reusable.yml@main
+    with:
+      working_directory: extensions/bogo-shopify-app
+      install_command: "npm ci && npx playwright install chromium --with-deps"
+      test_command: "npm run test:e2e"
+      needs_emulator: false
+      record_video: ${{ inputs.record_video || false }}

--- a/README.md
+++ b/README.md
@@ -189,3 +189,8 @@ gh issue edit <ISSUE_NUMBER> --add-label "ready-to-implement-legacy"
 - Installs all dependency trees (root, `web/`, `web/frontend/`, `extensions/cart-transformer/`)
 - Runs all 3 Vitest suites
 - Builds frontend with `CI=true`
+
+`.github/workflows/e2e-pipeline.yml` is a thin caller into the shared
+`11thandOrange/agent-ops` e2e pipeline — Playwright storefront e2e tests
+for `extensions/bogo-shopify-app`, run in parallel with `ci.yml` on every
+PR targeting `main`.


### PR DESCRIPTION
Per #285 Phase 6.

## What changed
- `ci.yml`: removed the `storefront-e2e` job (and its `Install, Test, Build & E2E` → `Install, Test & Build` name update, since e2e no longer lives here). `test-and-build` is unchanged.
- `e2e-pipeline.yml` (new): thin caller into `11thandOrange/agent-ops`'s `e2e-pipeline-reusable.yml@main` — same Playwright commands (`npm ci && npx playwright install chromium --with-deps`, `npm run test:e2e`), `working_directory: extensions/bogo-shopify-app`, `needs_emulator: false`.
- `README.md`: documented the new caller workflow alongside the existing `ci.yml` CI section.

## Why
The old `storefront-e2e` job duplicated plumbing (checkout, artifact upload, PR comment, draft-PR skip) that's now centralized in agent-ops's shared e2e pipeline — the same reusable workflow OrderMate's Espresso e2e will call via `needs_emulator: true`. BusyBuddy_v2 keeps only its own `install_command`/`test_command`.

## Behavior notes
- `coverage_manifest_path` is left unset (no `e2e-coverage.yaml` exists yet for this repo) — skips the flow-coverage check, same as before this migration (no such check existed previously either).
- The old job's `needs: test-and-build` (same-workflow job dependency) isn't reproducible across separate workflow files without a `workflow_run` trigger, so `e2e-pipeline.yml` now runs in parallel with `ci.yml` rather than after it. Draft-PR skip is preserved.
- Depends on `11thandOrange/agent-ops` PR #5 (`e2e-pipeline-reusable.yml`, still open) — this workflow will fail to resolve `uses:` until that merges.

Blocks: none. Blocked by: agent-ops#5.

Does not touch `main` beyond this PR itself; not merging without explicit instruction.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwYNchxsiaH54huqH1em4y)_