### PR TITLE
feat(wiki): enable authored feature docs via wiki-author.mjs

### DIFF
--- a/.github/workflows/wiki-generate.yml
+++ b/.github/workflows/wiki-generate.yml
@@ -32,4 +32,5 @@ jobs:
     with:
       site_dir: docs
       config_path: wiki.config.yaml
+      author_content: true
     secrets: inherit

--- a/wiki-content/authoring.yaml
+++ b/wiki-content/authoring.yaml
@@ -1,0 +1,38 @@
+# wiki-content/authoring.yaml - authoring manifest for scripts/wiki-author.mjs
+# (agent-ops issue #286). Lists features to auto-draft via the LiteLLM
+# "documentation" alias when author_content: true is set on the
+# wiki-generate.yml caller. facts: are the only ground truth passed to the
+# model - real file/route names confirmed in this repo, nothing invented.
+# wiki-author.mjs never overwrites an existing docs/src/content/features/*.md
+# file, so re-runs are safe.
+
+features:
+  - slug: buy-one-get-one
+    title: "Buy One Get One (BOGO)"
+    order: 1
+    facts: |
+      Frontend page: web/frontend/pages/buy-one-get-one.jsx, rendering
+      web/frontend/apps/buy-one-get-one/buyoneGetone.jsx (a discount editor
+      built on the shared web/frontend/components/BundelDiscountList
+      component). Part of BusyBuddy's Shopify discount-app family alongside
+      bundles, bundle-discount, volume-discounts, and mix-and-match (all
+      under web/frontend/pages/).
+
+  - slug: subscription-management
+    title: "Subscription Management"
+    order: 2
+    facts: |
+      Backend routes at web/backend/routes/subscription/index.js:
+      GET /getUserSubscription, POST /subscribe, POST /cancel-subscription,
+      GET /checkBusyBuddyEnabled, GET /getThemeEditorUrl,
+      POST /toggle-app, GET /app-status/:appId?. Handlers live in
+      web/backend/controller/subscription/index.js. Governs whether the app
+      (and its widgets) are active/enabled for a given shop.
+
+  - slug: announcement-bars
+    title: "Announcement Bars"
+    order: 3
+    facts: |
+      Frontend page: web/frontend/pages/announcement-bar.jsx. Backend
+      routes: web/backend/routes/announcementBars/. A storefront widget
+      merchants configure to show promotional banners.

--- a/wiki.config.yaml
+++ b/wiki.config.yaml
@@ -79,6 +79,12 @@ extractors:
     widgetConfigExport: "widgetConfig"
     planFeaturesExport: "planFeatures"
 
+  # Authored (not derived) - drafted via wiki-author.mjs from
+  # wiki-content/authoring.yaml when author_content: true is set on the
+  # caller, then read verbatim from docs/src/content/features/*.md here.
+  features:
+    enabled: true
+
 output:
   dataDir: "src/data"
   contentDir: "src/content"


### PR DESCRIPTION
Adds `wiki-content/authoring.yaml` (real, verified file/route names only — no prose), sets `author_content: true` on the `wiki-generate.yml` caller so `wiki-author.mjs` drafts `docs/src/content/features/*.md` via the LiteLLM `documentation` alias before extraction, and enables `extractors.features`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwYNchxsiaH54huqH1em4y)_