### PR TITLE
ci(wiki): re-enable automatic prose authoring (author_content: true)

### DIFF
--- a/.github/workflows/wiki-generate.yml
+++ b/.github/workflows/wiki-generate.yml
@@ -32,9 +32,9 @@ jobs:
     with:
       site_dir: docs
       config_path: wiki.config.yaml
-      # author_content left off for now - the LiteLLM gateway wiki-author.mjs
-      # calls into is returning intermittent 500/503s (server-side, outside
-      # this repo's control), which was breaking otherwise-reliable runs.
-      # Re-enable once that service is confirmed stable.
-      author_content: false
+      # Automatic prose authoring (wiki-author.mjs) for every page kind. The
+      # step now degrades gracefully: each gateway call is wrapped per-entry, so
+      # an intermittent LiteLLM 500/503 just means "no new summaries this run"
+      # instead of a failed build - it no longer breaks otherwise-reliable runs.
+      author_content: true
     secrets: inherit


### PR DESCRIPTION
## What

Turns automatic summary generation back on for the docs pipeline (`author_content: false` → `true`).

## Why it's safe now

`author_content` was disabled (`#298`) because the LiteLLM gateway's intermittent 500/503s broke otherwise-green runs. The generalized `wiki-author.mjs` ([agent-ops #21](https://github.com/11thandOrange/agent-ops/pull/21)) now wraps **every** gateway call per-entry in try/catch — a flaky gateway degrades to "no new summaries this run" instead of a failed build. So re-enabling can no longer break CI.

## Effect

On each `wiki-generate` run, the pipeline automatically drafts summaries for Features, Apps, Automation, Tests, and Workflows from the extracted facts and overlays them onto the pages — no hand-written content.

---
_Generated by [Claude Code](https://claude.ai/code/session_014DrrDL2UxkHMaS4eSQJMa5)_