### PR TITLE
fix(wiki-generate): call the 11thandOrange/agent-ops fork, not HeyItsChloe/agent-ops directly

### DIFF
--- a/.github/workflows/wiki-generate.yml
+++ b/.github/workflows/wiki-generate.yml
@@ -1,8 +1,13 @@
 # Thin caller for agent-ops's shared wiki generator (issue #286). Real logic
-# lives once, centrally, in HeyItsChloe/agent-ops's
-# .github/workflows/wiki-generate-reusable.yml - see that file's own header
-# comment for the full flow (checkout target + control repo -> run
+# lives once, centrally, in wiki-generate-reusable.yml - see that file's own
+# header comment for the full flow (checkout target + control repo -> run
 # wiki-generate.mjs -> commit generated changes -> build -> deploy to Pages).
+#
+# Points at the 11thandOrange/agent-ops fork, not HeyItsChloe/agent-ops
+# directly: secrets: inherit only propagates within the calling repo's own
+# org/enterprise, and this fork exists precisely so 11thandOrange-owned
+# repos can consume agent-ops content - including this reusable workflow -
+# from a same-org source (see that fork's CONTRIBUTING.md).
 
 name: wiki-generate
 
@@ -23,7 +28,7 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: HeyItsChloe/agent-ops/.github/workflows/wiki-generate-reusable.yml@main
+    uses: 11thandOrange/agent-ops/.github/workflows/wiki-generate-reusable.yml@main
     with:
       site_dir: docs
       config_path: wiki.config.yaml


### PR DESCRIPTION
## Summary
- `secrets: inherit` only propagates within the calling repo's own org/enterprise. `HeyItsChloe/agent-ops` is a different account than `11thandOrange`, so every `wiki-generate` run failed pre-flight with `Secret GH_APP_ID is required, but not provided while calling.` even with the secrets correctly configured on this repo.
- `11thandOrange/agent-ops` (synced from upstream via `sync-upstream.yml`) already carries a current copy of `wiki-generate-reusable.yml` and its dependencies (extractors, templates). Pointing the caller there keeps `secrets: inherit` working as-is, with no explicit secret duplication needed.

## Test plan
- [ ] `wiki-generate` workflow run succeeds against the fork


---
_Generated by [Claude Code](https://claude.ai/code/session_01RwYNchxsiaH54huqH1em4y)_