### PR TITLE
Drop custom home-screen header, full-width layout, snooze emoji icon

### DIFF
--- a/web/frontend/pages/DashboardHome.css
+++ b/web/frontend/pages/DashboardHome.css
@@ -1,6 +1,7 @@
 /* Dashboard Home Styles - mirrors the "Mockup A: Performance-first dashboard"
-   reference layout (sticky header, gradient hero band, 12-col widgets/activity
-   split with a real border divider) rather than the app's older card style. */
+   reference layout (gradient hero band with the range pills/Help folded in,
+   full-width widgets/activity split with a real border divider). Shopify's
+   own page header is the only header - this component renders none of its own. */
 .dashboard-home {
   background: #f4f4f2;
   overflow-y: auto;
@@ -10,44 +11,7 @@
 }
 
 .dashboard-inner {
-  max-width: 1400px;
-  margin: 0 auto;
-}
-
-/* Outer app frame - the whole dashboard lives inside one bordered card */
-.app-frame {
-  background: #fff;
-  border: 1px solid #ececec;
-  border-radius: 14px;
-  overflow: hidden;
-}
-
-/* Sticky header: logo + range pills - dark bar, distinct from the light card body */
-.app-header {
-  padding: 12px 20px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background: linear-gradient(135deg, #16171a 0%, #23252b 100%);
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
-.app-header-brand {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.app-header-brand .logo {
-  font-size: 18px;
-  line-height: 1;
-}
-
-.app-header-brand .name {
-  font-weight: 700;
-  font-size: 15px;
-  color: #fff;
+  width: 100%;
 }
 
 .app-tag {
@@ -58,12 +22,6 @@
   background: #f4f4f2;
   color: #374151;
   border: 1px solid #ececec;
-}
-
-.app-header-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 
 .pill-nav {
@@ -104,14 +62,29 @@
   text-decoration: none;
 }
 
-/* Hero metrics band */
+/* Hero band: the only "header" this component renders. Carries the range
+   pills + Help link (hero-controls-row) plus the 4 metric tiles
+   (hero-metrics). No outer card wraps this - it's a standalone rounded
+   block that sits directly on the page. */
 .hero-band {
-  padding: 20px 24px;
-  border-bottom: 1px solid #ececec;
-  background: linear-gradient(to bottom, #fff, #faf9f6);
+  border-radius: 14px;
+  background: linear-gradient(135deg, #16171a 0%, #23252b 100%);
+  padding: 16px 22px 20px;
+}
+
+.hero-controls-row {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.hero-metrics {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 20px;
+  gap: 24px;
 }
 
 .hero-tile {
@@ -123,7 +96,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #6b7280;
+  color: #9aa0ab;
   margin-bottom: 6px;
 }
 
@@ -137,7 +110,7 @@
 .hero-value {
   font-size: 26px;
   font-weight: 700;
-  color: #111;
+  color: #fff;
   line-height: 1.15;
   font-variant-numeric: tabular-nums;
 }
@@ -145,12 +118,12 @@
 .hero-value-sub {
   font-size: 16px;
   font-weight: 500;
-  color: #9ca3af;
+  color: #7d838d;
 }
 
 .hero-sub {
   font-size: 12px;
-  color: #6b7280;
+  color: #9aa0ab;
   margin-top: 6px;
   line-height: 1.4;
 }
@@ -158,9 +131,10 @@
 .hero-empty,
 .hero-loading {
   font-size: 13px;
-  color: #6b7280;
+  color: #9aa0ab;
   margin-top: 4px;
   line-height: 1.4;
+  max-width: 22em;
 }
 
 .hero-badge {
@@ -173,9 +147,9 @@
   font-weight: 600;
 }
 
-.hero-badge-up { background: #e7f7ee; color: #0f7a3b; }
-.hero-badge-down { background: #fdecec; color: #d63535; }
-.hero-badge-new { background: #eaf3ff; color: #0b76ef; }
+.hero-badge-up { background: rgba(52, 199, 89, 0.18); color: #4ade80; }
+.hero-badge-down { background: rgba(255, 59, 48, 0.18); color: #ff6b6b; }
+.hero-badge-new { background: rgba(0, 122, 255, 0.18); color: #60a5fa; }
 
 .widget-spark {
   width: 100%;
@@ -183,21 +157,23 @@
   margin-top: 8px;
 }
 
-@media (max-width: 1200px) {
-  .hero-band { grid-template-columns: repeat(2, 1fr); }
+@media (max-width: 900px) {
+  .hero-metrics { grid-template-columns: repeat(2, 1fr); }
 }
-@media (max-width: 640px) {
-  .hero-band { grid-template-columns: 1fr; }
+@media (max-width: 560px) {
+  .hero-metrics { grid-template-columns: 1fr; }
 }
 
-/* Content grid: widgets (9/12) + activity rail (3/12), like the reference layout */
+/* Content grid: widgets (left) + activity rail (right), full width, no
+   outer box - just a divider between the two columns. */
 .dashboard-layout {
   display: grid;
   grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
+  margin-top: 16px;
 }
 
 .widgets-column {
-  padding: 20px 24px;
+  padding: 20px 20px 20px 4px;
   border-right: 1px solid #ececec;
 }
 
@@ -258,6 +234,11 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+}
+
+.icon-emoji {
+  display: inline-block;
+  line-height: 1;
 }
 
 /* Status Indicator */
@@ -378,8 +359,9 @@
 
 /* Right rail - Live activity */
 .history-column {
-  background: #fafafa;
   padding: 20px;
+  background: rgba(17, 17, 17, 0.045);
+  border-radius: 0 14px 14px 0;
 }
 
 .history-header {
@@ -447,7 +429,7 @@
   text-align: center;
 }
 
-/* Notification banners - real app alerts, sit under the frame */
+/* Notification banners - real app alerts, sit below the main content */
 .notification-card {
   display: flex;
   flex-direction: column;
@@ -487,13 +469,21 @@
 /* Responsive */
 @media (max-width: 1024px) {
   .dashboard-layout { grid-template-columns: 1fr; }
-  .widgets-column { border-right: none; border-bottom: 1px solid #ececec; }
+  .widgets-column {
+    border-right: none;
+    border-bottom: 1px solid #ececec;
+    padding: 20px;
+  }
+  .history-column {
+    border-radius: 14px;
+    margin-top: 16px;
+  }
 }
 
 @media (max-width: 640px) {
   .dashboard-home { padding: 10px; }
-  .app-header { padding: 10px 14px; }
   .hero-band { padding: 16px; }
+  .hero-controls-row { justify-content: center; }
   .widgets-column, .history-column { padding: 16px; }
   .widgets-grid { grid-template-columns: 1fr; }
 }

--- a/web/frontend/pages/DashboardHome.jsx
+++ b/web/frontend/pages/DashboardHome.jsx
@@ -9,7 +9,6 @@ import {
   Plus,
   Settings,
   DollarSign,
-  AlarmClockOff,
   ExternalLink,
   Zap,
   TrendingUp,
@@ -84,7 +83,7 @@ const widgetConfig = [
     appId: "inactive_tab",
     title: "Inactive Tab Message",
     subtitle: "Re-engage tab-switchers",
-    icon: AlarmClockOff,
+    icon: "💤",
     iconBg: "#f4f4f2",
     accent: "#6b7280",
     settingsRoute: "/inactive-tab-message?tab=settings",
@@ -155,6 +154,21 @@ function Sparkline({ data, color }) {
   );
 }
 
+// Widget icons are usually a lucide component, but Inactive Tab Message uses
+// a plain "💤" glyph (no lucide icon reads as "snooze"), so this renders
+// either kind consistently at the given size.
+function WidgetIcon({ icon, size }) {
+  if (typeof icon === "string") {
+    return (
+      <span className="icon-emoji" style={{ fontSize: size }} role="img" aria-hidden="true">
+        {icon}
+      </span>
+    );
+  }
+  const IconComponent = icon;
+  return <IconComponent size={size} />;
+}
+
 function RevenueChangeBadge({ change }) {
   if (!change) return null;
   if (change.kind === "new") {
@@ -177,7 +191,7 @@ const activityIconMap = {
   volume: Layers,
   "mix-match": Shuffle,
   announcement: Megaphone,
-  "inactive-tab": AlarmClockOff,
+  "inactive-tab": "💤",
 };
 
 export default function DashboardHome() {
@@ -419,33 +433,27 @@ export default function DashboardHome() {
   return (
     <div className="dashboard-home">
       <div className="dashboard-inner">
-        <div className="app-frame">
-          {/* Header */}
-          <div className="app-header">
-            <div className="app-header-brand">
-              <span className="logo">🐝</span>
-              <span className="name">BusyBuddy</span>
+        {/* Hero band: this is the only "header" our component renders - the
+            Shopify page header above it already shows the app name/logo. */}
+        <div className="hero-band">
+          <div className="hero-controls-row">
+            <div className="pill-nav">
+              {RANGE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.id}
+                  className={range === opt.id ? "active" : ""}
+                  onClick={() => setRange(opt.id)}
+                >
+                  {opt.label}
+                </button>
+              ))}
             </div>
-            <div className="app-header-actions">
-              <div className="pill-nav">
-                {RANGE_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.id}
-                    className={range === opt.id ? "active" : ""}
-                    onClick={() => setRange(opt.id)}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
-              <a className="help-link" href="https://help.shopify.com" target="_blank" rel="noopener noreferrer">
-                Help
-              </a>
-            </div>
+            <a className="help-link" href="https://help.shopify.com" target="_blank" rel="noopener noreferrer">
+              Help
+            </a>
           </div>
 
-          {/* Hero metrics band */}
-          <div className="hero-band">
+          <div className="hero-metrics">
             <div className="hero-tile">
               <div className="hero-label">Attributed revenue &middot; {rangeLabel}</div>
               {summaryLoading ? (
@@ -456,7 +464,7 @@ export default function DashboardHome() {
                     <span className="hero-value">{formatMoney(summary.revenue.amount)}</span>
                     <RevenueChangeBadge change={summary.revenue.change} />
                   </div>
-                  <Sparkline data={summary.revenue.trend} color="#111111" />
+                  <Sparkline data={summary.revenue.trend} color="#ffffff" />
                 </>
               ) : (
                 <div className="hero-empty">No attributed revenue recorded in this period yet.</div>
@@ -512,126 +520,125 @@ export default function DashboardHome() {
               )}
             </div>
           </div>
+        </div>
 
-          {/* Main content: widgets (9/12) + activity rail (3/12) */}
-          <div className="dashboard-layout">
-            <div className="widgets-column">
-              <div className="section-header">
-                <h2 className="section-title">Your widgets</h2>
-              </div>
+        {/* Main content: widgets (left) + activity rail (right) - full width, no boxed container */}
+        <div className="dashboard-layout">
+          <div className="widgets-column">
+            <div className="section-header">
+              <h2 className="section-title">Your widgets</h2>
+            </div>
 
-              <div className="widgets-grid">
-                {widgetConfig.map((widget) => {
-                  const IconComponent = widget.icon;
-                  const status = getWidgetStatus(widget);
-                  const metrics = widgetMetrics(widget.id);
+            <div className="widgets-grid">
+              {widgetConfig.map((widget) => {
+                const status = getWidgetStatus(widget);
+                const metrics = widgetMetrics(widget.id);
 
-                  return (
-                    <div key={widget.id} className="widget-tile">
-                      <div className="widget-tile-top">
-                        <div className="widget-icon-large" style={{ background: widget.iconBg, color: widget.accent }}>
-                          <IconComponent size={20} />
-                        </div>
-                        <div className={`status-indicator ${status.state}`}>
-                          {status.state === "locked" ? <Lock size={9} /> : <span className="status-dot"></span>}
-                          {status.label}
-                        </div>
+                return (
+                  <div key={widget.id} className="widget-tile">
+                    <div className="widget-tile-top">
+                      <div className="widget-icon-large" style={{ background: widget.iconBg, color: widget.accent }}>
+                        <WidgetIcon icon={widget.icon} size={20} />
                       </div>
+                      <div className={`status-indicator ${status.state}`}>
+                        {status.state === "locked" ? <Lock size={9} /> : <span className="status-dot"></span>}
+                        {status.label}
+                      </div>
+                    </div>
 
-                      <div className="widget-name">{widget.title}</div>
-                      <div className="widget-desc">{widget.subtitle}</div>
-                      <div className="widget-divider"></div>
+                    <div className="widget-name">{widget.title}</div>
+                    <div className="widget-desc">{widget.subtitle}</div>
+                    <div className="widget-divider"></div>
 
-                      {summaryLoading ? (
-                        <div className="widget-metrics-empty">Loading performance&hellip;</div>
-                      ) : (
-                        <>
-                          <div className="widget-metrics-grid">
-                            <div className="widget-metric">
-                              <div className="metric-label">Rev</div>
-                              <div className="metric-value">
-                                {metrics.revenue.hasData ? formatMoney(metrics.revenue.amount) : "—"}
-                              </div>
+                    {summaryLoading ? (
+                      <div className="widget-metrics-empty">Loading performance&hellip;</div>
+                    ) : (
+                      <>
+                        <div className="widget-metrics-grid">
+                          <div className="widget-metric">
+                            <div className="metric-label">Rev</div>
+                            <div className="metric-value">
+                              {metrics.revenue.hasData ? formatMoney(metrics.revenue.amount) : "—"}
                             </div>
-                            {metrics.impressions.tracked ? (
-                              <>
-                                <div className="widget-metric">
-                                  <div className="metric-label">Impr</div>
-                                  <div className="metric-value">{formatCompactNumber(metrics.impressions.views)}</div>
-                                </div>
-                                <div className="widget-metric">
-                                  <div className="metric-label">CTR</div>
-                                  <div className="metric-value">
-                                    {metrics.impressions.hasData ? `${metrics.impressions.ctr.toFixed(1)}%` : "—"}
-                                  </div>
-                                </div>
-                              </>
-                            ) : (
-                              <div className="widget-metric-note">Impressions are not tracked for this widget yet</div>
-                            )}
                           </div>
-                          {metrics.revenue.hasData && <Sparkline data={metrics.revenue.trend} color={widget.accent} />}
-                          {!metrics.revenue.hasData && !metrics.impressions.hasData && (
-                            <div className="widget-metrics-empty">No activity recorded in this period yet.</div>
+                          {metrics.impressions.tracked ? (
+                            <>
+                              <div className="widget-metric">
+                                <div className="metric-label">Impr</div>
+                                <div className="metric-value">{formatCompactNumber(metrics.impressions.views)}</div>
+                              </div>
+                              <div className="widget-metric">
+                                <div className="metric-label">CTR</div>
+                                <div className="metric-value">
+                                  {metrics.impressions.hasData ? `${metrics.impressions.ctr.toFixed(1)}%` : "—"}
+                                </div>
+                              </div>
+                            </>
+                          ) : (
+                            <div className="widget-metric-note">Impressions are not tracked for this widget yet</div>
                           )}
-                        </>
-                      )}
+                        </div>
+                        {metrics.revenue.hasData && <Sparkline data={metrics.revenue.trend} color={widget.accent} />}
+                        {!metrics.revenue.hasData && !metrics.impressions.hasData && (
+                          <div className="widget-metrics-empty">No activity recorded in this period yet.</div>
+                        )}
+                      </>
+                    )}
 
-                      <div className="widget-buttons">
-                        <button className="widget-btn create" onClick={() => handleCreate(widget)}>
-                          <Plus size={12} /> Create
-                        </button>
-                        <button className="widget-btn manage" onClick={() => handleManage(widget)}>
-                          <Settings size={12} /> Manage
-                        </button>
+                    <div className="widget-buttons">
+                      <button className="widget-btn create" onClick={() => handleCreate(widget)}>
+                        <Plus size={12} /> Create
+                      </button>
+                      <button className="widget-btn manage" onClick={() => handleManage(widget)}>
+                        <Settings size={12} /> Manage
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Activity rail */}
+          <div className="history-column">
+            <div className="history-header">
+              <h2 className="history-title">Live activity</h2>
+              <span className="app-tag">Streaming</span>
+            </div>
+
+            <div className="history-list">
+              {activityLoading ? (
+                <div className="history-loading">Loading activity...</div>
+              ) : activities.length === 0 ? (
+                <div className="history-empty">No activity yet</div>
+              ) : (
+                activities.map((item) => {
+                  const icon = activityIconMap[item.widget] || DollarSign;
+                  const accent = widgetConfig.find((w) => w.id === ACTIVITY_SLUG_TO_WIDGET_ID[item.widget])?.accent || "#6b7280";
+                  return (
+                    <div key={item.id} className="history-item">
+                      <div className="history-icon" style={{ background: `${accent}1a`, color: accent }}>
+                        <WidgetIcon icon={icon} size={14} />
+                      </div>
+                      <div className="history-content">
+                        <div className="history-text">
+                          <strong>{item.title}</strong>
+                        </div>
+                        <div className="history-meta">
+                          {item.meta}
+                          {item.amount && (
+                            <>
+                              {" "}
+                              &middot; <span className="history-amount">{item.amount}</span>
+                            </>
+                          )}
+                        </div>
+                        <div className="history-meta">{item.time}</div>
                       </div>
                     </div>
                   );
-                })}
-              </div>
-            </div>
-
-            {/* Activity rail */}
-            <div className="history-column">
-              <div className="history-header">
-                <h2 className="history-title">Live activity</h2>
-                <span className="app-tag">Streaming</span>
-              </div>
-
-              <div className="history-list">
-                {activityLoading ? (
-                  <div className="history-loading">Loading activity...</div>
-                ) : activities.length === 0 ? (
-                  <div className="history-empty">No activity yet</div>
-                ) : (
-                  activities.map((item) => {
-                    const IconComponent = activityIconMap[item.widget] || DollarSign;
-                    const accent = widgetConfig.find((w) => w.id === ACTIVITY_SLUG_TO_WIDGET_ID[item.widget])?.accent || "#6b7280";
-                    return (
-                      <div key={item.id} className="history-item">
-                        <div className="history-icon" style={{ background: `${accent}1a`, color: accent }}>
-                          <IconComponent size={14} />
-                        </div>
-                        <div className="history-content">
-                          <div className="history-text">
-                            <strong>{item.title}</strong>
-                          </div>
-                          <div className="history-meta">
-                            {item.meta}
-                            {item.amount && (
-                              <>
-                                {" "}
-                                &middot; <span className="history-amount">{item.amount}</span>
-                              </>
-                            )}
-                          </div>
-                          <div className="history-meta">{item.time}</div>
-                        </div>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
+                })
+              )}
             </div>
           </div>
         </div>

--- a/web/frontend/tests/pages/DashboardHome.test.jsx
+++ b/web/frontend/tests/pages/DashboardHome.test.jsx
@@ -131,22 +131,27 @@ describe('DashboardHome', () => {
   });
 
   describe('Header', () => {
-    it('should render the app brand without a Home tag', async () => {
+    it('should not render its own header bar (Shopify\'s page header is the only one)', async () => {
       renderWithRouter(<DashboardHome />);
 
       await waitFor(() => {
-        expect(screen.getByText('BusyBuddy')).toBeInTheDocument();
+        expect(document.querySelector('.app-header')).toBeNull();
+        expect(document.querySelector('.app-frame')).toBeNull();
+        expect(screen.queryByText('BusyBuddy')).not.toBeInTheDocument();
         expect(screen.queryByText('Home')).not.toBeInTheDocument();
       });
     });
 
-    it('should render lowercase 7d/30d/90d range pills', async () => {
+    it('should render the range pills and Help link inside the hero band', async () => {
       renderWithRouter(<DashboardHome />);
 
       await waitFor(() => {
+        const heroBand = document.querySelector('.hero-band');
+        expect(heroBand.querySelector('.hero-controls-row')).toBeTruthy();
         expect(screen.getByText('7d')).toBeInTheDocument();
         expect(screen.getByText('30d')).toBeInTheDocument();
         expect(screen.getByText('90d')).toBeInTheDocument();
+        expect(screen.getByText('Help')).toBeInTheDocument();
       });
     });
   });
@@ -171,6 +176,16 @@ describe('DashboardHome', () => {
         expect(screen.getByText('Volume Discounts')).toBeInTheDocument();
         expect(screen.getByText('Mix & Match')).toBeInTheDocument();
         expect(screen.getByText('Inactive Tab Message')).toBeInTheDocument();
+      });
+    });
+
+    it('should use a snooze emoji (not a clock icon) for Inactive Tab Message', async () => {
+      renderWithRouter(<DashboardHome />);
+
+      await waitFor(() => {
+        const card = screen.getByText('Inactive Tab Message').closest('.widget-tile');
+        expect(card.querySelector('.icon-emoji')?.textContent).toBe('💤');
+        expect(card.querySelector('.widget-icon-large svg')).toBeNull();
       });
     });
 


### PR DESCRIPTION
## Context

PR #303 (the dashboard home redesign) was merged before this follow-up commit was pushed, so this one commit was left stranded on the branch. This PR carries it forward on top of current `main`.

## Changes

- Remove the component's own header bar/frame entirely. Shopify's page header is the only header now; the range pills and Help link move into a controls row at the top of the dark hero band.
- Remove the centered max-width wrapper and the bordered "app-frame" card — the hero band, widgets grid, and activity rail now sit directly on the page at full width, with just a divider between the widgets column and the activity rail.
- Hero band is now genuinely dark (gradient bg, light text/badges) — previously only the (now-removed) header bar was dark.
- Live activity panel background is a translucent grey overlay (`rgba(17,17,17,.045)`) instead of flat `#fafafa`.
- Inactive Tab Message uses a "💤" glyph instead of a lucide clock icon, via a small `WidgetIcon` helper that renders either a lucide component or an emoji consistently (widget grid + activity feed).
- Added/adjusted responsive breakpoints for the hero metrics grid, widgets grid, and the widgets/activity column stacking so the translucent panel and divider adapt correctly on narrow screens.

## Test plan

- [x] 114 frontend tests pass (`npx vitest run`)
- [x] `npx vite build` succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01WEpy97mZfJXCdaLqaek7kf)_