### PR TITLE
Redesign dashboard home to match performance-first mockup

### DIFF
--- a/web/backend/controller/activity/index.js
+++ b/web/backend/controller/activity/index.js
@@ -34,12 +34,12 @@ async function getRecentActivity(req, res) {
       });
     }
 
-    const shopId = shopData._id;
-
-    // Fetch real-time activities and stats in parallel
+    // ActivityLog documents are keyed by the shop's myshopify domain (a
+    // string), not the Mongo _id - Bundle/AnnouncementBar counts need the
+    // ObjectId instead, so both ids are passed through separately.
     const [activities, stats] = await Promise.all([
-      activityLogService.getRecentActivities(shopId, 20),
-      activityLogService.getQuickStats(shopId),
+      activityLogService.getRecentActivities(session.shop, 20),
+      activityLogService.getQuickStats(session.shop, shopData._id),
     ]);
 
     // Format activities for frontend display
@@ -102,7 +102,7 @@ async function getActivityStats(req, res) {
       });
     }
 
-    const stats = await activityLogService.getQuickStats(shopData._id);
+    const stats = await activityLogService.getQuickStats(session.shop, shopData._id);
 
     res.json({
       status: "SUCCESS",

--- a/web/backend/controller/dashboard/index.js
+++ b/web/backend/controller/dashboard/index.js
@@ -1,0 +1,199 @@
+import ActivityLog from "../../models/activityLog.model.js";
+
+// GET /api/dashboard/summary?range=7d|30d|90d
+// Aggregates real per-widget performance from ActivityLog - no placeholder
+// numbers. Fields with no underlying data come back with hasData:false so
+// the frontend can render an explicit "no data" message instead of a 0.
+
+const RANGE_DAYS = { "7d": 7, "30d": 30, "90d": 90 };
+
+// Widget slugs as stored on ActivityLog.widget
+const WIDGET_SLUGS = ["bundle", "bogo", "volume", "mix-match", "announcement", "inactive-tab"];
+
+// Maps ActivityLog widget slugs to the frontend widget ids
+const SLUG_TO_WIDGET_ID = {
+  bundle: "bundle-discount",
+  bogo: "buy-one-get-one",
+  volume: "volume-discounts",
+  "mix-match": "mix-and-match",
+  announcement: "announcement-bar",
+  "inactive-tab": "inactive-tab-message",
+};
+
+// Only the Announcement Bar has storefront view/click tracking wired up
+// today (see controller/announcementBars/index.js#trackAnnouncementBarAnalytics).
+// Bundle-type widgets and the Inactive Tab Message have no impression
+// instrumentation, so their impressions/CTR are reported as untracked
+// rather than a misleading 0.
+const IMPRESSION_TRACKED_SLUGS = ["announcement"];
+
+function resolveRange(rangeParam) {
+  return RANGE_DAYS[rangeParam] ? rangeParam : "7d";
+}
+
+async function aggregateTotalsByWidget(shopDomain, start, end) {
+  const rows = await ActivityLog.aggregate([
+    {
+      $match: {
+        shopId: shopDomain,
+        createdAt: { $gte: start, $lt: end },
+        type: { $in: ["purchase", "view", "click"] },
+      },
+    },
+    {
+      $group: {
+        _id: "$widget",
+        revenue: { $sum: { $cond: [{ $eq: ["$type", "purchase"] }, { $ifNull: ["$amount", 0] }, 0] } },
+        purchaseCount: { $sum: { $cond: [{ $eq: ["$type", "purchase"] }, 1, 0] } },
+        views: { $sum: { $cond: [{ $eq: ["$type", "view"] }, 1, 0] } },
+        clicks: { $sum: { $cond: [{ $eq: ["$type", "click"] }, 1, 0] } },
+      },
+    },
+  ]);
+
+  const bySlug = {};
+  for (const row of rows) {
+    bySlug[row._id] = row;
+  }
+  return bySlug;
+}
+
+async function aggregateDailyRevenueByWidget(shopDomain, start, end) {
+  const rows = await ActivityLog.aggregate([
+    {
+      $match: {
+        shopId: shopDomain,
+        createdAt: { $gte: start, $lt: end },
+        type: "purchase",
+      },
+    },
+    {
+      $group: {
+        _id: { widget: "$widget", day: { $dateToString: { format: "%Y-%m-%d", date: "$createdAt" } } },
+        revenue: { $sum: { $ifNull: ["$amount", 0] } },
+      },
+    },
+    { $sort: { "_id.day": 1 } },
+  ]);
+
+  const byWidget = {};
+  const allWidgetsByDay = {};
+  for (const row of rows) {
+    const { widget, day } = row._id;
+    if (!byWidget[widget]) byWidget[widget] = [];
+    byWidget[widget].push({ date: day, revenue: row.revenue });
+    allWidgetsByDay[day] = (allWidgetsByDay[day] || 0) + row.revenue;
+  }
+
+  const overallTrend = Object.keys(allWidgetsByDay)
+    .sort()
+    .map((day) => ({ date: day, revenue: allWidgetsByDay[day] }));
+
+  return { byWidget, overallTrend };
+}
+
+function buildRevenueSummary(currentTotal, previousTotal, trend) {
+  let change = null;
+  if (previousTotal > 0) {
+    change = {
+      pct: ((currentTotal - previousTotal) / previousTotal) * 100,
+      kind: currentTotal >= previousTotal ? "up" : "down",
+    };
+  } else if (currentTotal > 0) {
+    change = { pct: null, kind: "new" };
+  }
+
+  return {
+    amount: currentTotal,
+    hasData: currentTotal > 0,
+    change,
+    trend,
+  };
+}
+
+function buildWidgetSummary(slug, totals = {}, trend = []) {
+  const revenueAmount = totals.revenue || 0;
+  const purchaseCount = totals.purchaseCount || 0;
+  const tracked = IMPRESSION_TRACKED_SLUGS.includes(slug);
+  const views = totals.views || 0;
+  const clicks = totals.clicks || 0;
+
+  return {
+    id: SLUG_TO_WIDGET_ID[slug],
+    revenue: {
+      amount: revenueAmount,
+      purchaseCount,
+      hasData: purchaseCount > 0,
+      trend: purchaseCount > 0 ? trend : [],
+    },
+    impressions: {
+      tracked,
+      hasData: tracked && views > 0,
+      views: tracked ? views : null,
+      clicks: tracked ? clicks : null,
+      ctr: tracked && views > 0 ? (clicks / views) * 100 : null,
+    },
+  };
+}
+
+async function getDashboardSummary(req, res) {
+  try {
+    const session = res.locals.shopify?.session;
+    if (!session?.shop) {
+      return res.status(401).json({
+        status: "ERROR",
+        message: "Unauthorized - No shop session",
+      });
+    }
+
+    const shopDomain = session.shop;
+    const range = resolveRange(req.query.range);
+    const days = RANGE_DAYS[range];
+    const now = new Date();
+    const currentStart = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+    const previousStart = new Date(currentStart.getTime() - days * 24 * 60 * 60 * 1000);
+
+    const [currentTotals, previousTotals, dailyRevenue] = await Promise.all([
+      aggregateTotalsByWidget(shopDomain, currentStart, now),
+      aggregateTotalsByWidget(shopDomain, previousStart, currentStart),
+      aggregateDailyRevenueByWidget(shopDomain, currentStart, now),
+    ]);
+
+    const widgets = WIDGET_SLUGS.map((slug) =>
+      buildWidgetSummary(slug, currentTotals[slug], dailyRevenue.byWidget[slug])
+    );
+
+    const currentRevenueTotal = widgets.reduce((sum, w) => sum + w.revenue.amount, 0);
+    const previousRevenueTotal = WIDGET_SLUGS.reduce((sum, slug) => sum + (previousTotals[slug]?.revenue || 0), 0);
+    const purchaseCountTotal = widgets.reduce((sum, w) => sum + w.revenue.purchaseCount, 0);
+
+    const trackedViews = IMPRESSION_TRACKED_SLUGS.reduce((sum, slug) => sum + (currentTotals[slug]?.views || 0), 0);
+    const trackedClicks = IMPRESSION_TRACKED_SLUGS.reduce((sum, slug) => sum + (currentTotals[slug]?.clicks || 0), 0);
+
+    res.json({
+      status: "SUCCESS",
+      data: {
+        range,
+        revenue: buildRevenueSummary(currentRevenueTotal, previousRevenueTotal, dailyRevenue.overallTrend),
+        avgOrderValue: purchaseCountTotal > 0 ? currentRevenueTotal / purchaseCountTotal : null,
+        purchaseCount: purchaseCountTotal,
+        impressions: {
+          hasData: trackedViews > 0,
+          views: trackedViews,
+          clicks: trackedClicks,
+          ctr: trackedViews > 0 ? (trackedClicks / trackedViews) * 100 : null,
+          trackedWidgetIds: IMPRESSION_TRACKED_SLUGS.map((slug) => SLUG_TO_WIDGET_ID[slug]),
+        },
+        widgets,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching dashboard summary:", error);
+    res.status(500).json({
+      status: "ERROR",
+      message: "Failed to fetch dashboard summary",
+    });
+  }
+}
+
+export { getDashboardSummary };

--- a/web/backend/routes/dashboard/index.js
+++ b/web/backend/routes/dashboard/index.js
@@ -1,0 +1,9 @@
+import express from "express";
+import { getDashboardSummary } from "../../controller/dashboard/index.js";
+
+const router = express.Router();
+
+// GET /api/dashboard/summary - Real per-widget revenue/impressions for the home screen
+router.get("/summary", getDashboardSummary);
+
+export default router;

--- a/web/backend/routes/index.js
+++ b/web/backend/routes/index.js
@@ -10,6 +10,7 @@ import analyticsRoutes from './analytics/index.js';
 import emailProviderRoutes from './emailProvider/index.js';
 import googleAnalyticsRoutes from './googleAnalytics/index.js';
 import activityRoutes from './activity/index.js';
+import dashboardRoutes from './dashboard/index.js';
 // Note: webhookRoutes are mounted separately in web/index.js to bypass session auth
 // Note: referralRoutes are registered in web/index.js BEFORE Shopify auth middleware
 // to allow public access without shop authentication
@@ -24,5 +25,6 @@ router.use('/analytics', analyticsRoutes);
 router.use('/email-provider', emailProviderRoutes);
 router.use('/analytics/google', googleAnalyticsRoutes);
 router.use('/activity', activityRoutes);
+router.use('/dashboard', dashboardRoutes);
 
 export default router;

--- a/web/backend/services/activityLogService.js
+++ b/web/backend/services/activityLogService.js
@@ -67,10 +67,12 @@ const activityLogService = {
 
   /**
    * Get quick stats for a shop (customer events today, active offers)
-   * @param {string} shopId - Shop identifier
+   * @param {string} shopDomain - Shop myshopify domain (ActivityLog.shopId is stored as this string)
+   * @param {string} [shopObjectId] - Shop's MongoDB _id (Bundle/AnnouncementBar store shopId as this ObjectId).
+   *   Defaults to shopDomain for callers that only have one id and don't need offer counts.
    * @returns {Promise<Object>} Stats object with activeOffers and usesToday
    */
-  async getQuickStats(shopId) {
+  async getQuickStats(shopDomain, shopObjectId = shopDomain) {
     try {
       const startOfDay = new Date();
       startOfDay.setHours(0, 0, 0, 0);
@@ -79,7 +81,7 @@ const activityLogService = {
       const [usageStats] = await ActivityLog.aggregate([
         {
           $match: {
-            shopId,
+            shopId: shopDomain,
             createdAt: { $gte: startOfDay },
             type: { $in: ["view", "click", "purchase"] },
           },
@@ -94,7 +96,7 @@ const activityLogService = {
       ]);
 
       // Get counts of active offers by type
-      const { bundles, announcements } = await this.countActiveOffers(shopId);
+      const { bundles, announcements } = await this.countActiveOffers(shopObjectId);
 
       return {
         activeBundles: bundles,

--- a/web/backend/tests/controller/activity.test.js
+++ b/web/backend/tests/controller/activity.test.js
@@ -77,9 +77,11 @@ describe('Activity Controller', () => {
 
       await getRecentActivity(req, res);
 
-      // Controller resolves shop domain → MongoDB _id via Shop.findOne, then passes _id to service
-      expect(activityLogService.getRecentActivities).toHaveBeenCalledWith(MOCK_SHOP_ID, 20);
-      expect(activityLogService.getQuickStats).toHaveBeenCalledWith(MOCK_SHOP_ID);
+      // ActivityLog documents are keyed by the shop domain string (how they're
+      // written in bundles/announcementBars/webhooks controllers), while
+      // Bundle/AnnouncementBar counts need the Mongo _id - both are passed through.
+      expect(activityLogService.getRecentActivities).toHaveBeenCalledWith('test-shop.myshopify.com', 20);
+      expect(activityLogService.getQuickStats).toHaveBeenCalledWith('test-shop.myshopify.com', MOCK_SHOP_ID);
     });
 
     it('should format activities with id, widget, title, meta, amount, time, iconClass', async () => {
@@ -164,7 +166,7 @@ describe('Activity Controller', () => {
 
       await getActivityStats(req, res);
 
-      expect(activityLogService.getQuickStats).toHaveBeenCalledWith(MOCK_SHOP_ID);
+      expect(activityLogService.getQuickStats).toHaveBeenCalledWith('test-shop.myshopify.com', MOCK_SHOP_ID);
       expect(res.json).toHaveBeenCalledWith({
         status: 'SUCCESS',
         data: {

--- a/web/backend/tests/controller/dashboard.test.js
+++ b/web/backend/tests/controller/dashboard.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { MockActivityLog } = vi.hoisted(() => {
+  const MockActivityLog = { aggregate: vi.fn() };
+  return { MockActivityLog };
+});
+
+vi.mock('../../models/activityLog.model.js', () => ({ default: MockActivityLog }));
+
+import { getDashboardSummary } from '../../controller/dashboard/index.js';
+
+const createMockReq = (query = {}) => ({ query });
+
+const createMockRes = (overrides = {}) => ({
+  locals: {
+    shopify: {
+      session: { shop: 'test-shop.myshopify.com' },
+    },
+  },
+  status: vi.fn().mockReturnThis(),
+  json: vi.fn().mockReturnThis(),
+  ...overrides,
+});
+
+describe('getDashboardSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return 401 if no shop session', async () => {
+    const req = createMockReq();
+    const res = createMockRes({ locals: { shopify: { session: null } } });
+
+    await getDashboardSummary(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      status: 'ERROR',
+      message: 'Unauthorized - No shop session',
+    });
+  });
+
+  it('should report no data (not zero-as-fact) when nothing has been logged yet', async () => {
+    MockActivityLog.aggregate.mockResolvedValue([]);
+
+    const req = createMockReq({ range: '7d' });
+    const res = createMockRes();
+
+    await getDashboardSummary(req, res);
+
+    const response = res.json.mock.calls[0][0];
+    expect(response.status).toBe('SUCCESS');
+    expect(response.data.revenue.hasData).toBe(false);
+    expect(response.data.revenue.amount).toBe(0);
+    expect(response.data.revenue.change).toBeNull();
+    expect(response.data.avgOrderValue).toBeNull();
+    expect(response.data.impressions.hasData).toBe(false);
+
+    const announcement = response.data.widgets.find((w) => w.id === 'announcement-bar');
+    expect(announcement.impressions.tracked).toBe(true);
+    expect(announcement.impressions.hasData).toBe(false);
+    expect(announcement.impressions.views).toBe(0);
+
+    const bundle = response.data.widgets.find((w) => w.id === 'bundle-discount');
+    expect(bundle.impressions.tracked).toBe(false);
+    expect(bundle.impressions.views).toBeNull();
+    expect(bundle.impressions.ctr).toBeNull();
+    expect(bundle.revenue.hasData).toBe(false);
+  });
+
+  it('should default an unknown range to 7d', async () => {
+    MockActivityLog.aggregate.mockResolvedValue([]);
+    const req = createMockReq({ range: 'not-a-range' });
+    const res = createMockRes();
+
+    await getDashboardSummary(req, res);
+
+    expect(res.json.mock.calls[0][0].data.range).toBe('7d');
+  });
+
+  it('should populate real per-widget revenue and impressions from ActivityLog', async () => {
+    // Order of ActivityLog.aggregate() calls: current totals, previous totals, daily revenue trend
+    MockActivityLog.aggregate
+      .mockResolvedValueOnce([
+        { _id: 'bundle', revenue: 500, purchaseCount: 4, views: 0, clicks: 0 },
+        { _id: 'announcement', revenue: 0, purchaseCount: 0, views: 1000, clicks: 40 },
+      ])
+      .mockResolvedValueOnce([{ _id: 'bundle', revenue: 200, purchaseCount: 2, views: 0, clicks: 0 }])
+      .mockResolvedValueOnce([
+        { _id: { widget: 'bundle', day: '2026-08-01' }, revenue: 500 },
+      ]);
+
+    const req = createMockReq({ range: '30d' });
+    const res = createMockRes();
+
+    await getDashboardSummary(req, res);
+
+    const response = res.json.mock.calls[0][0];
+    expect(response.data.revenue.amount).toBe(500);
+    expect(response.data.revenue.hasData).toBe(true);
+    expect(response.data.revenue.change).toEqual({ pct: 150, kind: 'up' });
+    expect(response.data.avgOrderValue).toBe(125);
+
+    const bundle = response.data.widgets.find((w) => w.id === 'bundle-discount');
+    expect(bundle.revenue.amount).toBe(500);
+    expect(bundle.revenue.purchaseCount).toBe(4);
+    expect(bundle.revenue.hasData).toBe(true);
+    expect(bundle.revenue.trend).toEqual([{ date: '2026-08-01', revenue: 500 }]);
+
+    const announcement = response.data.widgets.find((w) => w.id === 'announcement-bar');
+    expect(announcement.impressions.views).toBe(1000);
+    expect(announcement.impressions.clicks).toBe(40);
+    expect(announcement.impressions.ctr).toBe(4);
+    expect(response.data.impressions.views).toBe(1000);
+    expect(response.data.impressions.ctr).toBe(4);
+  });
+
+  it('should mark revenue change as "new" when there was no revenue in the prior period', async () => {
+    MockActivityLog.aggregate
+      .mockResolvedValueOnce([{ _id: 'bundle', revenue: 100, purchaseCount: 1, views: 0, clicks: 0 }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const req = createMockReq({ range: '7d' });
+    const res = createMockRes();
+
+    await getDashboardSummary(req, res);
+
+    const response = res.json.mock.calls[0][0];
+    expect(response.data.revenue.change).toEqual({ pct: null, kind: 'new' });
+  });
+
+  it('should return 500 on error', async () => {
+    MockActivityLog.aggregate.mockRejectedValue(new Error('Database error'));
+
+    const req = createMockReq();
+    const res = createMockRes();
+
+    await getDashboardSummary(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      status: 'ERROR',
+      message: 'Failed to fetch dashboard summary',
+    });
+  });
+});

--- a/web/backend/tests/services/activityLogService.test.js
+++ b/web/backend/tests/services/activityLogService.test.js
@@ -118,21 +118,21 @@ describe('activityLogService', () => {
       MockActivityLog.aggregate.mockResolvedValue([{ eventsToday: 10, revenueToday: 50 }]);
     });
 
-    it('should count active bundles by shopId and status', async () => {
-      const stats = await activityLogService.getQuickStats('test-shop.myshopify.com');
+    it('should count active bundles by the shop ObjectId (not the domain used for ActivityLog)', async () => {
+      const stats = await activityLogService.getQuickStats('test-shop.myshopify.com', 'shop-object-id-123');
 
       expect(Bundle.countDocuments).toHaveBeenCalledWith({
-        shopId: 'test-shop.myshopify.com',
+        shopId: 'shop-object-id-123',
         status: true,
       });
       expect(stats.activeBundles).toBe(5);
     });
 
-    it('should count active announcements by shopId and status', async () => {
-      const stats = await activityLogService.getQuickStats('test-shop.myshopify.com');
+    it('should count active announcements by the shop ObjectId (not the domain used for ActivityLog)', async () => {
+      const stats = await activityLogService.getQuickStats('test-shop.myshopify.com', 'shop-object-id-123');
 
       expect(AnnouncementBar.countDocuments).toHaveBeenCalledWith({
-        shopId: 'test-shop.myshopify.com',
+        shopId: 'shop-object-id-123',
         status: 'active',
       });
       expect(stats.activeAnnouncements).toBe(3);

--- a/web/frontend/pages/DashboardHome.css
+++ b/web/frontend/pages/DashboardHome.css
@@ -22,14 +22,13 @@
   overflow: hidden;
 }
 
-/* Sticky header: logo + range pills */
+/* Sticky header: logo + range pills - dark bar, distinct from the light card body */
 .app-header {
   padding: 12px 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 1px solid #ececec;
-  background: rgba(244, 244, 242, 0.85);
+  background: linear-gradient(135deg, #16171a 0%, #23252b 100%);
   flex-wrap: wrap;
   gap: 12px;
 }
@@ -48,7 +47,13 @@
 .app-header-brand .name {
   font-weight: 700;
   font-size: 15px;
-  color: #111;
+  color: #fff;
+}
+
+.app-header .app-tag {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e5e7eb;
+  border: 1px solid rgba(255, 255, 255, 0.14);
 }
 
 .app-tag {
@@ -70,9 +75,9 @@
 .pill-nav {
   display: inline-flex;
   padding: 4px;
-  background: #f4f4f2;
+  background: rgba(255, 255, 255, 0.08);
   border-radius: 10px;
-  border: 1px solid #ececec;
+  border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 .pill-nav button {
@@ -82,7 +87,7 @@
   border-radius: 7px;
   font-size: 13px;
   font-weight: 500;
-  color: #4b5563;
+  color: #b3b6bd;
   cursor: pointer;
   font-family: inherit;
 }
@@ -99,9 +104,9 @@
   border-radius: 8px;
   font-size: 13px;
   font-weight: 600;
-  background: #f4f4f2;
-  color: #111;
-  border: 1px solid #ececec;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.14);
   text-decoration: none;
 }
 
@@ -218,32 +223,6 @@
   margin: 0;
 }
 
-.sort-controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  color: #6b7280;
-}
-
-.tag {
-  font-size: 11px;
-  padding: 3px 9px;
-  border-radius: 6px;
-  background: #f4f4f2;
-  color: #374151;
-  border: 1px solid #ececec;
-  font-weight: 500;
-  cursor: pointer;
-  font-family: inherit;
-}
-
-.tag.active {
-  background: #111;
-  color: #fff;
-  border-color: #111;
-}
-
 /* Widgets Grid */
 .widgets-grid {
   display: grid;
@@ -262,6 +241,9 @@
   border: 1px solid #ececec;
   background: #fff;
   transition: box-shadow 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .widget-tile:hover {
@@ -370,12 +352,14 @@
   padding: 2px 0;
 }
 
-/* Widget Buttons */
+/* Widget Buttons - always pinned to the bottom of the card, whether or not
+   a sparkline/metrics row is present above it */
 .widget-buttons {
   display: flex;
   gap: 8px;
   width: 100%;
-  margin-top: 12px;
+  margin-top: auto;
+  padding-top: 12px;
 }
 
 .widget-btn {
@@ -424,11 +408,6 @@
   gap: 14px;
 }
 
-.history-list.is-capped {
-  max-height: 380px;
-  overflow: hidden;
-}
-
 .history-item {
   display: flex;
   align-items: flex-start;
@@ -473,22 +452,6 @@
   padding: 16px 0;
   text-align: center;
 }
-
-.view-all-btn {
-  width: 100%;
-  margin-top: 14px;
-  padding: 8px 12px;
-  border-radius: 8px;
-  font-size: 12.5px;
-  font-weight: 600;
-  background: #f4f4f2;
-  color: #111;
-  border: 1px solid #ececec;
-  cursor: pointer;
-  font-family: inherit;
-}
-
-.view-all-btn:hover { background: #ececec; }
 
 /* Notification banners - real app alerts, sit under the frame */
 .notification-card {

--- a/web/frontend/pages/DashboardHome.css
+++ b/web/frontend/pages/DashboardHome.css
@@ -50,12 +50,6 @@
   color: #fff;
 }
 
-.app-header .app-tag {
-  background: rgba(255, 255, 255, 0.1);
-  color: #e5e7eb;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-}
-
 .app-tag {
   font-size: 11px;
   font-weight: 600;

--- a/web/frontend/pages/DashboardHome.css
+++ b/web/frontend/pages/DashboardHome.css
@@ -1,34 +1,153 @@
 /* Dashboard Home Styles */
 .dashboard-home {
   background: #f2f2f7;
-  overflow: hidden;
+  overflow-y: auto;
   padding: 16px;
   box-sizing: border-box;
-  height: calc(100vh - 57px); /* Subtract header height */
+  min-height: calc(100vh - 57px); /* Subtract header height */
+}
+
+.dashboard-inner {
+  max-width: 1400px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
+  gap: 16px;
+}
+
+/* Range selector */
+.range-bar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.pill-nav {
+  display: inline-flex;
+  padding: 4px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.pill-nav button {
+  padding: 6px 14px;
+  border: none;
+  background: transparent;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #8e8e93;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.pill-nav button.active {
+  background: #1c1c1e;
+  color: #fff;
+}
+
+/* Hero metrics band */
+.hero-band {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.hero-tile {
+  background: #fff;
+  border-radius: 16px;
+  padding: 18px 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  min-height: 92px;
+}
+
+.hero-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8e8e93;
+  margin-bottom: 6px;
+}
+
+.hero-value-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.hero-value {
+  font-size: 26px;
+  font-weight: 700;
+  color: #1c1c1e;
+  line-height: 1.15;
+}
+
+.hero-value-sub {
+  font-size: 15px;
+  font-weight: 600;
+  color: #8e8e93;
+}
+
+.hero-sub {
+  font-size: 12px;
+  color: #8e8e93;
+  margin-top: 4px;
+}
+
+.hero-empty,
+.hero-loading {
+  font-size: 13px;
+  color: #8e8e93;
+  margin-top: 4px;
+  line-height: 1.4;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.hero-badge-up { background: rgba(52, 199, 89, 0.15); color: #2d8a4e; }
+.hero-badge-down { background: rgba(255, 59, 48, 0.12); color: #d63535; }
+.hero-badge-new { background: rgba(0, 122, 255, 0.12); color: #007aff; }
+
+.widget-spark,
+.hero-tile .widget-spark {
+  width: 100%;
+  height: 32px;
+  margin-top: 6px;
+}
+
+@media (max-width: 1200px) {
+  .hero-band {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .hero-band {
+    grid-template-columns: 1fr;
+  }
 }
 
 .dashboard-layout {
   display: grid;
   grid-template-columns: 1.2fr 0.8fr;
   gap: 24px;
-  max-width: 1400px;
-  margin: 0 auto;
   padding: 0;
-  height: 100%;
-  overflow: hidden;
-  flex: 1;
-  min-height: 0;
 }
 
 /* Left Column - Widgets */
 .widgets-column {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  max-height: 100%;
-  min-height: 0;
 }
 
 .widgets-container {
@@ -36,10 +155,6 @@
   border-radius: 20px;
   padding: 24px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  flex: 1;
-  overflow-y: auto;
-  max-height: 100%;
-  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -210,9 +325,20 @@
   color: #2d8a4e;
 }
 
-.status-indicator.inactive {
+.status-indicator.inactive,
+.status-indicator.not-set-up {
   background: rgba(142, 142, 147, 0.15);
   color: #636366;
+}
+
+.status-indicator.paused {
+  background: rgba(255, 149, 0, 0.15);
+  color: #b3600a;
+}
+
+.status-indicator.locked {
+  background: rgba(142, 142, 147, 0.15);
+  color: #8e8e93;
 }
 
 .status-dot {
@@ -225,8 +351,13 @@
   background: #34c759;
 }
 
-.status-indicator.inactive .status-dot {
+.status-indicator.inactive .status-dot,
+.status-indicator.not-set-up .status-dot {
   background: #8e8e93;
+}
+
+.status-indicator.paused .status-dot {
+  background: #ff9500;
 }
 
 /* Large Widget Icon - Tone on Tone */
@@ -261,8 +392,59 @@
   font-size: 11px;
   color: #8e8e93;
   line-height: 1.4;
-  margin-bottom: 14px;
+  margin-bottom: 10px;
   max-width: 160px;
+}
+
+/* Widget Performance Metrics */
+.widget-metrics {
+  width: 100%;
+  border-top: 1px solid #f2f2f7;
+  border-bottom: 1px solid #f2f2f7;
+  padding: 10px 0;
+  margin-bottom: 12px;
+}
+
+.widget-metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  text-align: center;
+}
+
+.widget-metric .metric-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8e8e93;
+  font-weight: 700;
+}
+
+.widget-metric .metric-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: #1c1c1e;
+  margin-top: 2px;
+}
+
+.widget-metric-note {
+  grid-column: span 2;
+  font-size: 10px;
+  color: #8e8e93;
+  align-self: center;
+  line-height: 1.3;
+}
+
+.widget-metrics-empty {
+  font-size: 11px;
+  color: #8e8e93;
+  text-align: center;
+  padding: 4px 0;
+}
+
+.widget-tile .widget-spark {
+  height: 28px;
+  margin-top: 8px;
 }
 
 /* Widget Buttons */
@@ -309,21 +491,15 @@
 .history-column {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  max-height: 100%;
-  min-height: 0;
 }
 
 .history-container {
   background: #fff;
   border-radius: 20px;
   padding: 20px;
-  flex: 1;
   display: flex;
   flex-direction: column;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  overflow: hidden;
-  min-height: 0;
 }
 
 .history-header {
@@ -375,14 +551,13 @@
 
 /* History List with Fade */
 .history-list-wrapper {
-  flex: 1;
   position: relative;
   overflow: hidden;
-  min-height: 0;
+  max-height: 420px;
 }
 
 .history-list {
-  height: 100%;
+  max-height: 420px;
   overflow-y: auto;
   padding-bottom: 40px;
 }

--- a/web/frontend/pages/DashboardHome.css
+++ b/web/frontend/pages/DashboardHome.css
@@ -1,6 +1,8 @@
-/* Dashboard Home Styles */
+/* Dashboard Home Styles - mirrors the "Mockup A: Performance-first dashboard"
+   reference layout (sticky header, gradient hero band, 12-col widgets/activity
+   split with a real border divider) rather than the app's older card style. */
 .dashboard-home {
-  background: #f2f2f7;
+  background: #f4f4f2;
   overflow-y: auto;
   padding: 16px;
   box-sizing: border-box;
@@ -10,63 +12,119 @@
 .dashboard-inner {
   max-width: 1400px;
   margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
 }
 
-/* Range selector */
-.range-bar {
+/* Outer app frame - the whole dashboard lives inside one bordered card */
+.app-frame {
+  background: #fff;
+  border: 1px solid #ececec;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+/* Sticky header: logo + range pills */
+.app-header {
+  padding: 12px 20px;
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #ececec;
+  background: rgba(244, 244, 242, 0.85);
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.app-header-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-header-brand .logo {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.app-header-brand .name {
+  font-weight: 700;
+  font-size: 15px;
+  color: #111;
+}
+
+.app-tag {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 6px;
+  background: #f4f4f2;
+  color: #374151;
+  border: 1px solid #ececec;
+}
+
+.app-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .pill-nav {
   display: inline-flex;
   padding: 4px;
-  background: #fff;
+  background: #f4f4f2;
   border-radius: 10px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border: 1px solid #ececec;
 }
 
 .pill-nav button {
-  padding: 6px 14px;
+  padding: 6px 12px;
   border: none;
   background: transparent;
   border-radius: 7px;
   font-size: 13px;
-  font-weight: 600;
-  color: #8e8e93;
+  font-weight: 500;
+  color: #4b5563;
   cursor: pointer;
-  transition: all 0.15s ease;
+  font-family: inherit;
 }
 
 .pill-nav button.active {
-  background: #1c1c1e;
-  color: #fff;
+  background: #fff;
+  color: #111;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  font-weight: 600;
+}
+
+.help-link {
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  background: #f4f4f2;
+  color: #111;
+  border: 1px solid #ececec;
+  text-decoration: none;
 }
 
 /* Hero metrics band */
 .hero-band {
+  padding: 20px 24px;
+  border-bottom: 1px solid #ececec;
+  background: linear-gradient(to bottom, #fff, #faf9f6);
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
+  gap: 20px;
 }
 
 .hero-tile {
-  background: #fff;
-  border-radius: 16px;
-  padding: 18px 20px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  min-height: 92px;
+  min-width: 0;
 }
 
 .hero-label {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8e8e93;
+  letter-spacing: 0.08em;
+  color: #6b7280;
   margin-bottom: 6px;
 }
 
@@ -80,26 +138,28 @@
 .hero-value {
   font-size: 26px;
   font-weight: 700;
-  color: #1c1c1e;
+  color: #111;
   line-height: 1.15;
+  font-variant-numeric: tabular-nums;
 }
 
 .hero-value-sub {
-  font-size: 15px;
-  font-weight: 600;
-  color: #8e8e93;
+  font-size: 16px;
+  font-weight: 500;
+  color: #9ca3af;
 }
 
 .hero-sub {
   font-size: 12px;
-  color: #8e8e93;
-  margin-top: 4px;
+  color: #6b7280;
+  margin-top: 6px;
+  line-height: 1.4;
 }
 
 .hero-empty,
 .hero-loading {
   font-size: 13px;
-  color: #8e8e93;
+  color: #6b7280;
   margin-top: 4px;
   line-height: 1.4;
 }
@@ -108,238 +168,138 @@
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  padding: 2px 7px;
+  padding: 3px 8px;
   border-radius: 999px;
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
-.hero-badge-up { background: rgba(52, 199, 89, 0.15); color: #2d8a4e; }
-.hero-badge-down { background: rgba(255, 59, 48, 0.12); color: #d63535; }
-.hero-badge-new { background: rgba(0, 122, 255, 0.12); color: #007aff; }
+.hero-badge-up { background: #e7f7ee; color: #0f7a3b; }
+.hero-badge-down { background: #fdecec; color: #d63535; }
+.hero-badge-new { background: #eaf3ff; color: #0b76ef; }
 
-.widget-spark,
-.hero-tile .widget-spark {
+.widget-spark {
   width: 100%;
-  height: 32px;
-  margin-top: 6px;
+  height: 34px;
+  margin-top: 8px;
 }
 
 @media (max-width: 1200px) {
-  .hero-band {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  .hero-band { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .hero-band { grid-template-columns: 1fr; }
 }
 
-@media (max-width: 768px) {
-  .hero-band {
-    grid-template-columns: 1fr;
-  }
-}
-
+/* Content grid: widgets (9/12) + activity rail (3/12), like the reference layout */
 .dashboard-layout {
   display: grid;
-  grid-template-columns: 1.2fr 0.8fr;
-  gap: 24px;
-  padding: 0;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
 }
 
-/* Left Column - Widgets */
 .widgets-column {
-  display: flex;
-  flex-direction: column;
-}
-
-.widgets-container {
-  background: #fff;
-  border-radius: 20px;
-  padding: 24px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  display: flex;
-  flex-direction: column;
+  padding: 20px 24px;
+  border-right: 1px solid #ececec;
 }
 
 .section-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
   margin-bottom: 16px;
-  flex-shrink: 0;
 }
 
 .section-title {
-  font-size: 17px;
+  font-size: 15px;
   font-weight: 600;
-  color: #1c1c1e;
+  color: #111;
   margin: 0;
+}
+
+.sort-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.tag {
+  font-size: 11px;
+  padding: 3px 9px;
+  border-radius: 6px;
+  background: #f4f4f2;
+  color: #374151;
+  border: 1px solid #ececec;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.tag.active {
+  background: #111;
+  color: #fff;
+  border-color: #111;
 }
 
 /* Widgets Grid */
 .widgets-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-  width: 100%;
-  align-content: start;
+  gap: 14px;
 }
 
-/* Responsive breakpoints for widgets grid */
-@media (max-width: 1400px) {
-  .widgets-grid {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 14px;
-  }
-  .widget-tile {
-    padding: 16px 12px;
-  }
+@media (max-width: 1300px) {
+  .widgets-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
-@media (max-width: 1200px) {
-  .dashboard-layout {
-    grid-template-columns: 1fr 0.9fr;
-    gap: 20px;
-  }
-  .widgets-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (max-width: 1024px) {
-  .dashboard-home {
-    padding: 12px;
-    height: auto;
-    min-height: calc(100vh - 57px);
-  }
-  .dashboard-layout {
-    grid-template-columns: 1fr;
-    gap: 16px;
-    height: auto;
-    min-height: auto;
-    overflow: visible;
-  }
-  .widgets-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-  .widgets-column,
-  .history-column {
-    max-height: none;
-  }
-  .widgets-container {
-    max-height: none;
-    overflow: visible;
-  }
-}
-
-@media (max-width: 768px) {
-  .dashboard-home {
-    height: auto;
-    min-height: auto;
-  }
-  .dashboard-layout {
-    height: auto;
-    overflow: visible;
-  }
-  .widgets-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
-  }
-  .widgets-container {
-    padding: 16px;
-    max-height: none;
-    overflow: visible;
-  }
-  .widget-icon-large {
-    width: 56px;
-    height: 56px;
-  }
-  .widget-icon-large svg {
-    width: 24px;
-    height: 24px;
-  }
-}
-
-@media (max-width: 480px) {
-  .dashboard-home {
-    padding: 8px;
-    height: auto;
-  }
-  .widgets-grid {
-    grid-template-columns: 1fr 1fr;
-    gap: 10px;
-  }
-  .widget-tile {
-    padding: 12px 8px;
-  }
-  .widget-name {
-    font-size: 12px;
-  }
-  .widget-desc {
-    font-size: 10px;
-    max-width: 100%;
-  }
-  .widget-btn {
-    padding: 8px 6px;
-    font-size: 10px;
-  }
-  .status-indicator {
-    font-size: 8px;
-    padding: 2px 6px;
-  }
-}
-
-/* Widget Tile */
+/* Widget card - left-aligned, like the reference layout's widget cards */
 .widget-tile {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  padding: 20px 16px;
-  border-radius: 16px;
-  border: 3px solid #f2f2f7;
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid #ececec;
   background: #fff;
-  transition: all 0.2s ease;
-  position: relative;
+  transition: box-shadow 0.15s ease;
 }
 
 .widget-tile:hover {
-  border-color: #e5e5ea;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+}
+
+.widget-tile-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.widget-icon-large {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 /* Status Indicator */
 .status-indicator {
-  position: absolute;
-  top: 12px;
-  right: 12px;
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 4px 8px;
-  border-radius: 12px;
-  font-size: 10px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 11px;
   font-weight: 600;
+  flex-shrink: 0;
 }
 
-.status-indicator.active {
-  background: rgba(52, 199, 89, 0.15);
-  color: #2d8a4e;
-}
-
-.status-indicator.inactive,
-.status-indicator.not-set-up {
-  background: rgba(142, 142, 147, 0.15);
-  color: #636366;
-}
-
-.status-indicator.paused {
-  background: rgba(255, 149, 0, 0.15);
-  color: #b3600a;
-}
-
-.status-indicator.locked {
-  background: rgba(142, 142, 147, 0.15);
-  color: #8e8e93;
-}
+.status-indicator.active { background: #e7f7ee; color: #0f7a3b; }
+.status-indicator.paused { background: #fdf1dc; color: #b3600a; }
+.status-indicator.not-set-up { background: #f4f4f2; color: #374151; }
+.status-indicator.locked { background: #f4f4f2; color: #8e8e93; }
 
 .status-dot {
   width: 6px;
@@ -347,104 +307,67 @@
   border-radius: 50%;
 }
 
-.status-indicator.active .status-dot {
-  background: #34c759;
-}
+.status-indicator.active .status-dot { background: #12a24a; }
+.status-indicator.paused .status-dot { background: #e6a23c; }
+.status-indicator.not-set-up .status-dot { background: #9ca3af; }
 
-.status-indicator.inactive .status-dot,
-.status-indicator.not-set-up .status-dot {
-  background: #8e8e93;
-}
-
-.status-indicator.paused .status-dot {
-  background: #ff9500;
-}
-
-/* Large Widget Icon - Tone on Tone */
-.widget-icon-large {
-  width: 72px;
-  height: 72px;
-  border-radius: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 12px;
-}
-
-.widget-icon-large.orange { background: rgba(255, 149, 0, 0.15); color: #e67e00; }
-.widget-icon-large.blue { background: rgba(0, 122, 255, 0.15); color: #007aff; }
-.widget-icon-large.green { background: rgba(52, 199, 89, 0.15); color: #34c759; }
-.widget-icon-large.pink { background: rgba(255, 45, 85, 0.15); color: #ff2d55; }
-.widget-icon-large.purple { background: rgba(175, 82, 222, 0.15); color: #af52de; }
-.widget-icon-large.indigo { background: rgba(88, 86, 214, 0.15); color: #5856d6; }
-
-/* Widget Name */
+/* Widget Name / subtitle */
 .widget-name {
   font-size: 14px;
   font-weight: 600;
-  color: #1c1c1e;
-  margin-bottom: 4px;
-  line-height: 1.2;
+  color: #111;
+  margin: 10px 0 1px;
+  line-height: 1.25;
 }
 
-/* Widget Description */
 .widget-desc {
-  font-size: 11px;
-  color: #8e8e93;
+  font-size: 11.5px;
+  color: #6b7280;
   line-height: 1.4;
-  margin-bottom: 10px;
-  max-width: 160px;
+}
+
+.widget-divider {
+  height: 1px;
+  background: #eee;
+  margin: 10px 0;
 }
 
 /* Widget Performance Metrics */
-.widget-metrics {
-  width: 100%;
-  border-top: 1px solid #f2f2f7;
-  border-bottom: 1px solid #f2f2f7;
-  padding: 10px 0;
-  margin-bottom: 12px;
-}
-
 .widget-metrics-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 6px;
-  text-align: center;
+  gap: 4px;
+  font-size: 11px;
 }
 
 .widget-metric .metric-label {
   font-size: 9px;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #8e8e93;
+  letter-spacing: 0.06em;
+  color: #6b7280;
   font-weight: 700;
 }
 
 .widget-metric .metric-value {
   font-size: 13px;
   font-weight: 600;
-  color: #1c1c1e;
-  margin-top: 2px;
+  color: #111;
+  margin-top: 3px;
+  font-variant-numeric: tabular-nums;
 }
 
 .widget-metric-note {
-  grid-column: span 2;
-  font-size: 10px;
-  color: #8e8e93;
-  align-self: center;
-  line-height: 1.3;
+  grid-column: span 3;
+  font-size: 10.5px;
+  color: #9ca3af;
+  line-height: 1.4;
+  padding: 2px 0;
 }
 
 .widget-metrics-empty {
   font-size: 11px;
-  color: #8e8e93;
-  text-align: center;
-  padding: 4px 0;
-}
-
-.widget-tile .widget-spark {
-  height: 28px;
-  margin-top: 8px;
+  color: #9ca3af;
+  padding: 2px 0;
 }
 
 /* Widget Buttons */
@@ -452,209 +375,127 @@
   display: flex;
   gap: 8px;
   width: 100%;
+  margin-top: 12px;
 }
 
 .widget-btn {
   flex: 1;
-  padding: 10px 12px;
+  padding: 8px 10px;
   border: none;
-  border-radius: 10px;
-  font-size: 12px;
+  border-radius: 8px;
+  font-size: 12.5px;
   font-weight: 600;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  transition: all 0.2s ease;
+  gap: 5px;
+  font-family: inherit;
 }
 
-.widget-btn.create {
-  background: #1c1c1e;
-  color: #fff;
-}
+.widget-btn.create { background: #111; color: #fff; }
+.widget-btn.create:hover { background: #333; }
+.widget-btn.manage { background: #f4f4f2; color: #111; border: 1px solid #ececec; }
+.widget-btn.manage:hover { background: #ececec; }
 
-.widget-btn.create:hover {
-  background: #333;
-}
-
-.widget-btn.manage {
-  background: #f2f2f7;
-  color: #1c1c1e;
-}
-
-.widget-btn.manage:hover {
-  background: #e5e5ea;
-}
-
-/* Right Column - History */
+/* Right rail - Live activity */
 .history-column {
-  display: flex;
-  flex-direction: column;
-}
-
-.history-container {
-  background: #fff;
-  border-radius: 20px;
+  background: #fafafa;
   padding: 20px;
-  display: flex;
-  flex-direction: column;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .history-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
-  flex-shrink: 0;
+  margin-bottom: 14px;
 }
 
 .history-title {
-  font-size: 17px;
+  font-size: 15px;
   font-weight: 600;
-  color: #1c1c1e;
+  color: #111;
   margin: 0;
 }
 
-/* Quick Stats */
-.quick-stats {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-  margin-bottom: 20px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid #f2f2f7;
-  flex-shrink: 0;
-}
-
-.quick-stat {
-  background: #f2f2f7;
-  border-radius: 12px;
-  padding: 14px;
-  text-align: center;
-}
-
-.quick-stat .value {
-  font-size: 28px;
-  font-weight: 700;
-  color: #1c1c1e;
-}
-
-.quick-stat .label {
-  font-size: 11px;
-  color: #8e8e93;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-top: 2px;
-}
-
-/* History List with Fade */
-.history-list-wrapper {
-  position: relative;
-  overflow: hidden;
-  max-height: 420px;
-}
-
 .history-list {
-  max-height: 420px;
-  overflow-y: auto;
-  padding-bottom: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
 }
 
-.history-list-wrapper::after {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 60px;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
-  pointer-events: none;
+.history-list.is-capped {
+  max-height: 380px;
+  overflow: hidden;
 }
 
 .history-item {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
-  padding: 14px 0;
-  border-bottom: 1px solid #f2f2f7;
-}
-
-.history-item:last-child {
-  border-bottom: none;
+  gap: 10px;
+  font-size: 13px;
 }
 
 .history-icon {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
 }
 
-/* Metric type icon colors */
-.history-icon.revenue { background: rgba(52, 199, 89, 0.15); color: #34c759; }
-.history-icon.views { background: rgba(0, 122, 255, 0.15); color: #007aff; }
-.history-icon.clicks { background: rgba(255, 149, 0, 0.15); color: #ff9500; }
-.history-icon.conversions { background: rgba(175, 82, 222, 0.15); color: #af52de; }
+.history-icon .status-dot { width: 7px; height: 7px; }
 
-/* Legacy icon classes */
-.history-icon.sale { background: rgba(0, 122, 255, 0.15); color: #007aff; }
-.history-icon.view { background: rgba(142, 142, 147, 0.15); color: #8e8e93; }
-.history-icon.promo { background: rgba(52, 199, 89, 0.15); color: #34c759; }
-.history-icon.mix { background: rgba(175, 82, 222, 0.15); color: #af52de; }
-
-.history-content {
-  flex: 1;
-  min-width: 0;
-}
+.history-content { flex: 1; min-width: 0; }
 
 .history-text {
-  font-size: 14px;
-  font-weight: 500;
-  color: #1c1c1e;
-  margin-bottom: 2px;
+  color: #111;
+  line-height: 1.35;
 }
 
 .history-meta {
   font-size: 12px;
-  color: #8e8e93;
-}
-
-.history-time {
-  font-size: 12px;
-  color: #c7c7cc;
-  flex-shrink: 0;
+  color: #9ca3af;
+  margin-top: 1px;
 }
 
 .history-amount {
-  font-size: 14px;
   font-weight: 600;
-  color: #34c759;
-  flex-shrink: 0;
+  color: #111;
 }
 
-/* Loading and Empty States */
-.history-loading,
-.history-empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100px;
-  color: #8e8e93;
-  font-size: 14px;
+.history-empty,
+.history-loading {
+  color: #9ca3af;
+  font-size: 13px;
+  padding: 16px 0;
+  text-align: center;
 }
 
-/* Notification Card */
+.view-all-btn {
+  width: 100%;
+  margin-top: 14px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 12.5px;
+  font-weight: 600;
+  background: #f4f4f2;
+  color: #111;
+  border: 1px solid #ececec;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.view-all-btn:hover { background: #ececec; }
+
+/* Notification banners - real app alerts, sit under the frame */
 .notification-card {
   display: flex;
   flex-direction: column;
   gap: 10px;
   margin-top: 16px;
-  flex-shrink: 0;
 }
 
 .notification-banner {
@@ -669,63 +510,33 @@
   transition: all 0.2s ease;
   text-decoration: none;
   cursor: pointer;
-  flex-shrink: 0;
 }
 
-.notification-banner.enable-extension {
-  background: rgba(0, 122, 255, 0.08);
-  color: #007aff;
-}
+.notification-banner.enable-extension { background: rgba(0, 122, 255, 0.08); color: #007aff; }
+.notification-banner.enable-extension:hover { background: rgba(0, 122, 255, 0.14); }
+.notification-banner.enable-extension strong { text-decoration: underline; }
+.notification-banner.upgrade-plan { background: rgba(255, 149, 0, 0.08); color: #e67e00; }
+.notification-banner.upgrade-plan:hover { background: rgba(255, 149, 0, 0.14); }
+.notification-icon { flex-shrink: 0; }
 
-.notification-banner.enable-extension:hover {
-  background: rgba(0, 122, 255, 0.14);
-}
-
-.notification-banner.enable-extension strong {
-  text-decoration: underline;
-}
-
-.notification-banner.upgrade-plan {
-  background: rgba(255, 149, 0, 0.08);
-  color: #e67e00;
-}
-
-.notification-banner.upgrade-plan:hover {
-  background: rgba(255, 149, 0, 0.14);
-}
-
-.notification-icon {
-  flex-shrink: 0;
-}
-
-/* Flash animation for banners before unmounting */
 @keyframes bannerFlash {
   0%, 100% { opacity: 1; }
   25% { opacity: 0.3; }
   50% { opacity: 1; }
   75% { opacity: 0.3; }
 }
+.notification-banner.flashing { animation: bannerFlash 0.6s ease-in-out; }
 
-.notification-banner.flashing {
-  animation: bannerFlash 0.6s ease-in-out;
-}
-
-/* Responsive adjustments for history column */
+/* Responsive */
 @media (max-width: 1024px) {
-  .history-column {
-    max-height: 400px;
-  }
+  .dashboard-layout { grid-template-columns: 1fr; }
+  .widgets-column { border-right: none; border-bottom: 1px solid #ececec; }
 }
 
-@media (max-width: 768px) {
-  .history-container {
-    padding: 16px;
-  }
-  .quick-stat .value {
-    font-size: 24px;
-  }
-  .notification-banner {
-    font-size: 12px;
-    padding: 10px 12px;
-  }
+@media (max-width: 640px) {
+  .dashboard-home { padding: 10px; }
+  .app-header { padding: 10px 14px; }
+  .hero-band { padding: 16px; }
+  .widgets-column, .history-column { padding: 16px; }
+  .widgets-grid { grid-template-columns: 1fr; }
 }

--- a/web/frontend/pages/DashboardHome.jsx
+++ b/web/frontend/pages/DashboardHome.jsx
@@ -335,7 +335,7 @@ export default function DashboardHome() {
 
   const checkExtensionStatus = async () => {
     try {
-      const response = await fetch("/api/subscription/extension-status");
+      const response = await fetch("/api/subscription/checkBusyBuddyEnabled");
       if (response.ok) {
         const data = await response.json();
         if (data.status === "SUCCESS") {

--- a/web/frontend/pages/DashboardHome.jsx
+++ b/web/frontend/pages/DashboardHome.jsx
@@ -9,7 +9,7 @@ import {
   Plus,
   Settings,
   DollarSign,
-  Eye,
+  AlarmClockOff,
   ExternalLink,
   Zap,
   TrendingUp,
@@ -84,7 +84,7 @@ const widgetConfig = [
     appId: "inactive_tab",
     title: "Inactive Tab Message",
     subtitle: "Re-engage tab-switchers",
-    icon: Eye,
+    icon: AlarmClockOff,
     iconBg: "#f4f4f2",
     accent: "#6b7280",
     settingsRoute: "/inactive-tab-message?tab=settings",
@@ -177,7 +177,7 @@ const activityIconMap = {
   volume: Layers,
   "mix-match": Shuffle,
   announcement: Megaphone,
-  "inactive-tab": Eye,
+  "inactive-tab": AlarmClockOff,
 };
 
 export default function DashboardHome() {
@@ -425,7 +425,6 @@ export default function DashboardHome() {
             <div className="app-header-brand">
               <span className="logo">🐝</span>
               <span className="name">BusyBuddy</span>
-              <span className="app-tag">Home</span>
             </div>
             <div className="app-header-actions">
               <div className="pill-nav">

--- a/web/frontend/pages/DashboardHome.jsx
+++ b/web/frontend/pages/DashboardHome.jsx
@@ -10,7 +10,6 @@ import {
   Settings,
   DollarSign,
   Eye,
-  MousePointer,
   ExternalLink,
   Zap,
   TrendingUp,
@@ -20,36 +19,30 @@ import {
 import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip } from "recharts";
 import "./DashboardHome.css";
 
-// Widget configuration with routes, colors, and the subscriptionConfig app id
-// used to read real plan-access + enabled/paused state from the subscription API.
+// Widget configuration: routes, plus the visual identity (icon/colors) and
+// short subtitle from the "Mockup A: Performance-first dashboard" reference,
+// and the subscriptionConfig app id used to read real plan-access/enabled
+// state from the subscription API. Order matches the reference layout.
 const widgetConfig = [
   {
     id: "announcement-bar",
     appId: "announcement_bar",
     title: "Announcement Bar",
-    description: "Display alerts and promotions at the top of your store",
+    subtitle: "Top-of-store alerts & promos",
     icon: Megaphone,
-    color: "orange",
+    iconBg: "#eef0ff",
+    accent: "#4f46e5",
     editorRoute: "/announcement-bar/editor",
     manageRoute: "/announcement-bar",
-  },
-  {
-    id: "inactive-tab-message",
-    appId: "inactive_tab",
-    title: "Inactive Tab Message",
-    description: "Re-engage visitors when they switch browser tabs",
-    icon: Eye,
-    color: "indigo",
-    settingsRoute: "/inactive-tab-message?tab=settings",
-    manageRoute: "/inactive-tab-message",
   },
   {
     id: "bundle-discount",
     appId: "bundle_discount",
     title: "Bundle Discounts",
-    description: "Create product bundles with automatic discounts",
+    subtitle: "Product bundles · auto discounts",
     icon: Package,
-    color: "blue",
+    iconBg: "#eaf3ff",
+    accent: "#0b76ef",
     editorRoute: "/bundle-discount/editor",
     manageRoute: "/bundle-discount",
   },
@@ -57,9 +50,10 @@ const widgetConfig = [
     id: "buy-one-get-one",
     appId: "buy_one_get_one",
     title: "Buy One Get One",
-    description: "BOGO deals, free gifts, and special offers",
+    subtitle: "BOGO deals & free gifts",
     icon: Gift,
-    color: "green",
+    iconBg: "#e8fbee",
+    accent: "#0f7a3b",
     editorRoute: "/buy-one-get-one/editor",
     manageRoute: "/buy-one-get-one",
   },
@@ -67,9 +61,10 @@ const widgetConfig = [
     id: "volume-discounts",
     appId: "volume_discounts",
     title: "Volume Discounts",
-    description: "Quantity-based pricing tiers and bulk savings",
+    subtitle: "Quantity tiers & bulk savings",
     icon: Layers,
-    color: "pink",
+    iconBg: "#fdecec",
+    accent: "#d63535",
     editorRoute: "/volume-discounts/editor",
     manageRoute: "/volume-discounts",
   },
@@ -77,11 +72,23 @@ const widgetConfig = [
     id: "mix-and-match",
     appId: "mix_match",
     title: "Mix & Match",
-    description: "Let customers build their own custom bundles",
+    subtitle: "Customer-built custom bundles",
     icon: Shuffle,
-    color: "purple",
+    iconBg: "#f2e8ff",
+    accent: "#7c3aed",
     editorRoute: "/mix-and-match/editor",
     manageRoute: "/mix-and-match",
+  },
+  {
+    id: "inactive-tab-message",
+    appId: "inactive_tab",
+    title: "Inactive Tab Message",
+    subtitle: "Re-engage tab-switchers",
+    icon: Eye,
+    iconBg: "#f4f4f2",
+    accent: "#6b7280",
+    settingsRoute: "/inactive-tab-message?tab=settings",
+    manageRoute: "/inactive-tab-message",
   },
 ];
 
@@ -89,25 +96,36 @@ const widgetConfig = [
 // as a safe default while the summary request is in flight.
 const IMPRESSION_TRACKED_WIDGET_IDS = ["announcement-bar"];
 
+// Maps ActivityLog widget slugs (returned by /api/activity/recent) to widget
+// ids, so "Recently edited" can rank widgets by their real last-touched event
+// instead of a fabricated timestamp.
+const ACTIVITY_SLUG_TO_WIDGET_ID = {
+  bundle: "bundle-discount",
+  bogo: "buy-one-get-one",
+  volume: "volume-discounts",
+  "mix-match": "mix-and-match",
+  announcement: "announcement-bar",
+  "inactive-tab": "inactive-tab-message",
+};
+
 const RANGE_OPTIONS = [
-  { id: "7d", label: "7D" },
-  { id: "30d", label: "30D" },
-  { id: "90d", label: "90D" },
+  { id: "7d", label: "7d" },
+  { id: "30d", label: "30d" },
+  { id: "90d", label: "90d" },
 ];
+
+const SORT_OPTIONS = [
+  { id: "revenue", label: "Revenue ↓" },
+  { id: "impressions", label: "Impressions" },
+  { id: "recent", label: "Recently edited" },
+];
+
+const ACTIVITY_REFRESH_MS = 30000;
+const ACTIVITY_VISIBLE_COUNT = 5;
 
 const EMPTY_WIDGET_METRICS = {
   revenue: { amount: 0, purchaseCount: 0, hasData: false, trend: [] },
   impressions: { tracked: false, hasData: false, views: null, clicks: null, ctr: null },
-};
-
-// Icon mapping for activity feed metric types
-const iconMap = {
-  bundle: Package,
-  announcement: Megaphone,
-  revenue: DollarSign,
-  views: Eye,
-  clicks: MousePointer,
-  default: Package,
 };
 
 function formatMoney(amount) {
@@ -121,7 +139,7 @@ function formatCompactNumber(n) {
   return `${value}`;
 }
 
-function Sparkline({ data, color = "#1c1c1e" }) {
+function Sparkline({ data, color }) {
   if (!data || data.length === 0) return null;
   const gradientId = `spark-${color.replace("#", "")}`;
   return (
@@ -130,7 +148,7 @@ function Sparkline({ data, color = "#1c1c1e" }) {
         <AreaChart data={data} margin={{ top: 2, right: 0, left: 0, bottom: 0 }}>
           <defs>
             <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor={color} stopOpacity={0.2} />
+              <stop offset="0%" stopColor={color} stopOpacity={0.18} />
               <stop offset="100%" stopColor={color} stopOpacity={0} />
             </linearGradient>
           </defs>
@@ -160,6 +178,15 @@ function RevenueChangeBadge({ change }) {
   );
 }
 
+const activityIconMap = {
+  bundle: Package,
+  bogo: Gift,
+  volume: Layers,
+  "mix-match": Shuffle,
+  announcement: Megaphone,
+  "inactive-tab": Eye,
+};
+
 export default function DashboardHome() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -172,8 +199,8 @@ export default function DashboardHome() {
   });
   const [loading, setLoading] = useState(true);
   const [activities, setActivities] = useState([]);
-  const [stats, setStats] = useState({ activeBundles: 0, activeAnnouncements: 0, eventsToday: 0 });
   const [activityLoading, setActivityLoading] = useState(true);
+  const [activityExpanded, setActivityExpanded] = useState(false);
   const [extensionEnabled, setExtensionEnabled] = useState(null); // null = loading
   const [showExtensionBanner, setShowExtensionBanner] = useState(false);
   const [showUpgradeBanner, setShowUpgradeBanner] = useState(false);
@@ -182,18 +209,25 @@ export default function DashboardHome() {
   const [range, setRange] = useState("7d");
   const [summary, setSummary] = useState(null);
   const [summaryLoading, setSummaryLoading] = useState(true);
+  const [sortBy, setSortBy] = useState("revenue");
 
   useEffect(() => {
     fetchUserSubscription();
     fetchActivityData();
     checkExtensionStatus();
 
+    // Live activity rail: refresh periodically so "Streaming" is a real claim.
+    const activityInterval = setInterval(fetchActivityData, ACTIVITY_REFRESH_MS);
+
     // Fallback: Force loading to false after 8 seconds if still loading
     const fallbackTimeout = setTimeout(() => {
       setLoading((prev) => (prev ? false : prev));
     }, 8000);
 
-    return () => clearTimeout(fallbackTimeout);
+    return () => {
+      clearInterval(activityInterval);
+      clearTimeout(fallbackTimeout);
+    };
   }, []);
 
   useEffect(() => {
@@ -271,7 +305,6 @@ export default function DashboardHome() {
         const data = await response.json();
         if (data.status === "SUCCESS") {
           setActivities(data.data.activities || []);
-          setStats(data.data.stats || { activeBundles: 0, activeAnnouncements: 0, eventsToday: 0 });
         }
       }
     } catch (err) {
@@ -387,161 +420,215 @@ export default function DashboardHome() {
     };
   };
 
+  // "Recently edited" ranks widgets by their real most-recent activity event
+  // (activities already arrive newest-first from the API) rather than a
+  // fabricated edit timestamp.
+  const recentActivityRank = () => {
+    const rank = {};
+    activities.forEach((item, index) => {
+      const widgetId = ACTIVITY_SLUG_TO_WIDGET_ID[item.widget];
+      if (widgetId && !(widgetId in rank)) rank[widgetId] = index;
+    });
+    return rank;
+  };
+
+  const getSortedWidgets = () => {
+    const rank = recentActivityRank();
+    return widgetConfig
+      .map((widget) => {
+        const metrics = widgetMetrics(widget.id);
+        let value;
+        if (sortBy === "impressions") {
+          value = metrics.impressions.tracked ? metrics.impressions.views ?? 0 : -1;
+        } else if (sortBy === "recent") {
+          value = rank[widget.id] === undefined ? -Infinity : -rank[widget.id];
+        } else {
+          value = metrics.revenue.amount || 0;
+        }
+        return { widget, metrics, value };
+      })
+      .sort((a, b) => b.value - a.value);
+  };
+
   const rangeLabel = RANGE_OPTIONS.find((r) => r.id === range)?.label || range;
   const trackedWidgetNames = (summary?.impressions?.trackedWidgetIds || IMPRESSION_TRACKED_WIDGET_IDS)
     .map((id) => widgetConfig.find((w) => w.id === id)?.title || id)
     .join(", ");
 
+  const visibleActivities = activityExpanded ? activities : activities.slice(0, ACTIVITY_VISIBLE_COUNT);
+
   return (
     <div className="dashboard-home">
       <div className="dashboard-inner">
-        {/* Range selector */}
-        <div className="range-bar">
-          <div className="pill-nav">
-            {RANGE_OPTIONS.map((opt) => (
-              <button
-                key={opt.id}
-                className={range === opt.id ? "active" : ""}
-                onClick={() => setRange(opt.id)}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Hero metrics band */}
-        <div className="hero-band">
-          <div className="hero-tile">
-            <div className="hero-label">Attributed revenue &middot; {rangeLabel}</div>
-            {summaryLoading ? (
-              <div className="hero-loading">Loading&hellip;</div>
-            ) : summary?.revenue?.hasData ? (
-              <>
-                <div className="hero-value-row">
-                  <span className="hero-value">{formatMoney(summary.revenue.amount)}</span>
-                  <RevenueChangeBadge change={summary.revenue.change} />
-                </div>
-                <Sparkline data={summary.revenue.trend} color="#1c1c1e" />
-              </>
-            ) : (
-              <div className="hero-empty">No attributed revenue recorded in this period yet.</div>
-            )}
-          </div>
-
-          <div className="hero-tile">
-            <div className="hero-label">Avg. attributed order value</div>
-            {summaryLoading ? (
-              <div className="hero-loading">Loading&hellip;</div>
-            ) : summary?.avgOrderValue != null ? (
-              <>
-                <div className="hero-value">{formatMoney(summary.avgOrderValue)}</div>
-                <div className="hero-sub">
-                  {summary.purchaseCount} attributed order{summary.purchaseCount === 1 ? "" : "s"}
-                </div>
-              </>
-            ) : (
-              <div className="hero-empty">No attributed purchases in this period yet.</div>
-            )}
-          </div>
-
-          <div className="hero-tile">
-            <div className="hero-label">Impressions</div>
-            {summaryLoading ? (
-              <div className="hero-loading">Loading&hellip;</div>
-            ) : summary?.impressions?.hasData ? (
-              <>
-                <div className="hero-value">{summary.impressions.views.toLocaleString()}</div>
-                <div className="hero-sub">
-                  CTR {summary.impressions.ctr.toFixed(1)}% &middot; tracked from {trackedWidgetNames}
-                </div>
-              </>
-            ) : (
-              <div className="hero-empty">
-                No impressions tracked yet{trackedWidgetNames ? ` (tracked from ${trackedWidgetNames})` : ""}.
+        <div className="app-frame">
+          {/* Header */}
+          <div className="app-header">
+            <div className="app-header-brand">
+              <span className="logo">🐝</span>
+              <span className="name">BusyBuddy</span>
+              <span className="app-tag">Home</span>
+            </div>
+            <div className="app-header-actions">
+              <div className="pill-nav">
+                {RANGE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.id}
+                    className={range === opt.id ? "active" : ""}
+                    onClick={() => setRange(opt.id)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
               </div>
-            )}
+              <a className="help-link" href="https://help.shopify.com" target="_blank" rel="noopener noreferrer">
+                Help
+              </a>
+            </div>
           </div>
 
-          <div className="hero-tile">
-            <div className="hero-label">Active widgets</div>
-            {loading ? (
-              <div className="hero-loading">Loading&hellip;</div>
-            ) : (
-              <>
-                <div className="hero-value">
-                  {subscription.enabledAppsCount}
-                  <span className="hero-value-sub"> / {subscription.maxAppsAllowed}</span>
+          {/* Hero metrics band */}
+          <div className="hero-band">
+            <div className="hero-tile">
+              <div className="hero-label">Attributed revenue &middot; {rangeLabel}</div>
+              {summaryLoading ? (
+                <div className="hero-loading">Loading&hellip;</div>
+              ) : summary?.revenue?.hasData ? (
+                <>
+                  <div className="hero-value-row">
+                    <span className="hero-value">{formatMoney(summary.revenue.amount)}</span>
+                    <RevenueChangeBadge change={summary.revenue.change} />
+                  </div>
+                  <Sparkline data={summary.revenue.trend} color="#111111" />
+                </>
+              ) : (
+                <div className="hero-empty">No attributed revenue recorded in this period yet.</div>
+              )}
+            </div>
+
+            <div className="hero-tile">
+              <div className="hero-label">Avg. attributed order value</div>
+              {summaryLoading ? (
+                <div className="hero-loading">Loading&hellip;</div>
+              ) : summary?.avgOrderValue != null ? (
+                <>
+                  <div className="hero-value">{formatMoney(summary.avgOrderValue)}</div>
+                  <div className="hero-sub">
+                    {summary.purchaseCount} attributed order{summary.purchaseCount === 1 ? "" : "s"}
+                  </div>
+                </>
+              ) : (
+                <div className="hero-empty">No attributed purchases in this period yet.</div>
+              )}
+            </div>
+
+            <div className="hero-tile">
+              <div className="hero-label">Impressions</div>
+              {summaryLoading ? (
+                <div className="hero-loading">Loading&hellip;</div>
+              ) : summary?.impressions?.hasData ? (
+                <>
+                  <div className="hero-value">{summary.impressions.views.toLocaleString()}</div>
+                  <div className="hero-sub">
+                    CTR {summary.impressions.ctr.toFixed(1)}% &middot; tracked from {trackedWidgetNames}
+                  </div>
+                </>
+              ) : (
+                <div className="hero-empty">
+                  No impressions tracked yet{trackedWidgetNames ? ` (tracked from ${trackedWidgetNames})` : ""}.
                 </div>
-                <div className="hero-sub">On the {subscription.planName} plan</div>
-              </>
-            )}
-          </div>
-        </div>
+              )}
+            </div>
 
-        <div className="dashboard-layout">
-          {/* Left Column - Widgets Grid */}
-          <div className="widgets-column">
-            <div className="widgets-container">
+            <div className="hero-tile">
+              <div className="hero-label">Active widgets</div>
+              {loading ? (
+                <div className="hero-loading">Loading&hellip;</div>
+              ) : (
+                <>
+                  <div className="hero-value">
+                    {subscription.enabledAppsCount}
+                    <span className="hero-value-sub"> / {subscription.maxAppsAllowed}</span>
+                  </div>
+                  <div className="hero-sub">On the {subscription.planName} plan</div>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Main content: widgets (9/12) + activity rail (3/12) */}
+          <div className="dashboard-layout">
+            <div className="widgets-column">
               <div className="section-header">
-                <h2 className="section-title">Your Widgets</h2>
+                <h2 className="section-title">Your widgets</h2>
+                <div className="sort-controls">
+                  Sort by
+                  {SORT_OPTIONS.map((opt) => (
+                    <span
+                      key={opt.id}
+                      className={`tag ${sortBy === opt.id ? "active" : ""}`}
+                      onClick={() => setSortBy(opt.id)}
+                    >
+                      {opt.label}
+                    </span>
+                  ))}
+                </div>
               </div>
+
               <div className="widgets-grid">
-                {widgetConfig.map((widget) => {
+                {getSortedWidgets().map(({ widget, metrics }) => {
                   const IconComponent = widget.icon;
                   const status = getWidgetStatus(widget);
-                  const metrics = widgetMetrics(widget.id);
 
                   return (
                     <div key={widget.id} className="widget-tile">
-                      <div className={`status-indicator ${status.state}`}>
-                        {status.state === "locked" ? <Lock size={9} /> : <span className="status-dot"></span>}
-                        {status.label}
+                      <div className="widget-tile-top">
+                        <div className="widget-icon-large" style={{ background: widget.iconBg, color: widget.accent }}>
+                          <IconComponent size={20} />
+                        </div>
+                        <div className={`status-indicator ${status.state}`}>
+                          {status.state === "locked" ? <Lock size={9} /> : <span className="status-dot"></span>}
+                          {status.label}
+                        </div>
                       </div>
-                      <div className={`widget-icon-large ${widget.color}`}>
-                        <IconComponent size={32} />
-                      </div>
-                      <div className="widget-name">{widget.title}</div>
-                      <div className="widget-desc">{widget.description}</div>
 
-                      <div className="widget-metrics">
-                        {summaryLoading ? (
-                          <div className="widget-metrics-empty">Loading performance&hellip;</div>
-                        ) : (
-                          <>
-                            <div className="widget-metrics-grid">
-                              <div className="widget-metric">
-                                <div className="metric-label">Revenue</div>
-                                <div className="metric-value">
-                                  {metrics.revenue.hasData ? formatMoney(metrics.revenue.amount) : "—"}
-                                </div>
+                      <div className="widget-name">{widget.title}</div>
+                      <div className="widget-desc">{widget.subtitle}</div>
+                      <div className="widget-divider"></div>
+
+                      {summaryLoading ? (
+                        <div className="widget-metrics-empty">Loading performance&hellip;</div>
+                      ) : (
+                        <>
+                          <div className="widget-metrics-grid">
+                            <div className="widget-metric">
+                              <div className="metric-label">Rev</div>
+                              <div className="metric-value">
+                                {metrics.revenue.hasData ? formatMoney(metrics.revenue.amount) : "—"}
                               </div>
-                              {metrics.impressions.tracked ? (
-                                <>
-                                  <div className="widget-metric">
-                                    <div className="metric-label">Impr.</div>
-                                    <div className="metric-value">
-                                      {formatCompactNumber(metrics.impressions.views)}
-                                    </div>
-                                  </div>
-                                  <div className="widget-metric">
-                                    <div className="metric-label">CTR</div>
-                                    <div className="metric-value">
-                                      {metrics.impressions.hasData ? `${metrics.impressions.ctr.toFixed(1)}%` : "—"}
-                                    </div>
-                                  </div>
-                                </>
-                              ) : (
-                                <div className="widget-metric-note">Impressions are not tracked for this widget yet</div>
-                              )}
                             </div>
-                            {metrics.revenue.hasData && <Sparkline data={metrics.revenue.trend} color="#4f46e5" />}
-                            {!metrics.revenue.hasData && !metrics.impressions.hasData && (
-                              <div className="widget-metrics-empty">No activity recorded in this period yet.</div>
+                            {metrics.impressions.tracked ? (
+                              <>
+                                <div className="widget-metric">
+                                  <div className="metric-label">Impr</div>
+                                  <div className="metric-value">{formatCompactNumber(metrics.impressions.views)}</div>
+                                </div>
+                                <div className="widget-metric">
+                                  <div className="metric-label">CTR</div>
+                                  <div className="metric-value">
+                                    {metrics.impressions.hasData ? `${metrics.impressions.ctr.toFixed(1)}%` : "—"}
+                                  </div>
+                                </div>
+                              </>
+                            ) : (
+                              <div className="widget-metric-note">Impressions are not tracked for this widget yet</div>
                             )}
-                          </>
-                        )}
-                      </div>
+                          </div>
+                          {metrics.revenue.hasData && <Sparkline data={metrics.revenue.trend} color={widget.accent} />}
+                          {!metrics.revenue.hasData && !metrics.impressions.hasData && (
+                            <div className="widget-metrics-empty">No activity recorded in this period yet.</div>
+                          )}
+                        </>
+                      )}
 
                       <div className="widget-buttons">
                         <button className="widget-btn create" onClick={() => handleCreate(widget)}>
@@ -556,86 +643,86 @@ export default function DashboardHome() {
                 })}
               </div>
             </div>
-          </div>
 
-          {/* Right Column - Recent Activity */}
-          <div className="history-column">
-            <div className="history-container">
+            {/* Activity rail */}
+            <div className="history-column">
               <div className="history-header">
-                <h2 className="history-title">Recent Activity</h2>
+                <h2 className="history-title">Live activity</h2>
+                <span className="app-tag">Streaming</span>
               </div>
 
-              {/* Quick Stats */}
-              <div className="quick-stats">
-                <div className="quick-stat">
-                  <div className="value">{stats.activeBundles}</div>
-                  <div className="label">Active Bundles</div>
-                </div>
-                <div className="quick-stat">
-                  <div className="value">{stats.activeAnnouncements}</div>
-                  <div className="label">Active Bars</div>
-                </div>
-              </div>
-
-              {/* Activity List */}
-              <div className="history-list-wrapper">
-                <div className="history-list">
-                  {activityLoading ? (
-                    <div className="history-loading">Loading activity...</div>
-                  ) : activities.length === 0 ? (
-                    <div className="history-empty">No activity yet</div>
-                  ) : (
-                    activities.map((item) => {
-                      const IconComponent = iconMap[item.iconClass] || iconMap[item.widget] || iconMap.default;
-                      return (
-                        <div key={item.id} className="history-item">
-                          <div className={`history-icon ${item.iconClass}`}>
-                            <IconComponent size={18} />
-                          </div>
-                          <div className="history-content">
-                            <div className="history-text">{item.title}</div>
-                            <div className="history-meta">{item.meta}</div>
-                          </div>
-                          {item.amount && <div className="history-amount">{item.amount}</div>}
-                          <div className="history-time">{item.time}</div>
+              <div className="history-list">
+                {activityLoading ? (
+                  <div className="history-loading">Loading activity...</div>
+                ) : activities.length === 0 ? (
+                  <div className="history-empty">No activity yet</div>
+                ) : (
+                  visibleActivities.map((item) => {
+                    const IconComponent = activityIconMap[item.widget] || DollarSign;
+                    const accent = widgetConfig.find((w) => w.id === ACTIVITY_SLUG_TO_WIDGET_ID[item.widget])?.accent || "#6b7280";
+                    return (
+                      <div key={item.id} className="history-item">
+                        <div className="history-icon" style={{ background: `${accent}1a`, color: accent }}>
+                          <IconComponent size={14} />
                         </div>
-                      );
-                    })
-                  )}
-                </div>
+                        <div className="history-content">
+                          <div className="history-text">
+                            <strong>{item.title}</strong>
+                          </div>
+                          <div className="history-meta">
+                            {item.meta}
+                            {item.amount && (
+                              <>
+                                {" "}
+                                &middot; <span className="history-amount">{item.amount}</span>
+                              </>
+                            )}
+                          </div>
+                          <div className="history-meta">{item.time}</div>
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
               </div>
-            </div>
 
-            {/* Notification Banners Card */}
-            {(showExtensionBanner || showUpgradeBanner) && (
-              <div className="notification-card">
-                {showExtensionBanner && (
-                  <a
-                    href={getThemeExtensionUrl()}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`notification-banner enable-extension ${extensionBannerFlashing ? "flashing" : ""}`}
-                  >
-                    <ExternalLink size={16} className="notification-icon" />
-                    <span>
-                      Enable BusyBuddy: open the theme editor, then{" "}
-                      <strong>Add block &gt; Apps &gt; BusyBuddy Announcement</strong>
-                    </span>
-                  </a>
-                )}
-                {showUpgradeBanner && (
-                  <div
-                    className={`notification-banner upgrade-plan ${upgradeBannerFlashing ? "flashing" : ""}`}
-                    onClick={() => navigate("/plan" + location.search)}
-                  >
-                    <Zap size={16} className="notification-icon" />
-                    <span>Upgrade your plan for more features!</span>
-                  </div>
-                )}
+              {activities.length > ACTIVITY_VISIBLE_COUNT && (
+                <button className="view-all-btn" onClick={() => setActivityExpanded((prev) => !prev)}>
+                  {activityExpanded ? "Show less" : "View all activity"}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Notification Banners */}
+        {(showExtensionBanner || showUpgradeBanner) && (
+          <div className="notification-card">
+            {showExtensionBanner && (
+              <a
+                href={getThemeExtensionUrl()}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`notification-banner enable-extension ${extensionBannerFlashing ? "flashing" : ""}`}
+              >
+                <ExternalLink size={16} className="notification-icon" />
+                <span>
+                  Enable BusyBuddy: open the theme editor, then{" "}
+                  <strong>Add block &gt; Apps &gt; BusyBuddy Announcement</strong>
+                </span>
+              </a>
+            )}
+            {showUpgradeBanner && (
+              <div
+                className={`notification-banner upgrade-plan ${upgradeBannerFlashing ? "flashing" : ""}`}
+                onClick={() => navigate("/plan" + location.search)}
+              >
+                <Zap size={16} className="notification-icon" />
+                <span>Upgrade your plan for more features!</span>
               </div>
             )}
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/web/frontend/pages/DashboardHome.jsx
+++ b/web/frontend/pages/DashboardHome.jsx
@@ -114,14 +114,7 @@ const RANGE_OPTIONS = [
   { id: "90d", label: "90d" },
 ];
 
-const SORT_OPTIONS = [
-  { id: "revenue", label: "Revenue ↓" },
-  { id: "impressions", label: "Impressions" },
-  { id: "recent", label: "Recently edited" },
-];
-
 const ACTIVITY_REFRESH_MS = 30000;
-const ACTIVITY_VISIBLE_COUNT = 5;
 
 const EMPTY_WIDGET_METRICS = {
   revenue: { amount: 0, purchaseCount: 0, hasData: false, trend: [] },
@@ -200,7 +193,6 @@ export default function DashboardHome() {
   const [loading, setLoading] = useState(true);
   const [activities, setActivities] = useState([]);
   const [activityLoading, setActivityLoading] = useState(true);
-  const [activityExpanded, setActivityExpanded] = useState(false);
   const [extensionEnabled, setExtensionEnabled] = useState(null); // null = loading
   const [showExtensionBanner, setShowExtensionBanner] = useState(false);
   const [showUpgradeBanner, setShowUpgradeBanner] = useState(false);
@@ -209,7 +201,6 @@ export default function DashboardHome() {
   const [range, setRange] = useState("7d");
   const [summary, setSummary] = useState(null);
   const [summaryLoading, setSummaryLoading] = useState(true);
-  const [sortBy, setSortBy] = useState("revenue");
 
   useEffect(() => {
     fetchUserSubscription();
@@ -420,42 +411,10 @@ export default function DashboardHome() {
     };
   };
 
-  // "Recently edited" ranks widgets by their real most-recent activity event
-  // (activities already arrive newest-first from the API) rather than a
-  // fabricated edit timestamp.
-  const recentActivityRank = () => {
-    const rank = {};
-    activities.forEach((item, index) => {
-      const widgetId = ACTIVITY_SLUG_TO_WIDGET_ID[item.widget];
-      if (widgetId && !(widgetId in rank)) rank[widgetId] = index;
-    });
-    return rank;
-  };
-
-  const getSortedWidgets = () => {
-    const rank = recentActivityRank();
-    return widgetConfig
-      .map((widget) => {
-        const metrics = widgetMetrics(widget.id);
-        let value;
-        if (sortBy === "impressions") {
-          value = metrics.impressions.tracked ? metrics.impressions.views ?? 0 : -1;
-        } else if (sortBy === "recent") {
-          value = rank[widget.id] === undefined ? -Infinity : -rank[widget.id];
-        } else {
-          value = metrics.revenue.amount || 0;
-        }
-        return { widget, metrics, value };
-      })
-      .sort((a, b) => b.value - a.value);
-  };
-
   const rangeLabel = RANGE_OPTIONS.find((r) => r.id === range)?.label || range;
   const trackedWidgetNames = (summary?.impressions?.trackedWidgetIds || IMPRESSION_TRACKED_WIDGET_IDS)
     .map((id) => widgetConfig.find((w) => w.id === id)?.title || id)
     .join(", ");
-
-  const visibleActivities = activityExpanded ? activities : activities.slice(0, ACTIVITY_VISIBLE_COUNT);
 
   return (
     <div className="dashboard-home">
@@ -560,24 +519,13 @@ export default function DashboardHome() {
             <div className="widgets-column">
               <div className="section-header">
                 <h2 className="section-title">Your widgets</h2>
-                <div className="sort-controls">
-                  Sort by
-                  {SORT_OPTIONS.map((opt) => (
-                    <span
-                      key={opt.id}
-                      className={`tag ${sortBy === opt.id ? "active" : ""}`}
-                      onClick={() => setSortBy(opt.id)}
-                    >
-                      {opt.label}
-                    </span>
-                  ))}
-                </div>
               </div>
 
               <div className="widgets-grid">
-                {getSortedWidgets().map(({ widget, metrics }) => {
+                {widgetConfig.map((widget) => {
                   const IconComponent = widget.icon;
                   const status = getWidgetStatus(widget);
+                  const metrics = widgetMetrics(widget.id);
 
                   return (
                     <div key={widget.id} className="widget-tile">
@@ -657,7 +605,7 @@ export default function DashboardHome() {
                 ) : activities.length === 0 ? (
                   <div className="history-empty">No activity yet</div>
                 ) : (
-                  visibleActivities.map((item) => {
+                  activities.map((item) => {
                     const IconComponent = activityIconMap[item.widget] || DollarSign;
                     const accent = widgetConfig.find((w) => w.id === ACTIVITY_SLUG_TO_WIDGET_ID[item.widget])?.accent || "#6b7280";
                     return (
@@ -685,12 +633,6 @@ export default function DashboardHome() {
                   })
                 )}
               </div>
-
-              {activities.length > ACTIVITY_VISIBLE_COUNT && (
-                <button className="view-all-btn" onClick={() => setActivityExpanded((prev) => !prev)}>
-                  {activityExpanded ? "Show less" : "View all activity"}
-                </button>
-              )}
             </div>
           </div>
         </div>

--- a/web/frontend/pages/DashboardHome.jsx
+++ b/web/frontend/pages/DashboardHome.jsx
@@ -13,13 +13,19 @@ import {
   MousePointer,
   ExternalLink,
   Zap,
+  TrendingUp,
+  TrendingDown,
+  Lock,
 } from "lucide-react";
+import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip } from "recharts";
 import "./DashboardHome.css";
 
-// Widget configuration with routes and colors
+// Widget configuration with routes, colors, and the subscriptionConfig app id
+// used to read real plan-access + enabled/paused state from the subscription API.
 const widgetConfig = [
   {
     id: "announcement-bar",
+    appId: "announcement_bar",
     title: "Announcement Bar",
     description: "Display alerts and promotions at the top of your store",
     icon: Megaphone,
@@ -29,6 +35,7 @@ const widgetConfig = [
   },
   {
     id: "inactive-tab-message",
+    appId: "inactive_tab",
     title: "Inactive Tab Message",
     description: "Re-engage visitors when they switch browser tabs",
     icon: Eye,
@@ -38,6 +45,7 @@ const widgetConfig = [
   },
   {
     id: "bundle-discount",
+    appId: "bundle_discount",
     title: "Bundle Discounts",
     description: "Create product bundles with automatic discounts",
     icon: Package,
@@ -47,6 +55,7 @@ const widgetConfig = [
   },
   {
     id: "buy-one-get-one",
+    appId: "buy_one_get_one",
     title: "Buy One Get One",
     description: "BOGO deals, free gifts, and special offers",
     icon: Gift,
@@ -56,6 +65,7 @@ const widgetConfig = [
   },
   {
     id: "volume-discounts",
+    appId: "volume_discounts",
     title: "Volume Discounts",
     description: "Quantity-based pricing tiers and bulk savings",
     icon: Layers,
@@ -65,6 +75,7 @@ const widgetConfig = [
   },
   {
     id: "mix-and-match",
+    appId: "mix_match",
     title: "Mix & Match",
     description: "Let customers build their own custom bundles",
     icon: Shuffle,
@@ -74,27 +85,22 @@ const widgetConfig = [
   },
 ];
 
-// Plan features mapping
-const planFeatures = {
-  Free: ["announcement-bar", "inactive-tab-message"],
-  Starter: [
-    "announcement-bar",
-    "inactive-tab-message",
-    "bundle-discount",
-    "buy-one-get-one",
-    "volume-discounts",
-  ],
-  Advanced: [
-    "announcement-bar",
-    "inactive-tab-message",
-    "bundle-discount",
-    "buy-one-get-one",
-    "volume-discounts",
-    "mix-and-match",
-  ],
+// Mirrors controller/dashboard/index.js#IMPRESSION_TRACKED_SLUGS - used only
+// as a safe default while the summary request is in flight.
+const IMPRESSION_TRACKED_WIDGET_IDS = ["announcement-bar"];
+
+const RANGE_OPTIONS = [
+  { id: "7d", label: "7D" },
+  { id: "30d", label: "30D" },
+  { id: "90d", label: "90D" },
+];
+
+const EMPTY_WIDGET_METRICS = {
+  revenue: { amount: 0, purchaseCount: 0, hasData: false, trend: [] },
+  impressions: { tracked: false, hasData: false, views: null, clicks: null, ctr: null },
 };
 
-// Icon mapping for metric types
+// Icon mapping for activity feed metric types
 const iconMap = {
   bundle: Package,
   announcement: Megaphone,
@@ -104,10 +110,66 @@ const iconMap = {
   default: Package,
 };
 
+function formatMoney(amount) {
+  const rounded = Math.round(Number(amount) || 0);
+  return `$${rounded.toLocaleString("en-US")}`;
+}
+
+function formatCompactNumber(n) {
+  const value = Number(n) || 0;
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return `${value}`;
+}
+
+function Sparkline({ data, color = "#1c1c1e" }) {
+  if (!data || data.length === 0) return null;
+  const gradientId = `spark-${color.replace("#", "")}`;
+  return (
+    <div className="widget-spark">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ top: 2, right: 0, left: 0, bottom: 0 }}>
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity={0.2} />
+              <stop offset="100%" stopColor={color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <XAxis dataKey="date" hide />
+          <YAxis hide domain={["auto", "auto"]} />
+          <Tooltip formatter={(value) => [formatMoney(value), "Revenue"]} labelFormatter={(label) => label} />
+          <Area type="monotone" dataKey="revenue" stroke={color} strokeWidth={1.5} fill={`url(#${gradientId})`} />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function RevenueChangeBadge({ change }) {
+  if (!change) return null;
+  if (change.kind === "new") {
+    return <span className="hero-badge hero-badge-new">New this period</span>;
+  }
+  const isUp = change.kind === "up";
+  const Icon = isUp ? TrendingUp : TrendingDown;
+  return (
+    <span className={`hero-badge ${isUp ? "hero-badge-up" : "hero-badge-down"}`}>
+      <Icon size={12} />
+      {change.pct >= 0 ? "+" : ""}
+      {change.pct.toFixed(1)}%
+    </span>
+  );
+}
+
 export default function DashboardHome() {
   const navigate = useNavigate();
   const location = useLocation();
-  const [currentPlan, setCurrentPlan] = useState("Free");
+  const [subscription, setSubscription] = useState({
+    planName: "Free",
+    maxAppsAllowed: 1,
+    enabledAppsCount: 0,
+    enabledApps: [],
+    subscriptionConfig: null,
+  });
   const [loading, setLoading] = useState(true);
   const [activities, setActivities] = useState([]);
   const [stats, setStats] = useState({ activeBundles: 0, activeAnnouncements: 0, eventsToday: 0 });
@@ -117,36 +179,31 @@ export default function DashboardHome() {
   const [showUpgradeBanner, setShowUpgradeBanner] = useState(false);
   const [extensionBannerFlashing, setExtensionBannerFlashing] = useState(false);
   const [upgradeBannerFlashing, setUpgradeBannerFlashing] = useState(false);
+  const [range, setRange] = useState("7d");
+  const [summary, setSummary] = useState(null);
+  const [summaryLoading, setSummaryLoading] = useState(true);
 
   useEffect(() => {
-    console.log("[DEBUG useEffect] Component mounted, fetching data...");
     fetchUserSubscription();
     fetchActivityData();
     checkExtensionStatus();
-    
+
     // Fallback: Force loading to false after 8 seconds if still loading
     const fallbackTimeout = setTimeout(() => {
-      setLoading((prev) => {
-        if (prev) {
-          console.log("[DEBUG] Fallback timeout - forcing loading to false");
-          return false;
-        }
-        return prev;
-      });
+      setLoading((prev) => (prev ? false : prev));
     }, 8000);
-    
+
     return () => clearTimeout(fallbackTimeout);
   }, []);
 
-  // Debug: Log state changes
   useEffect(() => {
-    console.log("[DEBUG State] loading:", loading, "currentPlan:", currentPlan);
-  }, [loading, currentPlan]);
+    fetchDashboardSummary(range);
+  }, [range]);
 
   // Handle extension banner visibility with flash animation
   useEffect(() => {
     if (extensionEnabled === null) return; // Still loading
-    
+
     if (extensionEnabled === false) {
       setShowExtensionBanner(true);
     } else if (showExtensionBanner) {
@@ -163,8 +220,8 @@ export default function DashboardHome() {
   // Handle upgrade banner visibility with flash animation
   useEffect(() => {
     if (loading) return; // Still loading
-    
-    const isHighestPlan = currentPlan === "Advanced";
+
+    const isHighestPlan = subscription.planName === "Advanced";
     if (!isHighestPlan) {
       setShowUpgradeBanner(true);
     } else if (showUpgradeBanner) {
@@ -176,48 +233,33 @@ export default function DashboardHome() {
       }, 600);
       return () => clearTimeout(timer);
     }
-  }, [currentPlan, loading]);
+  }, [subscription.planName, loading]);
 
   const fetchUserSubscription = async () => {
-    console.log("[DEBUG fetchUserSubscription] Starting...");
-    
-    // Create abort controller with 5 second timeout
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      console.log("[DEBUG fetchUserSubscription] Timeout - aborting fetch");
-      controller.abort();
-    }, 5000);
-    
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
     try {
-      // Use simple URL - let Shopify session middleware handle auth
-      const apiUrl = `/api/subscription/getUserSubscription`;
-      console.log("[DEBUG fetchUserSubscription] URL:", apiUrl);
-      
-      const response = await fetch(apiUrl, {
+      const response = await fetch(`/api/subscription/getUserSubscription`, {
         signal: controller.signal,
-        credentials: 'include'  // Include cookies for session
+        credentials: "include",
       });
       clearTimeout(timeoutId);
-      console.log("[DEBUG fetchUserSubscription] Response status:", response.status);
       if (response.ok) {
         const data = await response.json();
-        console.log("[DEBUG fetchUserSubscription] Data:", data);
         if (data.status === "SUCCESS") {
-          setCurrentPlan(data.data.planName);
-          console.log("[DEBUG fetchUserSubscription] Set plan to:", data.data.planName);
+          setSubscription({
+            planName: data.data.planName,
+            maxAppsAllowed: data.data.maxAppsAllowed,
+            enabledAppsCount: data.data.enabledAppsCount,
+            enabledApps: data.data.enabledApps || [],
+            subscriptionConfig: data.data.subscriptionConfig || null,
+          });
         }
-      } else {
-        console.error("[DEBUG fetchUserSubscription] HTTP Error:", response.status, await response.text());
       }
     } catch (err) {
-      clearTimeout(timeoutId);
-      if (err.name === 'AbortError') {
-        console.error("[DEBUG fetchUserSubscription] Request timed out");
-      } else {
-        console.error("[DEBUG fetchUserSubscription] Error:", err);
-      }
+      console.error("[DashboardHome] Error fetching subscription:", err);
     } finally {
-      console.log("[DEBUG fetchUserSubscription] Setting loading to false");
       setLoading(false);
     }
   };
@@ -236,6 +278,25 @@ export default function DashboardHome() {
       console.error("Error fetching activity:", err);
     } finally {
       setActivityLoading(false);
+    }
+  };
+
+  const fetchDashboardSummary = async (selectedRange) => {
+    setSummaryLoading(true);
+    try {
+      const response = await fetch(`/api/dashboard/summary?range=${selectedRange}`, {
+        credentials: "include",
+      });
+      if (response.ok) {
+        const data = await response.json();
+        if (data.status === "SUCCESS") {
+          setSummary(data.data);
+        }
+      }
+    } catch (err) {
+      console.error("Error fetching dashboard summary:", err);
+    } finally {
+      setSummaryLoading(false);
     }
   };
 
@@ -261,33 +322,43 @@ export default function DashboardHome() {
     const params = new URLSearchParams(location.search);
     const shop = params.get("shop");
     if (shop) {
-      // No ?context=apps here: that param opens the theme editor's "App
-      // embeds" panel, but the Announcement Bar block targets "section"
-      // (not an app embed), so it never appears there. Link to the plain
-      // editor instead - merchants add it via "Add block" > Apps.
       return `https://${shop}/admin/themes/current/editor`;
     }
     return "#";
   };
 
-  const isWidgetAccessible = (widgetId) => {
-    return planFeatures[currentPlan]?.includes(widgetId) || false;
+  // Real plan-access + enabled/paused state, sourced from
+  // /api/subscription/getUserSubscription (subscriptionConfig.allowedApps +
+  // enabledApps) rather than a hardcoded, possibly-stale plan/feature map.
+  const getWidgetStatus = (widget) => {
+    const planConfig = subscription.subscriptionConfig?.[subscription.planName];
+    const planAccessible = planConfig?.allowedApps?.includes(widget.appId) || false;
+
+    if (!planAccessible) {
+      return { state: "locked", label: "Locked" };
+    }
+
+    const entry = subscription.enabledApps.find((app) => app.appId === widget.appId);
+    if (entry?.enabled) {
+      return { state: "active", label: "Active" };
+    }
+    if (entry) {
+      return { state: "paused", label: "Paused" };
+    }
+    return { state: "not-set-up", label: "Needs setup" };
   };
 
+  const isWidgetAccessible = (widget) => getWidgetStatus(widget).state !== "locked";
+
   const handleCreate = (widget) => {
-    // Don't check plan access if subscription is still loading
-    // This prevents redirecting to /plan due to default "Free" state
-    if (!loading && !isWidgetAccessible(widget.id)) {
+    if (!loading && !isWidgetAccessible(widget)) {
       navigate("/plan" + location.search);
       return;
     }
-    
+
     if (widget.settingsRoute) {
-      // Inactive Tab Message: Navigate to settings tab (same window)
       navigate(widget.settingsRoute + (location.search ? "&" + location.search.slice(1) : ""));
     } else {
-      // All other apps: Open editor in new tab (fullscreen, no App Bridge)
-      // Use /editor.html to load standalone editor without Shopify admin shell
       const params = new URLSearchParams(location.search);
       const shop = params.get("shop");
       const queryString = shop ? `?shop=${shop}` : "";
@@ -296,147 +367,274 @@ export default function DashboardHome() {
   };
 
   const handleManage = (widget) => {
-    console.log("[DEBUG handleManage] Called with widget:", widget.id);
-    console.log("[DEBUG handleManage] loading:", loading);
-    console.log("[DEBUG handleManage] currentPlan:", currentPlan);
-    console.log("[DEBUG handleManage] isWidgetAccessible:", isWidgetAccessible(widget.id));
-    console.log("[DEBUG handleManage] location.search:", location.search);
-    console.log("[DEBUG handleManage] Full route:", widget.manageRoute + location.search);
-    
-    // Don't check plan access if subscription is still loading
-    // This prevents redirecting to /plan due to default "Free" state
-    if (!loading && !isWidgetAccessible(widget.id)) {
-      console.log("[DEBUG handleManage] Redirecting to /plan");
+    if (!loading && !isWidgetAccessible(widget)) {
       navigate("/plan" + location.search);
       return;
     }
-    // Navigate to app homepage
-    console.log("[DEBUG handleManage] Navigating to:", widget.manageRoute + location.search);
     navigate(widget.manageRoute + location.search);
-    console.log("[DEBUG handleManage] navigate() called");
   };
+
+  const widgetMetrics = (widgetId) => {
+    const fromSummary = summary?.widgets?.find((w) => w.id === widgetId);
+    if (fromSummary) return fromSummary;
+    return {
+      id: widgetId,
+      ...EMPTY_WIDGET_METRICS,
+      impressions: {
+        ...EMPTY_WIDGET_METRICS.impressions,
+        tracked: IMPRESSION_TRACKED_WIDGET_IDS.includes(widgetId),
+      },
+    };
+  };
+
+  const rangeLabel = RANGE_OPTIONS.find((r) => r.id === range)?.label || range;
+  const trackedWidgetNames = (summary?.impressions?.trackedWidgetIds || IMPRESSION_TRACKED_WIDGET_IDS)
+    .map((id) => widgetConfig.find((w) => w.id === id)?.title || id)
+    .join(", ");
 
   return (
     <div className="dashboard-home">
-      <div className="dashboard-layout">
-        {/* Left Column - Widgets Grid */}
-        <div className="widgets-column">
-          <div className="widgets-container">
-            <div className="section-header">
-              <h2 className="section-title">Your Widgets</h2>
-            </div>
-            <div className="widgets-grid">
-              {widgetConfig.map((widget) => {
-                const IconComponent = widget.icon;
-                const accessible = isWidgetAccessible(widget.id);
-
-                return (
-                  <div key={widget.id} className="widget-tile">
-                    <div className={`status-indicator ${accessible ? "active" : "inactive"}`}>
-                      <span className="status-dot"></span>
-                      {accessible ? "Active" : "Inactive"}
-                    </div>
-                    <div className={`widget-icon-large ${widget.color}`}>
-                      <IconComponent size={32} />
-                    </div>
-                    <div className="widget-name">{widget.title}</div>
-                    <div className="widget-desc">{widget.description}</div>
-                    <div className="widget-buttons">
-                      <button
-                        className="widget-btn create"
-                        onClick={() => handleCreate(widget)}
-                      >
-                        <Plus size={12} /> Create
-                      </button>
-                      <button
-                        className="widget-btn manage"
-                        onClick={() => handleManage(widget)}
-                      >
-                        <Settings size={12} /> Manage
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
+      <div className="dashboard-inner">
+        {/* Range selector */}
+        <div className="range-bar">
+          <div className="pill-nav">
+            {RANGE_OPTIONS.map((opt) => (
+              <button
+                key={opt.id}
+                className={range === opt.id ? "active" : ""}
+                onClick={() => setRange(opt.id)}
+              >
+                {opt.label}
+              </button>
+            ))}
           </div>
         </div>
 
-        {/* Right Column - Recent Activity */}
-        <div className="history-column">
-          <div className="history-container">
-            <div className="history-header">
-              <h2 className="history-title">Recent Activity</h2>
-            </div>
+        {/* Hero metrics band */}
+        <div className="hero-band">
+          <div className="hero-tile">
+            <div className="hero-label">Attributed revenue &middot; {rangeLabel}</div>
+            {summaryLoading ? (
+              <div className="hero-loading">Loading&hellip;</div>
+            ) : summary?.revenue?.hasData ? (
+              <>
+                <div className="hero-value-row">
+                  <span className="hero-value">{formatMoney(summary.revenue.amount)}</span>
+                  <RevenueChangeBadge change={summary.revenue.change} />
+                </div>
+                <Sparkline data={summary.revenue.trend} color="#1c1c1e" />
+              </>
+            ) : (
+              <div className="hero-empty">No attributed revenue recorded in this period yet.</div>
+            )}
+          </div>
 
-            {/* Quick Stats */}
-            <div className="quick-stats">
-              <div className="quick-stat">
-                <div className="value">{stats.activeBundles}</div>
-                <div className="label">Active Bundles</div>
-              </div>
-              <div className="quick-stat">
-                <div className="value">{stats.activeAnnouncements}</div>
-                <div className="label">Active Bars</div>
-              </div>
-            </div>
+          <div className="hero-tile">
+            <div className="hero-label">Avg. attributed order value</div>
+            {summaryLoading ? (
+              <div className="hero-loading">Loading&hellip;</div>
+            ) : summary?.avgOrderValue != null ? (
+              <>
+                <div className="hero-value">{formatMoney(summary.avgOrderValue)}</div>
+                <div className="hero-sub">
+                  {summary.purchaseCount} attributed order{summary.purchaseCount === 1 ? "" : "s"}
+                </div>
+              </>
+            ) : (
+              <div className="hero-empty">No attributed purchases in this period yet.</div>
+            )}
+          </div>
 
-            {/* Activity List */}
-            <div className="history-list-wrapper">
-              <div className="history-list">
-                {activityLoading ? (
-                  <div className="history-loading">Loading activity...</div>
-                ) : activities.length === 0 ? (
-                  <div className="history-empty">No activity yet</div>
-                ) : (
-                  activities.map((item) => {
-                    const IconComponent = iconMap[item.iconClass] || iconMap[item.widget] || iconMap.default;
-                    return (
-                      <div key={item.id} className="history-item">
-                        <div className={`history-icon ${item.iconClass}`}>
-                          <IconComponent size={18} />
-                        </div>
-                        <div className="history-content">
-                          <div className="history-text">{item.title}</div>
-                          <div className="history-meta">{item.meta}</div>
-                        </div>
-                        {item.amount && (
-                          <div className="history-amount">{item.amount}</div>
-                        )}
-                        <div className="history-time">{item.time}</div>
+          <div className="hero-tile">
+            <div className="hero-label">Impressions</div>
+            {summaryLoading ? (
+              <div className="hero-loading">Loading&hellip;</div>
+            ) : summary?.impressions?.hasData ? (
+              <>
+                <div className="hero-value">{summary.impressions.views.toLocaleString()}</div>
+                <div className="hero-sub">
+                  CTR {summary.impressions.ctr.toFixed(1)}% &middot; tracked from {trackedWidgetNames}
+                </div>
+              </>
+            ) : (
+              <div className="hero-empty">
+                No impressions tracked yet{trackedWidgetNames ? ` (tracked from ${trackedWidgetNames})` : ""}.
+              </div>
+            )}
+          </div>
+
+          <div className="hero-tile">
+            <div className="hero-label">Active widgets</div>
+            {loading ? (
+              <div className="hero-loading">Loading&hellip;</div>
+            ) : (
+              <>
+                <div className="hero-value">
+                  {subscription.enabledAppsCount}
+                  <span className="hero-value-sub"> / {subscription.maxAppsAllowed}</span>
+                </div>
+                <div className="hero-sub">On the {subscription.planName} plan</div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="dashboard-layout">
+          {/* Left Column - Widgets Grid */}
+          <div className="widgets-column">
+            <div className="widgets-container">
+              <div className="section-header">
+                <h2 className="section-title">Your Widgets</h2>
+              </div>
+              <div className="widgets-grid">
+                {widgetConfig.map((widget) => {
+                  const IconComponent = widget.icon;
+                  const status = getWidgetStatus(widget);
+                  const metrics = widgetMetrics(widget.id);
+
+                  return (
+                    <div key={widget.id} className="widget-tile">
+                      <div className={`status-indicator ${status.state}`}>
+                        {status.state === "locked" ? <Lock size={9} /> : <span className="status-dot"></span>}
+                        {status.label}
                       </div>
-                    );
-                  })
-                )}
+                      <div className={`widget-icon-large ${widget.color}`}>
+                        <IconComponent size={32} />
+                      </div>
+                      <div className="widget-name">{widget.title}</div>
+                      <div className="widget-desc">{widget.description}</div>
+
+                      <div className="widget-metrics">
+                        {summaryLoading ? (
+                          <div className="widget-metrics-empty">Loading performance&hellip;</div>
+                        ) : (
+                          <>
+                            <div className="widget-metrics-grid">
+                              <div className="widget-metric">
+                                <div className="metric-label">Revenue</div>
+                                <div className="metric-value">
+                                  {metrics.revenue.hasData ? formatMoney(metrics.revenue.amount) : "—"}
+                                </div>
+                              </div>
+                              {metrics.impressions.tracked ? (
+                                <>
+                                  <div className="widget-metric">
+                                    <div className="metric-label">Impr.</div>
+                                    <div className="metric-value">
+                                      {formatCompactNumber(metrics.impressions.views)}
+                                    </div>
+                                  </div>
+                                  <div className="widget-metric">
+                                    <div className="metric-label">CTR</div>
+                                    <div className="metric-value">
+                                      {metrics.impressions.hasData ? `${metrics.impressions.ctr.toFixed(1)}%` : "—"}
+                                    </div>
+                                  </div>
+                                </>
+                              ) : (
+                                <div className="widget-metric-note">Impressions are not tracked for this widget yet</div>
+                              )}
+                            </div>
+                            {metrics.revenue.hasData && <Sparkline data={metrics.revenue.trend} color="#4f46e5" />}
+                            {!metrics.revenue.hasData && !metrics.impressions.hasData && (
+                              <div className="widget-metrics-empty">No activity recorded in this period yet.</div>
+                            )}
+                          </>
+                        )}
+                      </div>
+
+                      <div className="widget-buttons">
+                        <button className="widget-btn create" onClick={() => handleCreate(widget)}>
+                          <Plus size={12} /> Create
+                        </button>
+                        <button className="widget-btn manage" onClick={() => handleManage(widget)}>
+                          <Settings size={12} /> Manage
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           </div>
 
-          {/* Notification Banners Card */}
-          {(showExtensionBanner || showUpgradeBanner) && (
-            <div className="notification-card">
-              {showExtensionBanner && (
-                <a
-                  href={getThemeExtensionUrl()}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={`notification-banner enable-extension ${extensionBannerFlashing ? "flashing" : ""}`}
-                >
-                  <ExternalLink size={16} className="notification-icon" />
-                  <span>Enable BusyBuddy: open the theme editor, then <strong>Add block &gt; Apps &gt; BusyBuddy Announcement</strong></span>
-                </a>
-              )}
-              {showUpgradeBanner && (
-                <div
-                  className={`notification-banner upgrade-plan ${upgradeBannerFlashing ? "flashing" : ""}`}
-                  onClick={() => navigate("/plan" + location.search)}
-                >
-                  <Zap size={16} className="notification-icon" />
-                  <span>Upgrade your plan for more features!</span>
+          {/* Right Column - Recent Activity */}
+          <div className="history-column">
+            <div className="history-container">
+              <div className="history-header">
+                <h2 className="history-title">Recent Activity</h2>
+              </div>
+
+              {/* Quick Stats */}
+              <div className="quick-stats">
+                <div className="quick-stat">
+                  <div className="value">{stats.activeBundles}</div>
+                  <div className="label">Active Bundles</div>
                 </div>
-              )}
+                <div className="quick-stat">
+                  <div className="value">{stats.activeAnnouncements}</div>
+                  <div className="label">Active Bars</div>
+                </div>
+              </div>
+
+              {/* Activity List */}
+              <div className="history-list-wrapper">
+                <div className="history-list">
+                  {activityLoading ? (
+                    <div className="history-loading">Loading activity...</div>
+                  ) : activities.length === 0 ? (
+                    <div className="history-empty">No activity yet</div>
+                  ) : (
+                    activities.map((item) => {
+                      const IconComponent = iconMap[item.iconClass] || iconMap[item.widget] || iconMap.default;
+                      return (
+                        <div key={item.id} className="history-item">
+                          <div className={`history-icon ${item.iconClass}`}>
+                            <IconComponent size={18} />
+                          </div>
+                          <div className="history-content">
+                            <div className="history-text">{item.title}</div>
+                            <div className="history-meta">{item.meta}</div>
+                          </div>
+                          {item.amount && <div className="history-amount">{item.amount}</div>}
+                          <div className="history-time">{item.time}</div>
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
             </div>
-          )}
+
+            {/* Notification Banners Card */}
+            {(showExtensionBanner || showUpgradeBanner) && (
+              <div className="notification-card">
+                {showExtensionBanner && (
+                  <a
+                    href={getThemeExtensionUrl()}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`notification-banner enable-extension ${extensionBannerFlashing ? "flashing" : ""}`}
+                  >
+                    <ExternalLink size={16} className="notification-icon" />
+                    <span>
+                      Enable BusyBuddy: open the theme editor, then{" "}
+                      <strong>Add block &gt; Apps &gt; BusyBuddy Announcement</strong>
+                    </span>
+                  </a>
+                )}
+                {showUpgradeBanner && (
+                  <div
+                    className={`notification-banner upgrade-plan ${upgradeBannerFlashing ? "flashing" : ""}`}
+                    onClick={() => navigate("/plan" + location.search)}
+                  >
+                    <Zap size={16} className="notification-icon" />
+                    <span>Upgrade your plan for more features!</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/web/frontend/tests/pages/DashboardHome.test.jsx
+++ b/web/frontend/tests/pages/DashboardHome.test.jsx
@@ -10,7 +10,7 @@ vi.mock('../../components', () => ({
 
 vi.mock('recharts', () => ({
   ResponsiveContainer: ({ children }) => <div data-testid="responsive-container">{children}</div>,
-  AreaChart: () => <div data-testid="area-chart" />,
+  AreaChart: ({ children }) => <div data-testid="area-chart">{children}</div>,
   Area: () => null,
   XAxis: () => null,
   YAxis: () => null,
@@ -36,31 +36,110 @@ const mockStats = {
   eventsToday: 15,
 };
 
+const subscriptionConfig = {
+  Free: {
+    maxApps: 1,
+    allowedApps: ['announcement_bar', 'inactive_tab'],
+  },
+  Starter: {
+    maxApps: 3,
+    allowedApps: ['announcement_bar', 'inactive_tab', 'bundle_discount', 'buy_one_get_one', 'volume_discounts'],
+  },
+  Advanced: {
+    maxApps: 6,
+    allowedApps: [
+      'announcement_bar',
+      'inactive_tab',
+      'bundle_discount',
+      'buy_one_get_one',
+      'volume_discounts',
+      'mix_match',
+    ],
+  },
+};
+
+const emptySummary = {
+  range: '7d',
+  revenue: { amount: 0, hasData: false, change: null, trend: [] },
+  avgOrderValue: null,
+  purchaseCount: 0,
+  impressions: { hasData: false, views: 0, clicks: 0, ctr: null, trackedWidgetIds: ['announcement-bar'] },
+  widgets: [
+    'announcement-bar',
+    'inactive-tab-message',
+    'bundle-discount',
+    'buy-one-get-one',
+    'volume-discounts',
+    'mix-and-match',
+  ].map((id) => ({
+    id,
+    revenue: { amount: 0, purchaseCount: 0, hasData: false, trend: [] },
+    impressions: {
+      tracked: id === 'announcement-bar',
+      hasData: false,
+      views: id === 'announcement-bar' ? 0 : null,
+      clicks: id === 'announcement-bar' ? 0 : null,
+      ctr: null,
+    },
+  })),
+};
+
+function mockFetchWith({ planName = 'Advanced', enabledApps = [], summary = emptySummary } = {}) {
+  return vi.fn((url) => {
+    if (url && url.includes('/api/activity/recent')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          status: 'SUCCESS',
+          data: { activities: mockActivities, stats: mockStats },
+        }),
+      });
+    }
+    if (url && url.includes('/api/dashboard/summary')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ status: 'SUCCESS', data: summary }),
+      });
+    }
+    if (url && url.includes('/api/subscription/getUserSubscription')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          status: 'SUCCESS',
+          data: {
+            planName,
+            maxAppsAllowed: subscriptionConfig[planName].maxApps,
+            enabledAppsCount: enabledApps.filter((a) => a.enabled).length,
+            enabledApps,
+            subscriptionConfig,
+          },
+        }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ status: 'SUCCESS', data: {} }),
+    });
+  });
+}
+
 describe('DashboardHome', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    global.fetch = vi.fn((url) => {
-      if (url && url.includes('/api/activity/recent')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({
-            status: 'SUCCESS',
-            data: { activities: mockActivities, stats: mockStats },
-          }),
-        });
-      }
-      // Subscription and other calls — return safe defaults
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ status: 'SUCCESS', data: {} }),
-      });
+    global.fetch = mockFetchWith({
+      planName: 'Advanced',
+      enabledApps: [
+        { appId: 'announcement_bar', enabled: true },
+        { appId: 'bundle_discount', enabled: true },
+        { appId: 'buy_one_get_one', enabled: false },
+      ],
     });
   });
 
   describe('Widget Cards', () => {
     it('should render 6 widget cards', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         const widgetCards = document.querySelectorAll('.widget-tile');
         expect(widgetCards.length).toBe(6);
@@ -69,7 +148,7 @@ describe('DashboardHome', () => {
 
     it('should display correct widget names', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         expect(screen.getByText('Announcement Bar')).toBeInTheDocument();
         expect(screen.getByText('Bundle Discounts')).toBeInTheDocument();
@@ -80,12 +159,149 @@ describe('DashboardHome', () => {
       });
     });
 
-    it('should show Active/Inactive status badge for each widget', async () => {
+    it('should show a truthful status badge per widget: active, paused, needs setup', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         const statusBadges = document.querySelectorAll('.status-indicator');
-        expect(statusBadges.length).toBeGreaterThan(0);
+        expect(statusBadges.length).toBe(6);
+      });
+
+      // announcement_bar: enabled: true
+      const announcementCard = screen.getByText('Announcement Bar').closest('.widget-tile');
+      expect(announcementCard.querySelector('.status-indicator.active')).toBeTruthy();
+
+      // buy_one_get_one: enabled: false (has a toggle entry -> paused, not "locked")
+      const bogoCard = screen.getByText('Buy One Get One').closest('.widget-tile');
+      expect(bogoCard.querySelector('.status-indicator.paused')).toBeTruthy();
+
+      // volume_discounts: no entry at all -> needs setup
+      const volumeCard = screen.getByText('Volume Discounts').closest('.widget-tile');
+      expect(volumeCard.querySelector('.status-indicator.not-set-up')).toBeTruthy();
+      expect(screen.getAllByText('Needs setup').length).toBeGreaterThan(0);
+    });
+
+    it('should lock widgets that are not included on the current plan', async () => {
+      global.fetch = mockFetchWith({ planName: 'Free', enabledApps: [{ appId: 'announcement_bar', enabled: true }] });
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const bundleCard = screen.getByText('Bundle Discounts').closest('.widget-tile');
+        expect(bundleCard.querySelector('.status-indicator.locked')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Widget performance metrics', () => {
+    const summaryWithData = {
+      ...emptySummary,
+      widgets: emptySummary.widgets.map((w) => {
+        if (w.id === 'bundle-discount') {
+          return {
+            ...w,
+            revenue: { amount: 240, purchaseCount: 3, hasData: true, trend: [{ date: '2026-08-01', revenue: 240 }] },
+          };
+        }
+        if (w.id === 'announcement-bar') {
+          return {
+            ...w,
+            impressions: { tracked: true, hasData: true, views: 5000, clicks: 150, ctr: 3 },
+          };
+        }
+        return w;
+      }),
+    };
+
+    it('should show real revenue for a widget with attributed purchases', async () => {
+      global.fetch = mockFetchWith({ summary: summaryWithData });
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const bundleCard = screen.getByText('Bundle Discounts').closest('.widget-tile');
+        expect(bundleCard.textContent).toContain('$240');
+      });
+    });
+
+    it('should show a "not tracked" note instead of a fake CTR for widgets without impression tracking', async () => {
+      global.fetch = mockFetchWith({ summary: summaryWithData });
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const bundleCard = screen.getByText('Bundle Discounts').closest('.widget-tile');
+        expect(bundleCard.textContent).toMatch(/not tracked/i);
+      });
+    });
+
+    it('should show real impressions/CTR for the announcement bar', async () => {
+      global.fetch = mockFetchWith({ summary: summaryWithData });
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const announcementCard = screen.getByText('Announcement Bar').closest('.widget-tile');
+        expect(announcementCard.textContent).toContain('5.0k');
+        expect(announcementCard.textContent).toContain('3.0%');
+      });
+    });
+
+    it('should show an explicit no-data message when nothing has happened for a widget yet', async () => {
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const volumeCard = screen.getByText('Volume Discounts').closest('.widget-tile');
+        expect(volumeCard.textContent).toMatch(/no activity recorded/i);
+      });
+    });
+  });
+
+  describe('Hero metrics band', () => {
+    it('should show an explicit no-data message instead of a fabricated $0 when there is no revenue', async () => {
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/No attributed revenue recorded in this period yet/i)).toBeInTheDocument();
+      });
+    });
+
+    it('should show real attributed revenue and a change badge when data exists', async () => {
+      global.fetch = mockFetchWith({
+        summary: {
+          ...emptySummary,
+          revenue: { amount: 1200, hasData: true, change: { pct: 25, kind: 'up' }, trend: [{ date: '2026-08-01', revenue: 1200 }] },
+          avgOrderValue: 400,
+          purchaseCount: 3,
+        },
+      });
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        expect(screen.getByText('$1,200')).toBeInTheDocument();
+        expect(screen.getByText('+25.0%')).toBeInTheDocument();
+        expect(screen.getByText('$400')).toBeInTheDocument();
+      });
+    });
+
+    it('should show the real active-widget count from the subscription API', async () => {
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const activeWidgetsTile = screen.getByText('Active widgets').closest('.hero-tile');
+        expect(activeWidgetsTile.querySelector('.hero-value').textContent).toBe('2 / 6');
+        expect(activeWidgetsTile.textContent).toContain('Advanced plan');
+      });
+    });
+
+    it('should refetch dashboard summary when the date range changes', async () => {
+      const fetchedUrl = (n) => global.fetch.mock.calls.some((call) => call[0].includes(n));
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        expect(fetchedUrl('range=7d')).toBe(true);
+      });
+
+      fireEvent.click(screen.getByText('30D'));
+
+      await waitFor(() => {
+        expect(fetchedUrl('range=30d')).toBe(true);
       });
     });
   });
@@ -101,8 +317,6 @@ describe('DashboardHome', () => {
       });
     });
 
-
-
     it('should have a Create button on the Bundle Discounts widget card', async () => {
       renderWithRouter(<DashboardHome />);
 
@@ -113,10 +327,7 @@ describe('DashboardHome', () => {
       });
     });
 
-
-
     it('should render the Inactive Tab Message widget card', async () => {
-      // useNavigate is already mocked globally in tests/setup.js
       renderWithRouter(<DashboardHome />);
 
       await waitFor(() => {
@@ -128,7 +339,7 @@ describe('DashboardHome', () => {
   describe('Manage Button Behavior', () => {
     it('should have Manage buttons for all widgets', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         const manageButtons = screen.getAllByText('Manage');
         expect(manageButtons.length).toBe(6);
@@ -139,7 +350,7 @@ describe('DashboardHome', () => {
   describe('Recent Activity Card', () => {
     it('should fetch activities from /api/activity/recent on mount', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalledWith(
           expect.stringContaining('/api/activity/recent')
@@ -149,7 +360,7 @@ describe('DashboardHome', () => {
 
     it('should display activity list when data is loaded', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         expect(screen.getByText('Summer Bundle')).toBeInTheDocument();
         expect(screen.getByText('Free Shipping')).toBeInTheDocument();
@@ -158,7 +369,7 @@ describe('DashboardHome', () => {
 
     it('should display stats', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         expect(screen.getByText('Active Bundles')).toBeInTheDocument();
         expect(screen.getByText('Active Bars')).toBeInTheDocument();
@@ -178,9 +389,9 @@ describe('DashboardHome', () => {
         }
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'SUCCESS', data: { planName: 'Advanced', enabled: true } }) });
       });
-      
+
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         expect(screen.getByText(/No activity yet/i)).toBeInTheDocument();
       });
@@ -190,7 +401,7 @@ describe('DashboardHome', () => {
   describe('Layout', () => {
     it('should render "Your Widgets" header', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         expect(screen.getByText('Your Widgets')).toBeInTheDocument();
       });
@@ -198,7 +409,7 @@ describe('DashboardHome', () => {
 
     it('should render "Recent Activity" header', async () => {
       renderWithRouter(<DashboardHome />);
-      
+
       await waitFor(() => {
         expect(screen.getByText('Recent Activity')).toBeInTheDocument();
       });

--- a/web/frontend/tests/pages/DashboardHome.test.jsx
+++ b/web/frontend/tests/pages/DashboardHome.test.jsx
@@ -26,15 +26,9 @@ const renderWithRouter = (component) => {
 };
 
 const mockActivities = [
-  { id: '1', widget: 'bundle', title: 'Summer Bundle', meta: 'purchased', time: '2m ago', iconClass: 'text-success' },
-  { id: '2', widget: 'announcement', title: 'Free Shipping', meta: 'viewed', time: '5m ago', iconClass: 'text-primary' },
+  { id: '1', widget: 'bundle', title: 'Summer Bundle', meta: 'purchased', time: '2m ago', amount: '$35' },
+  { id: '2', widget: 'announcement', title: 'Free Shipping', meta: 'viewed', time: '5m ago' },
 ];
-
-const mockStats = {
-  activeBundles: 3,
-  activeAnnouncements: 2,
-  eventsToday: 15,
-};
 
 const subscriptionConfig = {
   Free: {
@@ -66,11 +60,11 @@ const emptySummary = {
   impressions: { hasData: false, views: 0, clicks: 0, ctr: null, trackedWidgetIds: ['announcement-bar'] },
   widgets: [
     'announcement-bar',
-    'inactive-tab-message',
     'bundle-discount',
     'buy-one-get-one',
     'volume-discounts',
     'mix-and-match',
+    'inactive-tab-message',
   ].map((id) => ({
     id,
     revenue: { amount: 0, purchaseCount: 0, hasData: false, trend: [] },
@@ -84,14 +78,14 @@ const emptySummary = {
   })),
 };
 
-function mockFetchWith({ planName = 'Advanced', enabledApps = [], summary = emptySummary } = {}) {
+function mockFetchWith({ planName = 'Advanced', enabledApps = [], summary = emptySummary, activities = mockActivities } = {}) {
   return vi.fn((url) => {
     if (url && url.includes('/api/activity/recent')) {
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve({
           status: 'SUCCESS',
-          data: { activities: mockActivities, stats: mockStats },
+          data: { activities, stats: {} },
         }),
       });
     }
@@ -133,6 +127,27 @@ describe('DashboardHome', () => {
         { appId: 'bundle_discount', enabled: true },
         { appId: 'buy_one_get_one', enabled: false },
       ],
+    });
+  });
+
+  describe('Header', () => {
+    it('should render the app brand and a Home tag', async () => {
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        expect(screen.getByText('BusyBuddy')).toBeInTheDocument();
+        expect(screen.getByText('Home')).toBeInTheDocument();
+      });
+    });
+
+    it('should render lowercase 7d/30d/90d range pills', async () => {
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        expect(screen.getByText('7d')).toBeInTheDocument();
+        expect(screen.getByText('30d')).toBeInTheDocument();
+        expect(screen.getByText('90d')).toBeInTheDocument();
+      });
     });
   });
 
@@ -253,6 +268,37 @@ describe('DashboardHome', () => {
     });
   });
 
+  describe('Sort controls', () => {
+    it('should render the Revenue / Impressions / Recently edited sort chips', async () => {
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const sortControls = document.querySelector('.sort-controls');
+        expect(sortControls.textContent).toContain('Revenue ↓');
+        expect(sortControls.textContent).toContain('Impressions');
+        expect(sortControls.textContent).toContain('Recently edited');
+      });
+    });
+
+    it('should reorder widget cards by real revenue when the Revenue chip is active (default)', async () => {
+      const summary = {
+        ...emptySummary,
+        widgets: emptySummary.widgets.map((w) => {
+          if (w.id === 'mix-and-match') return { ...w, revenue: { amount: 900, purchaseCount: 1, hasData: true, trend: [] } };
+          if (w.id === 'announcement-bar') return { ...w, revenue: { amount: 100, purchaseCount: 1, hasData: true, trend: [] } };
+          return w;
+        }),
+      };
+      global.fetch = mockFetchWith({ summary });
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const names = Array.from(document.querySelectorAll('.widget-tile .widget-name')).map((n) => n.textContent);
+        expect(names[0]).toBe('Mix & Match');
+      });
+    });
+  });
+
   describe('Hero metrics band', () => {
     it('should show an explicit no-data message instead of a fabricated $0 when there is no revenue', async () => {
       renderWithRouter(<DashboardHome />);
@@ -298,7 +344,7 @@ describe('DashboardHome', () => {
         expect(fetchedUrl('range=7d')).toBe(true);
       });
 
-      fireEvent.click(screen.getByText('30D'));
+      fireEvent.click(screen.getByText('30d'));
 
       await waitFor(() => {
         expect(fetchedUrl('range=30d')).toBe(true);
@@ -347,7 +393,7 @@ describe('DashboardHome', () => {
     });
   });
 
-  describe('Recent Activity Card', () => {
+  describe('Live activity rail', () => {
     it('should fetch activities from /api/activity/recent on mount', async () => {
       renderWithRouter(<DashboardHome />);
 
@@ -367,28 +413,40 @@ describe('DashboardHome', () => {
       });
     });
 
-    it('should display stats', async () => {
+    it('should render a Streaming tag next to Live activity', async () => {
       renderWithRouter(<DashboardHome />);
 
       await waitFor(() => {
-        expect(screen.getByText('Active Bundles')).toBeInTheDocument();
-        expect(screen.getByText('Active Bars')).toBeInTheDocument();
+        expect(screen.getByText('Live activity')).toBeInTheDocument();
+        expect(screen.getByText('Streaming')).toBeInTheDocument();
+      });
+    });
+
+    it('should show "View all activity" only when there are more items than fit, and expand on click', async () => {
+      const manyActivities = Array.from({ length: 7 }, (_, i) => ({
+        id: String(i),
+        widget: 'bundle',
+        title: `Event ${i}`,
+        meta: 'purchased',
+        time: `${i}m ago`,
+      }));
+      global.fetch = mockFetchWith({ activities: manyActivities });
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Event 0')).toBeInTheDocument();
+        expect(screen.queryByText('Event 6')).not.toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('View all activity'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Event 6')).toBeInTheDocument();
       });
     });
 
     it('should show empty state when no activities', async () => {
-      global.fetch = vi.fn((url) => {
-        if (url && url.includes('/api/activity/recent')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({
-              status: 'SUCCESS',
-              data: { activities: [], stats: { activeBundles: 0, activeAnnouncements: 0, eventsToday: 0 } },
-            }),
-          });
-        }
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'SUCCESS', data: { planName: 'Advanced', enabled: true } }) });
-      });
+      global.fetch = mockFetchWith({ activities: [] });
 
       renderWithRouter(<DashboardHome />);
 
@@ -399,19 +457,19 @@ describe('DashboardHome', () => {
   });
 
   describe('Layout', () => {
-    it('should render "Your Widgets" header', async () => {
+    it('should render "Your widgets" header', async () => {
       renderWithRouter(<DashboardHome />);
 
       await waitFor(() => {
-        expect(screen.getByText('Your Widgets')).toBeInTheDocument();
+        expect(screen.getByText('Your widgets')).toBeInTheDocument();
       });
     });
 
-    it('should render "Recent Activity" header', async () => {
+    it('should render "Live activity" header', async () => {
       renderWithRouter(<DashboardHome />);
 
       await waitFor(() => {
-        expect(screen.getByText('Recent Activity')).toBeInTheDocument();
+        expect(screen.getByText('Live activity')).toBeInTheDocument();
       });
     });
   });

--- a/web/frontend/tests/pages/DashboardHome.test.jsx
+++ b/web/frontend/tests/pages/DashboardHome.test.jsx
@@ -268,33 +268,29 @@ describe('DashboardHome', () => {
     });
   });
 
-  describe('Sort controls', () => {
-    it('should render the Revenue / Impressions / Recently edited sort chips', async () => {
-      renderWithRouter(<DashboardHome />);
-
-      await waitFor(() => {
-        const sortControls = document.querySelector('.sort-controls');
-        expect(sortControls.textContent).toContain('Revenue ↓');
-        expect(sortControls.textContent).toContain('Impressions');
-        expect(sortControls.textContent).toContain('Recently edited');
-      });
-    });
-
-    it('should reorder widget cards by real revenue when the Revenue chip is active (default)', async () => {
+  describe('Widget card layout', () => {
+    it('should keep Create/Manage buttons at the bottom of the card whether or not a sparkline is shown', async () => {
       const summary = {
         ...emptySummary,
-        widgets: emptySummary.widgets.map((w) => {
-          if (w.id === 'mix-and-match') return { ...w, revenue: { amount: 900, purchaseCount: 1, hasData: true, trend: [] } };
-          if (w.id === 'announcement-bar') return { ...w, revenue: { amount: 100, purchaseCount: 1, hasData: true, trend: [] } };
-          return w;
-        }),
+        widgets: emptySummary.widgets.map((w) =>
+          w.id === 'bundle-discount'
+            ? { ...w, revenue: { amount: 240, purchaseCount: 3, hasData: true, trend: [{ date: '2026-08-01', revenue: 240 }] } }
+            : w
+        ),
       };
       global.fetch = mockFetchWith({ summary });
       renderWithRouter(<DashboardHome />);
 
       await waitFor(() => {
-        const names = Array.from(document.querySelectorAll('.widget-tile .widget-name')).map((n) => n.textContent);
-        expect(names[0]).toBe('Mix & Match');
+        // Bundle Discounts has a sparkline (real revenue data); Volume Discounts has none.
+        const bundleCard = screen.getByText('Bundle Discounts').closest('.widget-tile');
+        const volumeCard = screen.getByText('Volume Discounts').closest('.widget-tile');
+        expect(bundleCard.querySelector('.widget-buttons')).toBeTruthy();
+        expect(volumeCard.querySelector('.widget-buttons')).toBeTruthy();
+        // Both button rows are the last element in their card, so they land at the
+        // bottom regardless of how much metrics content precedes them.
+        expect(bundleCard.lastElementChild.className).toContain('widget-buttons');
+        expect(volumeCard.lastElementChild.className).toContain('widget-buttons');
       });
     });
   });
@@ -422,7 +418,7 @@ describe('DashboardHome', () => {
       });
     });
 
-    it('should show "View all activity" only when there are more items than fit, and expand on click', async () => {
+    it('should render every fetched activity without a "View all" button', async () => {
       const manyActivities = Array.from({ length: 7 }, (_, i) => ({
         id: String(i),
         widget: 'bundle',
@@ -435,14 +431,10 @@ describe('DashboardHome', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Event 0')).toBeInTheDocument();
-        expect(screen.queryByText('Event 6')).not.toBeInTheDocument();
-      });
-
-      fireEvent.click(screen.getByText('View all activity'));
-
-      await waitFor(() => {
         expect(screen.getByText('Event 6')).toBeInTheDocument();
       });
+
+      expect(screen.queryByText('View all activity')).not.toBeInTheDocument();
     });
 
     it('should show empty state when no activities', async () => {

--- a/web/frontend/tests/pages/DashboardHome.test.jsx
+++ b/web/frontend/tests/pages/DashboardHome.test.jsx
@@ -131,12 +131,12 @@ describe('DashboardHome', () => {
   });
 
   describe('Header', () => {
-    it('should render the app brand and a Home tag', async () => {
+    it('should render the app brand without a Home tag', async () => {
       renderWithRouter(<DashboardHome />);
 
       await waitFor(() => {
         expect(screen.getByText('BusyBuddy')).toBeInTheDocument();
-        expect(screen.getByText('Home')).toBeInTheDocument();
+        expect(screen.queryByText('Home')).not.toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
## Problem

Closes #

The current dashboard home uses an older card-based layout that doesn't align with the "Mockup A: Performance-first dashboard" reference design. The new design should feature a sticky header, gradient hero band with key metrics, a 12-column widget/activity split with a real border divider, and real per-widget performance data instead of placeholder numbers.

## Solution

### Frontend (DashboardHome.jsx & DashboardHome.css)

**Layout & Visual Redesign:**
- Replaced the old two-column grid layout with a new structure: sticky dark header (logo + range pills) → gradient hero band (4 key metrics) → content grid (9/12 widgets + 3/12 activity rail)
- Wrapped the entire dashboard in an `.app-frame` bordered card with rounded corners
- Added sticky header with BusyBuddy branding, range selector pills (7d/30d/90d), and help link
- Implemented hero band with 4 key metrics (Total Revenue, Avg Order Value, Purchase Count, Impressions) with sparklines and trend badges
- Redesigned widget cards: smaller icons (44×44), left-aligned layout, performance metrics grid, and buttons pinned to bottom
- Activity rail now uses a light background with circular status indicators and cleaner typography

**Real Performance Data:**
- Integrated new `/api/dashboard/summary` endpoint to fetch per-widget revenue, purchase counts, impressions, and CTR
- Widget cards now display real metrics: revenue amount + purchase count, or impressions + CTR (for tracked widgets like Announcement Bar)
- Added sparkline charts (via Recharts) showing 7/30/90-day revenue trends
- Implemented "no data" vs. "not tracked" distinction: widgets without impression instrumentation show `null` instead of misleading zeros

**Plan Access & Widget Status:**
- Replaced hardcoded `planFeatures` map with dynamic status from `subscriptionConfig` returned by `/api/subscription/getUserSubscription`
- Widget status now reflects three states:
  - **Active**: enabled and plan-accessible
  - **Paused**: plan-accessible but disabled by merchant
  - **Needs setup**: plan-accessible but never configured
  - **Locked**: not included on current plan
- Status badges use semantic colors (green for active, amber for paused, gray for needs setup/locked)

**Activity Rail:**
- Fetches real recent activity from `/api/activity/recent` and refreshes every 30 seconds
- Maps activity log widget slugs to frontend widget IDs for accurate "recently edited" ranking
- Displays activity with circular status indicators and cleaner metadata

### Backend (dashboard/index.js)

**New Dashboard Summary Endpoint:**
- `GET /api/dashboard/summary?range=7d|30d|90d` aggregates real per-widget performance from ActivityLog
- Computes current period totals, previous period totals (for trend calculation), and daily revenue trend
- Returns structured data with `hasData` flags so frontend can distinguish "no data" from "zero"
- Calculates revenue change percentage and kind (up/down/new)
- Separates impression-tracked widgets (Announcement Bar) from non-tracked widgets (bundles, etc.)
- Computes CTR only for tracked widgets; returns `null` for others

**Activity Log Aggregation:**
- Uses MongoDB aggregation pipeline to group by widget and date
- Filters by shop domain and date range
- Supports purchase, view, and click event types

### Tests

**Frontend (DashboardHome.test.jsx):**
- Added tests for header rendering (brand, range pills)
- Added tests for widget card rendering and truthful status badges (active/paused/needs setup/locked)
- Added tests for real performance metrics display (revenue, impressions, CTR)
- Added tests for "no data" vs. "not tracked" distinction
- Added tests for plan-based widget locking

**Backend (dashboard.test.js):**
- Added tests for 401 unauthorized response
- Added tests for "no data" reporting (hasData: false, not zero-as-fact)
- Added tests for unknown range defaulting to 7d
- Added tests for real per-widget revenue and impressions aggregation
- Added tests for revenue change calculation

https://claude.ai/code/session_01WEpy97mZfJXCdaLqaek7kf