### PR TITLE
docs: restructure repo-local skills into SKILL.md dirs, enable Skills page

### DIFF
--- a/docs/src/data/navigation.ts
+++ b/docs/src/data/navigation.ts
@@ -6,6 +6,7 @@ import { endpointGroups } from './endpoints';
 import { apps } from './apps';
 import { workflows } from './workflows';
 import { automation } from './automation';
+import { skills } from './skills';
 import { testSuites } from './tests';
 import { markdownPages } from './pages';
 
@@ -16,6 +17,7 @@ export const topNav: { title: string; href: string }[] = [
   { title: "App List", href: '/apps' },
   { title: "CI/CD", href: '/ci-cd' },
   { title: "Automation", href: '/automation' },
+  { title: "Skills", href: '/skills' },
   { title: "Test Coverage", href: '/tests' },
   { title: "Dependencies & Integrations", href: '/dependencies' },
   { title: "Changelog", href: '/changelog' },
@@ -27,6 +29,7 @@ export const sidebarSections: Record<string, NavSection> = {
   'apps': { title: "App List", href: '/apps', children: apps.map((a) => ({ title: a.name, href: `/apps/${a.slug}` })) },
   'ci-cd': { title: "CI/CD", href: '/ci-cd', children: workflows.map((w) => ({ title: w.title, href: `/ci-cd/${w.slug}` })) },
   'automation': { title: "Automation", href: '/automation', children: automation.map((a) => ({ title: a.name, href: `/automation/${a.slug}` })) },
+  'skills': { title: "Skills", href: '/skills', children: skills.map((s) => ({ title: s.title, href: `/skills/${s.slug}` })) },
   'tests': { title: "Test Coverage", href: '/tests', children: testSuites.map((t) => ({ title: t.name, href: `/tests/${t.slug}` })) },
   'dependencies': { title: "Dependencies & Integrations", href: '/dependencies', children: [] },
   'changelog': { title: "Changelog", href: '/changelog', children: markdownPages.filter((p) => p.navSection === "Changelog").map((p) => ({ title: p.title, href: `/changelog/${p.slug}` })) },

--- a/docs/src/data/skills.generated.json
+++ b/docs/src/data/skills.generated.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "slug": "shopify-cart-transformer",
+    "title": "shopify-cart-transformer",
+    "description": "Domain knowledge for extensions/cart-transformer — the Shopify Function that implements bundle-discount pricing at checkout: input schema, run() behavior, Function constraints, and the theme extension half.",
+    "appliesTo": "repo:11thandOrange/BusyBuddy_v2",
+    "category": "general",
+    "path": "skills/shopify-cart-transformer/SKILL.md",
+    "_sourceHash": "a3f4cc6a955b3a1a2594f635df9a0d7f88161ade"
+  },
+  {
+    "slug": "backend-frontend-conventions",
+    "title": "backend-frontend-conventions",
+    "description": "Stack-specific implementation conventions for web/backend (Express + Mongoose) and web/frontend (React + Polaris) in BusyBuddy_v2 — route/controller/model split, shop-scoping, Polaris/Redux patterns, and test setup.",
+    "appliesTo": "repo:11thandOrange/BusyBuddy_v2",
+    "category": "general",
+    "path": "skills/backend-frontend-conventions/SKILL.md",
+    "_sourceHash": "cb47177b5024a97c9e5637d2c9769755e9ae1d15"
+  }
+]

--- a/skills/backend-frontend-conventions/SKILL.md
+++ b/skills/backend-frontend-conventions/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: backend-frontend-conventions
+description: >-
+  Stack-specific implementation conventions for web/backend (Express + Mongoose)
+  and web/frontend (React + Polaris) in BusyBuddy_v2 — route/controller/model
+  split, shop-scoping, Polaris/Redux patterns, and test setup.
+applies_to: "repo:11thandOrange/BusyBuddy_v2"
+---
+
 # BusyBuddy_v2 Backend/Frontend Conventions
 
 Stack-specific implementation conventions for `web/backend` (Express +

--- a/skills/shopify-cart-transformer/SKILL.md
+++ b/skills/shopify-cart-transformer/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: shopify-cart-transformer
+description: >-
+  Domain knowledge for extensions/cart-transformer — the Shopify Function that
+  implements bundle-discount pricing at checkout: input schema, run() behavior,
+  Function constraints, and the theme extension half.
+applies_to: "repo:11thandOrange/BusyBuddy_v2"
+---
+
 # BusyBuddy_v2 Cart Transformer Extension
 
 Domain knowledge for `extensions/cart-transformer` — the Shopify Function that

--- a/wiki.config.yaml
+++ b/wiki.config.yaml
@@ -79,6 +79,15 @@ extractors:
     widgetConfigExport: "widgetConfig"
     planFeaturesExport: "planFeatures"
 
+  # Repo-local skills (SKILL.md with name/description/applies_to frontmatter).
+  # These are the same files the dev-ticket pipeline reads from skills/ in this
+  # repo's checkout; the extractor globs skills/**/SKILL.md and ingests the
+  # frontmatter verbatim (never rewritten).
+  skills:
+    enabled: true
+    roots:
+      - "skills"
+
   # Third parties that live in no package.json - authored here (approach A)
   # and rendered on the Dependencies & Integrations page. Every field is a
   # literal from this config; nothing is derived or LLM-generated. Slugs are


### PR DESCRIPTION
## Problem

The docs site's **Skills** section was empty. The skills extractor globs `skills/**/SKILL.md`, but this repo's repo-local skills were flat files (`skills/backend-frontend-conventions.md`, `skills/shopify-cart-transformer.md`) with no frontmatter, so nothing matched.

## Solution

Reformat the flat skill files into the `SKILL.md` directory layout the extractor reads — **content preserved byte-for-byte**, only the path changes and the `name`/`description`/`applies_to` frontmatter the extractor ingests is added:

- `skills/backend-frontend-conventions.md` → `skills/backend-frontend-conventions/SKILL.md`
- `skills/shopify-cart-transformer.md` → `skills/shopify-cart-transformer/SKILL.md`
- Enable the `skills` extractor in `wiki.config.yaml` (`roots: [skills]`)
- Regenerate `skills.generated.json` (2 entries) + `navigation.ts` (adds the **Skills** nav section)

## Approach

The files stay **under `skills/`** in this repo's checkout, so the dev-ticket pipeline's repo-local skills step (which reads `*.md` under `skills/`) still finds them — a `SKILL.md` one level deeper is still `*.md` under `skills/`. Kept repo-local (`applies_to: repo:11thandOrange/BusyBuddy_v2`) rather than moving into agent-ops's shared `skills/shared/dev/` tier, consistent with how these two skills were deliberately scoped (PR #171).

## Test Results

| Suite | Status |
|-------|--------|
| Docs build (`cd docs && npm run build`) | ✅ tsc + vite, clean |

---
_Generated by [Claude Code](https://claude.ai/code/session_014DrrDL2UxkHMaS4eSQJMa5)_