### PR TITLE
fix(wiki-generate): turn off author_content - LiteLLM gateway unreliable

### DIFF
--- a/.github/workflows/wiki-generate.yml
+++ b/.github/workflows/wiki-generate.yml
@@ -32,5 +32,9 @@ jobs:
     with:
       site_dir: docs
       config_path: wiki.config.yaml
-      author_content: true
+      # author_content left off for now - the LiteLLM gateway wiki-author.mjs
+      # calls into is returning intermittent 500/503s (server-side, outside
+      # this repo's control), which was breaking otherwise-reliable runs.
+      # Re-enable once that service is confirmed stable.
+      author_content: false
     secrets: inherit


### PR DESCRIPTION
`wiki-author.mjs`'s calls to the LiteLLM `documentation` alias are returning intermittent 500/503s from the gateway itself, breaking an otherwise reliably-succeeding pipeline. Turns `author_content` back off; `wiki-content/authoring.yaml` and `extractors.features` stay in place, so this is a one-line re-enable once the gateway is stable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwYNchxsiaH54huqH1em4y)_