### PR TITLE
ci: wire coverage_manifest_path against the storefront e2e suite

### DIFF
--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -36,3 +36,4 @@ jobs:
       test_command: "npm run test:e2e"
       needs_emulator: false
       record_video: ${{ inputs.record_video || false }}
+      coverage_manifest_path: e2e-coverage.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ shopify.app.toml
 
 # Playwright
 extensions/bogo-shopify-app/tests/e2e/.playwright-output/
+extensions/bogo-shopify-app/test-results/
 
 # Claude Code local tooling state (worktrees, local settings) — never project source
 .claude/

--- a/extensions/bogo-shopify-app/e2e-coverage.yaml
+++ b/extensions/bogo-shopify-app/e2e-coverage.yaml
@@ -1,0 +1,23 @@
+# Critical-flow manifest for e2e-pipeline-reusable.yml's coverage_manifest_path check
+# (agent-ops's check-flow-coverage.mjs, BusyBuddy_v2#285 Phase 6).
+#
+# Convention: each flow string must be a literal substring (case-insensitive) of a
+# PASSING Playwright test title in tests/e2e/storefront.spec.js. If a test title changes,
+# update the matching flow here too - the check has no other way to know the flow still
+# has coverage.
+
+flows:
+  # Announcement bar (tests/e2e/storefront.spec.js: "Announcement bar rendering")
+  - renders the bar and message
+  - no active bar
+  - returns an error status
+  - safe DOM construction
+  - email capture form
+  - invalid email client-side
+
+  # Inactive tab message (tests/e2e/storefront.spec.js: "Inactive tab message")
+  - changes the tab title when hidden
+  - feature is disabled
+  - does not show before startDate
+  - does not show after endDate
+  - within startDate/endDate range

--- a/extensions/bogo-shopify-app/playwright.config.js
+++ b/extensions/bogo-shopify-app/playwright.config.js
@@ -21,7 +21,10 @@ const executablePath = fs.existsSync(SANDBOX_CHROMIUM_PATH) ? SANDBOX_CHROMIUM_P
 export default defineConfig({
   testDir: './tests/e2e',
   outputDir: './tests/e2e/.playwright-output',
-  reporter: [['list']],
+  // 'json' output feeds agent-ops's check-flow-coverage.mjs (e2e-pipeline-reusable.yml's
+  // coverage_manifest_path check) - it reads test-results/results.json to verify every
+  // flow in e2e-coverage.yaml has a matching passing test.
+  reporter: [['list'], ['json', { outputFile: 'test-results/results.json' }]],
   timeout: 30_000,
 
   use: {


### PR DESCRIPTION
Per #285 Phase 6.

## What changed
- `extensions/bogo-shopify-app/e2e-coverage.yaml` (new): lists the 11 critical flows `tests/e2e/storefront.spec.js` covers (announcement bar render/disabled/error/XSS-safety/email-capture, inactive tab title-swap/disabled/date-window), each a literal substring of the matching Playwright test's title.
- `playwright.config.js`: added a `json` reporter output (`test-results/results.json`) alongside the existing `list` reporter — `check-flow-coverage.mjs` reads this file; without it there was nothing for the check to parse.
- `e2e-pipeline.yml`: added `coverage_manifest_path: e2e-coverage.yaml` so agent-ops's flow-coverage check actually runs instead of being skipped (it was left unset in #293).

## Why
#293 shipped the caller with `coverage_manifest_path` unset — the check existed in the shared pipeline but nothing in this repo used it yet. This closes that gap: every declared flow now has to keep a matching passing test, not just "the suite passed."

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwYNchxsiaH54huqH1em4y)_