### PR TITLE
docs: author feature pages and integrations for the wiki site

### DIFF
--- a/docs/src/content/features/announcement-bars.md
+++ b/docs/src/content/features/announcement-bars.md
@@ -1,0 +1,50 @@
+---
+title: "Announcement Bars"
+order: 3
+summary: "A storefront widget merchants configure to show promotional banners, with full CRUD, an active-bar lookup, and click/impression analytics."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+    - shopify-app-proxy
+runWith:
+  - "Create and edit bars from the Announcement Bar page in the BusyBuddy dashboard."
+  - "The storefront reads the current bar via GET /api/announcement-bars/active."
+  - "Impressions and clicks are recorded via POST /api/announcement-bars/:id/track and surfaced through GET /api/announcement-bars/analytics."
+tradeoffs:
+  - "Analytics are tracked per-bar through a dedicated track endpoint rather than a general analytics pipeline, keeping the feature self-contained but separate from the app-wide analytics routes."
+  - "Like the rest of the suite, the bar only renders on the storefront while BusyBuddy is enabled for the shop (see Subscription Management)."
+notes:
+  - kind: tip
+    body: "Use the /active endpoint to fetch only the bar that should currently display, rather than filtering the full list client-side."
+---
+
+## What it does
+
+Announcement Bars is a storefront widget merchants configure to display promotional
+banners — sales, shipping thresholds, seasonal messaging — across their store. It
+supports creating multiple bars, selecting which is active, and measuring engagement.
+
+## How it works
+
+The dashboard page is `web/frontend/pages/announcement-bar.jsx`. The backend routes live
+under `web/backend/routes/announcementBars/`:
+
+- `POST /` and `GET /` — create and list bars
+- `GET /active` — the bar that should currently display on the storefront
+- `GET /:id`, `PUT /:id`, `DELETE /:id` — read, update, delete a bar
+- `DELETE /bulk` — bulk delete
+- `GET /analytics` and `POST /:id/track` — read and record impression/click analytics
+
+Routes are mounted under `/api/announcement-bars`.
+
+## Configuration & running
+
+Merchants create and edit bars from the Announcement Bar page in the dashboard. The
+storefront fetches the current bar from `GET /active` and reports engagement through
+`POST /:id/track`, which the dashboard reads back via `GET /analytics`. The bar displays
+only while BusyBuddy is enabled for the shop.

--- a/docs/src/content/features/buy-one-get-one.md
+++ b/docs/src/content/features/buy-one-get-one.md
@@ -1,0 +1,48 @@
+---
+title: "Buy One Get One (BOGO)"
+order: 1
+summary: "A Shopify discount app that lets merchants configure buy-X-get-Y promotions from the BusyBuddy dashboard."
+status: stable
+implements:
+  workflows:
+    - ci
+    - e2e-pipeline
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+    - shopify-app-proxy
+runWith:
+  - "Open the BusyBuddy dashboard and choose the Buy One Get One app."
+  - "Create a discount in the editor, set the buy quantity and the reward, then save to publish it to your store."
+  - "Enable the app for the shop from the dashboard's app toggle before the storefront applies it."
+tradeoffs:
+  - "BOGO is one member of BusyBuddy's discount-app family (bundles, bundle-discount, volume-discounts, mix-and-match); they share the BundelDiscountList editor component rather than each owning bespoke UI, which keeps them consistent but couples their editing surface."
+  - "Discount logic runs through Shopify's discount/cart machinery, so behavior is bounded by what the Shopify platform exposes."
+notes:
+  - kind: note
+    body: "BOGO sits inside BusyBuddy's plan-gated app-toggle system: the promotion only affects the storefront while the app is enabled for the shop."
+---
+
+## What it does
+
+Buy One Get One (BOGO) is a Shopify discount app in the BusyBuddy suite. It lets a
+merchant configure "buy X, get Y" promotions — for example, buy one item and get a
+second at a discount or for free — and publish them to their storefront without
+touching theme code.
+
+## How it works
+
+The editor is a frontend page, `web/frontend/pages/buy-one-get-one.jsx`, which renders
+the app under `web/frontend/apps/buy-one-get-one/` (`buyoneGetone.jsx`, plus its
+`BuyXGetYEditor.jsx`, reducers, and actions). It is built on the shared
+`web/frontend/components/BundelDiscountList.jsx` component that the other
+discount apps in the suite reuse. Saved discounts are applied to the storefront through
+Shopify's discount and cart-transform layer.
+
+## Configuration & running
+
+Configure BOGO from the BusyBuddy dashboard: pick the Buy One Get One app, define the
+buy quantity and the reward in the editor, and save. Because BOGO is part of the
+plan-gated app family, the promotion is only live while the app is toggled on for the
+shop.

--- a/docs/src/content/features/subscription-management.md
+++ b/docs/src/content/features/subscription-management.md
@@ -1,0 +1,52 @@
+---
+title: "Subscription Management"
+order: 2
+summary: "Backend routes that govern whether BusyBuddy and its widgets are active and enabled for a given shop."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+    - shopify-app-proxy
+runWith:
+  - "Merchants pick a plan from the dashboard; the frontend calls POST /api/subscription/subscribe."
+  - "The app checks GET /api/subscription/checkBusyBuddyEnabled before applying storefront behavior."
+  - "Individual apps are switched on or off per shop via POST /api/subscription/toggle-app and read back via GET /api/subscription/app-status/:appId?."
+tradeoffs:
+  - "Subscription state is the single gate for the whole suite: if the app is not enabled for a shop, its widgets do not apply, so this route family is a dependency of every other feature."
+  - "Plan tiers are enforced server-side in the controller rather than in the client, so the dashboard reflects — but does not decide — entitlement."
+notes:
+  - kind: important
+    body: "This route family is the source of truth for whether the app is active for a shop. Most other BusyBuddy features check it before doing anything on the storefront."
+---
+
+## What it does
+
+Subscription Management governs whether BusyBuddy — and each of its widgets — is active
+and enabled for a given shop. It handles plan selection, cancellation, the app-level
+enable check, and per-app on/off toggling.
+
+## How it works
+
+The routes live in `web/backend/routes/subscription/index.js` and are handled in
+`web/backend/controller/subscription/index.js`:
+
+- `GET /getUserSubscription` — the shop's current subscription
+- `POST /subscribe` — subscribe to a plan
+- `POST /cancel-subscription` — cancel the subscription
+- `GET /checkBusyBuddyEnabled` — whether the app is enabled for the shop
+- `GET /getThemeEditorUrl` — deep link into the Shopify Theme Editor
+- `POST /toggle-app` — enable or disable an individual app
+- `GET /app-status/:appId?` — read an app's enabled state
+
+All routes are mounted under the `/api` prefix.
+
+## Configuration & running
+
+A merchant selects a plan from the dashboard, which drives `POST /subscribe`. Before any
+widget renders on the storefront, the app consults `GET /checkBusyBuddyEnabled`.
+Merchants turn individual apps on or off with `POST /toggle-app`, and the dashboard
+reflects the current state via `GET /app-status/:appId?`.

--- a/docs/src/data/features.generated.json
+++ b/docs/src/data/features.generated.json
@@ -1,1 +1,108 @@
-[]
+[
+  {
+    "slug": "buy-one-get-one",
+    "title": "Buy One Get One (BOGO)",
+    "summary": "A Shopify discount app that lets merchants configure buy-X-get-Y promotions from the BusyBuddy dashboard.",
+    "order": 1,
+    "status": "stable",
+    "implements": {
+      "workflows": [
+        "ci",
+        "e2e-pipeline"
+      ],
+      "skills": [],
+      "dependencies": [],
+      "integrations": [
+        "shopify-admin-api",
+        "shopify-app-proxy"
+      ]
+    },
+    "runWith": [
+      "Open the BusyBuddy dashboard and choose the Buy One Get One app.",
+      "Create a discount in the editor, set the buy quantity and the reward, then save to publish it to your store.",
+      "Enable the app for the shop from the dashboard's app toggle before the storefront applies it."
+    ],
+    "tradeoffs": [
+      "BOGO is one member of BusyBuddy's discount-app family (bundles, bundle-discount, volume-discounts, mix-and-match); they share the BundelDiscountList editor component rather than each owning bespoke UI, which keeps them consistent but couples their editing surface.",
+      "Discount logic runs through Shopify's discount/cart machinery, so behavior is bounded by what the Shopify platform exposes."
+    ],
+    "notes": [
+      {
+        "kind": "note",
+        "body": "BOGO sits inside BusyBuddy's plan-gated app-toggle system: the promotion only affects the storefront while the app is enabled for the shop."
+      }
+    ],
+    "contentFile": "features/buy-one-get-one.md",
+    "_sourceHash": "1b5abf27052987b14ed1f6f20c77cecec842c2ce"
+  },
+  {
+    "slug": "subscription-management",
+    "title": "Subscription Management",
+    "summary": "Backend routes that govern whether BusyBuddy and its widgets are active and enabled for a given shop.",
+    "order": 2,
+    "status": "stable",
+    "implements": {
+      "workflows": [
+        "ci"
+      ],
+      "skills": [],
+      "dependencies": [],
+      "integrations": [
+        "shopify-admin-api",
+        "shopify-app-proxy"
+      ]
+    },
+    "runWith": [
+      "Merchants pick a plan from the dashboard; the frontend calls POST /api/subscription/subscribe.",
+      "The app checks GET /api/subscription/checkBusyBuddyEnabled before applying storefront behavior.",
+      "Individual apps are switched on or off per shop via POST /api/subscription/toggle-app and read back via GET /api/subscription/app-status/:appId?."
+    ],
+    "tradeoffs": [
+      "Subscription state is the single gate for the whole suite: if the app is not enabled for a shop, its widgets do not apply, so this route family is a dependency of every other feature.",
+      "Plan tiers are enforced server-side in the controller rather than in the client, so the dashboard reflects — but does not decide — entitlement."
+    ],
+    "notes": [
+      {
+        "kind": "important",
+        "body": "This route family is the source of truth for whether the app is active for a shop. Most other BusyBuddy features check it before doing anything on the storefront."
+      }
+    ],
+    "contentFile": "features/subscription-management.md",
+    "_sourceHash": "4a462d2c2c0566ede5c7af0606e912d9480af8df"
+  },
+  {
+    "slug": "announcement-bars",
+    "title": "Announcement Bars",
+    "summary": "A storefront widget merchants configure to show promotional banners, with full CRUD, an active-bar lookup, and click/impression analytics.",
+    "order": 3,
+    "status": "stable",
+    "implements": {
+      "workflows": [
+        "ci"
+      ],
+      "skills": [],
+      "dependencies": [],
+      "integrations": [
+        "shopify-admin-api",
+        "shopify-app-proxy"
+      ]
+    },
+    "runWith": [
+      "Create and edit bars from the Announcement Bar page in the BusyBuddy dashboard.",
+      "The storefront reads the current bar via GET /api/announcement-bars/active.",
+      "Impressions and clicks are recorded via POST /api/announcement-bars/:id/track and surfaced through GET /api/announcement-bars/analytics."
+    ],
+    "tradeoffs": [
+      "Analytics are tracked per-bar through a dedicated track endpoint rather than a general analytics pipeline, keeping the feature self-contained but separate from the app-wide analytics routes.",
+      "Like the rest of the suite, the bar only renders on the storefront while BusyBuddy is enabled for the shop (see Subscription Management)."
+    ],
+    "notes": [
+      {
+        "kind": "tip",
+        "body": "Use the /active endpoint to fetch only the bar that should currently display, rather than filtering the full list client-side."
+      }
+    ],
+    "contentFile": "features/announcement-bars.md",
+    "_sourceHash": "4afb7f3a03468ca28f2fb29db381edf03b128140"
+  }
+]

--- a/docs/src/data/integrations.generated.json
+++ b/docs/src/data/integrations.generated.json
@@ -1,1 +1,77 @@
-[]
+[
+  {
+    "slug": "shopify-admin-api",
+    "name": "Shopify Admin API",
+    "kind": "api",
+    "summary": "The Shopify platform the app is built on - discounts, products, subscriptions, and theme integration all go through the Admin API.",
+    "auth": "OAuth session / admin API access token",
+    "url": "https://shopify.dev/docs/api/admin",
+    "notes": [
+      {
+        "kind": "note",
+        "body": "Session-authenticated backend routes under /api resolve the shop from the Shopify session."
+      }
+    ],
+    "_sourceHash": "b54cdf5decbd5e160d05ef6889a288af4a1f8549"
+  },
+  {
+    "slug": "shopify-app-proxy",
+    "name": "Shopify App Proxy",
+    "kind": "api",
+    "summary": "Serves BusyBuddy's public storefront endpoints (the frontStore router) so the theme can call the app without a merchant session.",
+    "auth": "App-proxy signature (no merchant session)",
+    "url": "https://shopify.dev/docs/apps/build/online-store/display-dynamic-store-data",
+    "notes": [
+      {
+        "kind": "tip",
+        "body": "Only the frontStore routes are reachable this way; everything else requires an admin session."
+      }
+    ],
+    "_sourceHash": "4f601a070392ce277ea5d1d35ff05e0e757faaa8"
+  },
+  {
+    "slug": "litellm-gateway",
+    "name": "LiteLLM Gateway",
+    "kind": "service",
+    "summary": "The documentation-authoring alias the wiki generator's optional wiki-author step calls to draft feature prose. Not on the storefront request path.",
+    "auth": "Virtual key (LITELLM_VIRTUAL_KEY)",
+    "url": "https://docs.litellm.ai/",
+    "notes": [
+      {
+        "kind": "warning",
+        "body": "author_content is currently off in the wiki-generate caller because this gateway was returning intermittent 500/503s; feature prose is committed directly instead."
+      }
+    ],
+    "_sourceHash": "2640d8404904109cd7305e78ca1bccf96d86969a"
+  },
+  {
+    "slug": "openhands-cloud",
+    "name": "OpenHands Cloud",
+    "kind": "service",
+    "summary": "Autonomous-dev and complex-logic automations that pick up GitHub issues for this repo and open pull requests. Driven from the Postman collection.",
+    "auth": "API key (OPENHANDS_API_KEY)",
+    "url": "https://app.all-hands.dev/",
+    "notes": [
+      {
+        "kind": "note",
+        "body": "See postman/README.md for the trigger -> poll -> send-issue-context workflow."
+      }
+    ],
+    "_sourceHash": "963d734e4c1d3460bd3a62f4c195999e24496a8b"
+  },
+  {
+    "slug": "pipeline-orchestrator",
+    "name": "Pipeline Orchestrator (agent-ops)",
+    "kind": "service",
+    "summary": "The agent-ops control repo whose pipelines.yaml registers this repo's automation entries and whose shared workflow generates this docs site.",
+    "auth": "GitHub App / repo secrets (secrets: inherit)",
+    "url": "https://github.com/11thandOrange/agent-ops",
+    "notes": [
+      {
+        "kind": "note",
+        "body": "The Automation page is generated from this repo's entries in agent-ops's orchestrator/src/registry/pipelines.yaml."
+      }
+    ],
+    "_sourceHash": "3aed2831e56833b8f8f71ffc53125630224ea79c"
+  }
+]

--- a/docs/src/data/navigation.ts
+++ b/docs/src/data/navigation.ts
@@ -17,6 +17,7 @@ export const topNav: { title: string; href: string }[] = [
   { title: "CI/CD", href: '/ci-cd' },
   { title: "Automation", href: '/automation' },
   { title: "Test Coverage", href: '/tests' },
+  { title: "Dependencies & Integrations", href: '/dependencies' },
   { title: "Changelog", href: '/changelog' },
 ];
 
@@ -27,6 +28,7 @@ export const sidebarSections: Record<string, NavSection> = {
   'ci-cd': { title: "CI/CD", href: '/ci-cd', children: workflows.map((w) => ({ title: w.title, href: `/ci-cd/${w.slug}` })) },
   'automation': { title: "Automation", href: '/automation', children: automation.map((a) => ({ title: a.name, href: `/automation/${a.slug}` })) },
   'tests': { title: "Test Coverage", href: '/tests', children: testSuites.map((t) => ({ title: t.name, href: `/tests/${t.slug}` })) },
+  'dependencies': { title: "Dependencies & Integrations", href: '/dependencies', children: [] },
   'changelog': { title: "Changelog", href: '/changelog', children: markdownPages.filter((p) => p.navSection === "Changelog").map((p) => ({ title: p.title, href: `/changelog/${p.slug}` })) },
 };
 

--- a/wiki.config.yaml
+++ b/wiki.config.yaml
@@ -79,6 +79,59 @@ extractors:
     widgetConfigExport: "widgetConfig"
     planFeaturesExport: "planFeatures"
 
+  # Third parties that live in no package.json - authored here (approach A)
+  # and rendered on the Dependencies & Integrations page. Every field is a
+  # literal from this config; nothing is derived or LLM-generated. Slugs are
+  # referenced by feature docs' implements.integrations.
+  integrations:
+    enabled: true
+    items:
+      - slug: shopify-admin-api
+        name: "Shopify Admin API"
+        kind: api
+        summary: "The Shopify platform the app is built on - discounts, products, subscriptions, and theme integration all go through the Admin API."
+        auth: "OAuth session / admin API access token"
+        url: "https://shopify.dev/docs/api/admin"
+        notes:
+          - kind: note
+            body: "Session-authenticated backend routes under /api resolve the shop from the Shopify session."
+      - slug: shopify-app-proxy
+        name: "Shopify App Proxy"
+        kind: api
+        summary: "Serves BusyBuddy's public storefront endpoints (the frontStore router) so the theme can call the app without a merchant session."
+        auth: "App-proxy signature (no merchant session)"
+        url: "https://shopify.dev/docs/apps/build/online-store/display-dynamic-store-data"
+        notes:
+          - kind: tip
+            body: "Only the frontStore routes are reachable this way; everything else requires an admin session."
+      - slug: litellm-gateway
+        name: "LiteLLM Gateway"
+        kind: service
+        summary: "The documentation-authoring alias the wiki generator's optional wiki-author step calls to draft feature prose. Not on the storefront request path."
+        auth: "Virtual key (LITELLM_VIRTUAL_KEY)"
+        url: "https://docs.litellm.ai/"
+        notes:
+          - kind: warning
+            body: "author_content is currently off in the wiki-generate caller because this gateway was returning intermittent 500/503s; feature prose is committed directly instead."
+      - slug: openhands-cloud
+        name: "OpenHands Cloud"
+        kind: service
+        summary: "Autonomous-dev and complex-logic automations that pick up GitHub issues for this repo and open pull requests. Driven from the Postman collection."
+        auth: "API key (OPENHANDS_API_KEY)"
+        url: "https://app.all-hands.dev/"
+        notes:
+          - kind: note
+            body: "See postman/README.md for the trigger -> poll -> send-issue-context workflow."
+      - slug: pipeline-orchestrator
+        name: "Pipeline Orchestrator (agent-ops)"
+        kind: service
+        summary: "The agent-ops control repo whose pipelines.yaml registers this repo's automation entries and whose shared workflow generates this docs site."
+        auth: "GitHub App / repo secrets (secrets: inherit)"
+        url: "https://github.com/11thandOrange/agent-ops"
+        notes:
+          - kind: note
+            body: "The Automation page is generated from this repo's entries in agent-ops's orchestrator/src/registry/pipelines.yaml."
+
   # Authored (not derived) - drafted via wiki-author.mjs from
   # wiki-content/authoring.yaml when author_content: true is set on the
   # caller, then read verbatim from docs/src/content/features/*.md here.


### PR DESCRIPTION
## Problem

The generated docs site had two empty sections. The **Features** section was blank because `author_content: false` in the wiki-generate caller (the LiteLLM authoring gateway was flaky), and there was no **Integrations** content at all — the `integrations` extractor was never configured. `features.generated.json` and `integrations.generated.json` were both `[]`.

## Solution

Populate both sections by feeding the existing agent-ops wiki generator authored input, rather than waiting on the LLM gateway:

- **Author 3 Feature pages** under `docs/src/content/features/` (Buy One Get One, Subscription Management, Announcement Bars), grounded in real routes/components (`web/backend/routes/subscription/index.js`, `web/frontend/pages/*`, `BundelDiscountList.jsx`, etc.). Each has how-it-works, tradeoffs, and callouts in the exact frontmatter the `features` extractor parses.
- **Add an `integrations` block** to `wiki.config.yaml` (Shopify Admin API, Shopify App Proxy, LiteLLM gateway, OpenHands Cloud, pipeline orchestrator) — every field a literal, nothing derived. This adds the **Dependencies & Integrations** nav section.
- **Regenerate** `features.generated.json`, `integrations.generated.json`, and `navigation.ts` by running `scripts/wiki-generate.mjs` from the agent-ops control repo locally (output verified byte-identical to CI before changes).

## Acceptance Criteria

- [x] Features section is populated (3 pages)
- [x] Integrations section is populated (5 entries) and appears in nav
- [x] Docs site builds clean

## Approach

Authored the feature markdown directly instead of re-enabling `author_content`, since the LiteLLM gateway was the original failure point. Ran the real generator (`wiki-generate.mjs`) against a fresh agent-ops checkout to produce the generated data, confirming a no-op baseline run first so the diff contains only intended content. Left the `skills` and npm `dependencies` extractors off deliberately — skills would need the flat `skills/*.md` files restructured into `SKILL.md` directories, and raw npm dependencies would be noise rather than docs.

## Test Results

| Suite | Status | Count |
|-------|--------|-------|
| Docs build (`cd docs && npm run build`) | ✅ | tsc + vite, 1727 modules, clean |

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] Generated content matches real source (routes, components, workflows)
- [x] Docs site builds locally

---
_Generated by [Claude Code](https://claude.ai/code/session_014DrrDL2UxkHMaS4eSQJMa5)_