### PR TITLE
Add theme-extension gating for app toggles and per-app banners

### DIFF
--- a/busybuddy-demos/scripts/announcement-bar-e2e/04-storefront-render.spec.js
+++ b/busybuddy-demos/scripts/announcement-bar-e2e/04-storefront-render.spec.js
@@ -1,0 +1,11 @@
+import { test, expect, gotoStorefrontHome } from '../../fixtures/app.js';
+
+// Runs after 01-create-and-customize.spec.js (relies on the bar it creates
+// rather than creating its own - see workers:1/file-order convention this
+// suite already depends on).
+// 1. Load the live storefront homepage
+// 2. Confirm the announcement bar actually renders on the page
+test('Announcement Bar: renders live on the storefront homepage', async ({ page }) => {
+  await gotoStorefrontHome(page);
+  await expect(page.locator('#busybuddy-announcement-bar')).toBeVisible({ timeout: 15_000 });
+});

--- a/busybuddy-demos/scripts/bundle-discounts-e2e/04-storefront-render.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts-e2e/04-storefront-render.spec.js
@@ -1,0 +1,14 @@
+import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
+
+// Runs after 01-create-and-customize.spec.js (relies on the bundle it
+// creates rather than creating its own - see workers:1/file-order
+// convention this suite already depends on).
+// 1. Load the Polaroid Instant Camera product page on the live storefront
+// 2. Confirm the bundle widget renders there
+test('Bundle Discount: bundle widget renders on the storefront product page', async ({ page }) => {
+  await gotoStorefrontProduct(page, 'polaroid-instant-camera');
+  // .bogo-bundle-container is the real markup from
+  // extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid (the
+  // block shared by all 4 bundle-type apps).
+  await expect(page.locator('.bogo-bundle-container').first()).toBeVisible({ timeout: 15_000 });
+});

--- a/busybuddy-demos/scripts/bundle-discounts/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/bundle-discounts/04-storefront-live.spec.js
@@ -4,5 +4,9 @@ import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
 // 2. Confirm the bundle widget renders on that page
 test('Bundle Discounts: bundle widget renders on a bundled product\'s page', async ({ page }) => {
   await gotoStorefrontProduct(page, 'nintendo-game-boy');
-  await expect(page.locator('[id*="star_rating"], [class*="busybuddy-bundle"]').first()).toBeVisible({ timeout: 15_000 });
+  // .bogo-bundle-container is the real markup from
+  // extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid (the
+  // block shared by all 4 bundle-type apps) - the previous selector never
+  // matched anything real on this page.
+  await expect(page.locator('.bogo-bundle-container').first()).toBeVisible({ timeout: 15_000 });
 });

--- a/busybuddy-demos/scripts/buy-one-get-one-e2e/01-create-and-customize.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one-e2e/01-create-and-customize.spec.js
@@ -59,16 +59,21 @@ test('BOGO: create + customize full editor workflow', async ({ page, app }) => {
   await toggleEditorEnabled(popup);
   await demoPause(popup);
 
+  // Polaroid Instant Camera/MiniDV Camcorder are used by bundle-discounts-e2e
+  // (and products get permanently tagged busybuddybundles - excluded from
+  // every bundle-type picker across every app - once used in any bundle-type
+  // discount, per the non-e2e volume-discounts/mix-and-match suites' own
+  // comments), so this uses disjoint, otherwise-untouched catalog products
+  // instead of overlapping with that test's pair.
   await clickSidepaneItem(popup, 'Customer Buys (X)');
-  await addProductToPool(popup, 'Polaroid Instant Camera');
+  await addProductToPool(popup, 'Original iPod');
   await demoPause(popup);
 
   await clickSidepaneItem(popup, 'Customer Gets (Y)');
-  // "cam" matches both "Polaroid Instant Camera" and "MiniDV Camcorder", but
-  // Polaroid is already selected for X and excluded from Y's available pool -
-  // still search "cam" as the ticket specifies and click MiniDV Camcorder
-  // by its full title rather than assuming the filtered pool is unambiguous.
-  await addProductToPoolBySearch(popup, 'cam', 'MiniDV Camcorder');
+  // "ipod" matches iPod Mini/Classic/Nano in Y's available pool (Original
+  // iPod is already selected for X and excluded from it) - search it and
+  // click iPod Mini specifically rather than assuming the pool is unambiguous.
+  await addProductToPoolBySearch(popup, 'ipod', 'iPod Mini');
   await demoPause(popup);
 
   await clickSidepaneItem(popup, 'Discount Settings');

--- a/busybuddy-demos/scripts/buy-one-get-one-e2e/04-storefront-render.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one-e2e/04-storefront-render.spec.js
@@ -1,0 +1,15 @@
+import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
+
+// Runs after 01-create-and-customize.spec.js (relies on the offer it
+// creates rather than creating its own - see workers:1/file-order
+// convention this suite already depends on).
+// 1. Load the Original iPod product page on the live storefront - the "buy"
+//    (X) side product that offer's created against
+// 2. Confirm the offer widget renders there
+test('BOGO: offer widget renders on the storefront trigger product page', async ({ page }) => {
+  await gotoStorefrontProduct(page, 'original-ipod');
+  // .bogo-bundle-container is the real markup from
+  // extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid (the
+  // block shared by all 4 bundle-type apps).
+  await expect(page.locator('.bogo-bundle-container').first()).toBeVisible({ timeout: 15_000 });
+});

--- a/busybuddy-demos/scripts/buy-one-get-one/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/buy-one-get-one/04-storefront-live.spec.js
@@ -4,5 +4,9 @@ import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
 // 2. Confirm the offer widget renders on that page
 test('BOGO: offer widget renders on the trigger product\'s page', async ({ page }) => {
   await gotoStorefrontProduct(page, 'sony-walkman');
-  await expect(page.locator('[id*="star_rating"], [class*="busybuddy-bundle"]').first()).toBeVisible({ timeout: 15_000 });
+  // .bogo-bundle-container is the real markup from
+  // extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid (the
+  // block shared by all 4 bundle-type apps) - the previous selector never
+  // matched anything real on this page.
+  await expect(page.locator('.bogo-bundle-container').first()).toBeVisible({ timeout: 15_000 });
 });

--- a/busybuddy-demos/scripts/inactive-tab-message-e2e/04-storefront-render.spec.js
+++ b/busybuddy-demos/scripts/inactive-tab-message-e2e/04-storefront-render.spec.js
@@ -1,0 +1,14 @@
+import { test, expect, gotoStorefrontHome } from '../../fixtures/app.js';
+
+// Runs after 01-configure-settings.spec.js (relies on the enable state it
+// leaves rather than creating its own - see workers:1/file-order convention
+// this suite already depends on).
+// 1. Load the live storefront homepage
+// 2. Confirm the Inactive Tab Message embed script is actually loaded there -
+//    extensions/bogo-shopify-app/blocks/inactive_tab.liquid has no visible
+//    markup of its own, just a deferred <script src="inactiveTab.js">, so
+//    the script tag's presence is the real, verifiable render signal here.
+test('Inactive Tab Message: embed script loads on the storefront homepage', async ({ page }) => {
+  await gotoStorefrontHome(page);
+  await expect(page.locator('script[src*="inactiveTab.js"]')).toHaveCount(1, { timeout: 15_000 });
+});

--- a/busybuddy-demos/scripts/mix-and-match-e2e/01-create-and-customize.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match-e2e/01-create-and-customize.spec.js
@@ -66,18 +66,21 @@ test('Mix & Match: create + customize full editor workflow', async ({ page, app 
   await toggleEditorEnabled(popup);
   await demoPause(popup);
 
+  // Polaroid/MiniDV/Flip Video Camera/CRT Television are all used by the
+  // other 3 bundle-type e2e suites (and products get permanently tagged
+  // busybuddybundles - excluded from every bundle-type picker across every
+  // app - once used in any bundle-type discount, per the non-e2e
+  // volume-discounts/mix-and-match suites' own comments), so this uses 4
+  // disjoint, otherwise-untouched catalog products instead.
   await clickSidepaneItem(popup, 'Select Products');
-  await addProductViaPicker(popup, 'Polaroid Instant Camera');
+  await addProductViaPicker(popup, 'Vintage Macintosh Laptop');
   await demoPause(popup);
-  await addProductViaPicker(popup, 'MiniDV Camcorder');
+  await addProductViaPicker(popup, 'iMac G3');
   await demoPause(popup);
-  await addProductViaPicker(popup, 'Flip Video Camera');
+  await addProductViaPicker(popup, 'Nokia 3310');
   await demoPause(popup);
-  // "tele" matches only "CRT Television" in the seeded catalog - the
-  // ticket's original "tv" wording doesn't match anything (the real
-  // product search is a literal title-substring match), same correction
-  // already applied to this ticket's "tele" search elsewhere.
-  await addProductViaPickerSearch(popup, 'tele', 'CRT Television');
+  // "motorola" matches only "Motorola Razr" in the seeded catalog.
+  await addProductViaPickerSearch(popup, 'motorola', 'Motorola Razr');
   await demoPause(popup);
 
   await clickSidepaneItem(popup, 'Discount Settings');

--- a/busybuddy-demos/scripts/mix-and-match-e2e/04-storefront-render.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match-e2e/04-storefront-render.spec.js
@@ -1,0 +1,15 @@
+import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
+
+// Runs after 01-create-and-customize.spec.js (relies on the offer it
+// creates rather than creating its own - see workers:1/file-order
+// convention this suite already depends on).
+// 1. Load the Vintage Macintosh Laptop product page on the live storefront -
+//    the first of the 4 products that offer's created against
+// 2. Confirm the offer widget renders there
+test('Mix and Match: offer widget renders on a storefront grouped product page', async ({ page }) => {
+  await gotoStorefrontProduct(page, 'vintage-macintosh-laptop');
+  // .bogo-bundle-container is the real markup from
+  // extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid (the
+  // block shared by all 4 bundle-type apps).
+  await expect(page.locator('.bogo-bundle-container').first()).toBeVisible({ timeout: 15_000 });
+});

--- a/busybuddy-demos/scripts/mix-and-match/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/mix-and-match/04-storefront-live.spec.js
@@ -1,8 +1,15 @@
 import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
 
-// 1. Load the Cassette Player product page on the live storefront
+// 1. Load the Sega Game Gear product page on the live storefront - "Cassette
+//    Player" was never a real seeded product (see products.json); Sega Game
+//    Gear is the first of the 3 products 02-create-offer.spec.js actually
+//    adds to this offer.
 // 2. Confirm the offer widget renders on that page
 test('Mix and Match: offer widget renders on a grouped product\'s page', async ({ page }) => {
-  await gotoStorefrontProduct(page, 'cassette-player');
-  await expect(page.locator('[id*="star_rating"], [class*="busybuddy-bundle"]').first()).toBeVisible({ timeout: 15_000 });
+  await gotoStorefrontProduct(page, 'sega-game-gear');
+  // .bogo-bundle-container is the real markup from
+  // extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid (the
+  // block shared by all 4 bundle-type apps) - the previous selector never
+  // matched anything real on this page.
+  await expect(page.locator('.bogo-bundle-container').first()).toBeVisible({ timeout: 15_000 });
 });

--- a/busybuddy-demos/scripts/volume-discounts-e2e/04-storefront-render.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts-e2e/04-storefront-render.spec.js
@@ -1,0 +1,14 @@
+import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
+
+// Runs after 01-create-and-customize.spec.js (relies on the discount it
+// creates rather than creating its own - see workers:1/file-order
+// convention this suite already depends on).
+// 1. Load the CRT Television product page on the live storefront
+// 2. Confirm the quantity-break widget renders there
+test('Volume Discounts: quantity-break widget renders on the storefront product page', async ({ page }) => {
+  await gotoStorefrontProduct(page, 'crt-television');
+  // .bogo-bundle-container is the real markup from
+  // extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid (the
+  // block shared by all 4 bundle-type apps).
+  await expect(page.locator('.bogo-bundle-container').first()).toBeVisible({ timeout: 15_000 });
+});

--- a/busybuddy-demos/scripts/volume-discounts/04-storefront-live.spec.js
+++ b/busybuddy-demos/scripts/volume-discounts/04-storefront-live.spec.js
@@ -1,8 +1,15 @@
 import { test, expect, gotoStorefrontProduct } from '../../fixtures/app.js';
 
-// 1. Load the Discman product page on the live storefront
+// 1. Load the Palm Pilot product page on the live storefront - the actual
+//    product 02-create-volume-discount.spec.js uses (Sony Discman, despite
+//    being a real seeded product, gets permanently excluded from every
+//    bundle-type picker once used elsewhere - see that file's own comment)
 // 2. Confirm the quantity-break widget renders on that page
 test('Volume Discounts: quantity-break tiers render on the product page', async ({ page }) => {
-  await gotoStorefrontProduct(page, 'discman');
-  await expect(page.locator('[id*="star_rating"], [class*="busybuddy-bundle"]').first()).toBeVisible({ timeout: 15_000 });
+  await gotoStorefrontProduct(page, 'palm-pilot');
+  // .bogo-bundle-container is the real markup from
+  // extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid (the
+  // block shared by all 4 bundle-type apps) - the previous selector never
+  // matched anything real on this page.
+  await expect(page.locator('.bogo-bundle-container').first()).toBeVisible({ timeout: 15_000 });
 });

--- a/extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid
+++ b/extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid
@@ -190,7 +190,7 @@
 
 {% schema %}
 {
-  "name": "BusyBuddy Bundles and Discounts",
+  "name": "BusyBuddy Bundles",
   "target": "section",
   "settings": [
     {

--- a/extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid
+++ b/extensions/bogo-shopify-app/blocks/bundles_and_discounts.liquid
@@ -190,7 +190,7 @@
 
 {% schema %}
 {
-  "name": "BusyBuddy Bundle",
+  "name": "BusyBuddy Bundles and Discounts",
   "target": "section",
   "settings": [
     {

--- a/web/backend/configs/subscriptionConfig.js
+++ b/web/backend/configs/subscriptionConfig.js
@@ -73,3 +73,35 @@ export const appMapping = {
   },
 };
 
+// Maps each appId to the physical theme-extension block/embed that renders it
+// on the storefront, so the theme-editor deep link and the "is it enabled in
+// the theme" check can be generated generically instead of hardcoded to one
+// app. The 4 discount-type apps all share a single block (bundles_and_discounts,
+// née star_rating.liquid) since the backend's getActiveBundle already resolves
+// one winning bundle across all 4 types on a shared product.
+const BUNDLE_BLOCK = {
+  handle: "bundles_and_discounts",
+  target: "section",
+  editorTemplate: "product",
+  editorSectionTarget: "newAppsSection",
+  scanAssets: ["templates/product.json"],
+};
+
+export const themeBlockConfig = {
+  announcement_bar: {
+    handle: "announcement_bar",
+    target: "section",
+    editorTemplate: "index",
+    editorSectionTarget: "sectionGroup:header",
+    scanAssets: ["sections/header-group.json", "templates/index.json"],
+  },
+  inactive_tab: {
+    handle: "inactive_tab",
+    target: "body",
+  },
+  bundle_discount: BUNDLE_BLOCK,
+  buy_one_get_one: BUNDLE_BLOCK,
+  volume_discounts: BUNDLE_BLOCK,
+  mix_match: BUNDLE_BLOCK,
+};
+

--- a/web/backend/controller/subscription/index.js
+++ b/web/backend/controller/subscription/index.js
@@ -2,8 +2,73 @@ import subscriptionModel from "../../models/subscription.model.js";
 import shopify from "../../../shopify.js";
 import { billingConfig, cancelSubscriptionPlan, getAppSubscription, isTestPaymentMode } from "../../../billing.js";
 import { subscriptionUpdate } from "../../services/subscription.js";
-import { subscriptionConfig, appMapping } from "../../configs/subscriptionConfig.js";
+import { subscriptionConfig, appMapping, themeBlockConfig } from "../../configs/subscriptionConfig.js";
 import { merchantEventService } from "../../services/merchantEventService.js";
+
+// Short-lived per-shop/per-app cache for theme-extension status so the
+// Admin Assets API isn't hit on every homepage load and every toggle
+// attempt - Shopify has no webhook for app block/embed toggle changes, so
+// this can only ever be "eventually correct" until the caller refetches.
+const EXTENSION_STATUS_TTL_MS = 30_000;
+const extensionStatusCache = new Map();
+
+function findEnabledBlock(node, blockHandle, depth = 0) {
+  if (!node || typeof node !== "object" || depth > 6) return false;
+  if (typeof node.type === "string" && node.type.includes(`/blocks/${blockHandle}/`) && node.disabled !== true) {
+    return true;
+  }
+  for (const key of Object.keys(node)) {
+    if (findEnabledBlock(node[key], blockHandle, depth + 1)) return true;
+  }
+  return false;
+}
+
+async function isBlockPresentInAsset(client, themeId, assetKey, blockHandle) {
+  try {
+    const assets = await client.get({
+      path: `themes/${themeId}/assets`,
+      query: { "asset[key]": assetKey },
+    });
+    const data = JSON.parse(assets.body.asset.value);
+    return findEnabledBlock(data, blockHandle);
+  } catch (error) {
+    // Asset doesn't exist on this theme, or isn't valid JSON - treat as "not configured" rather than erroring the whole check.
+    return false;
+  }
+}
+
+// Checks whether the given appId's theme block/embed is actually enabled on
+// the shop's live theme. Body-target blocks (app embeds) are a single global
+// toggle stored in config/settings_data.json; section-target blocks have no
+// canonical location, so we scan the template(s) each app is expected on.
+async function checkExtensionStatus(session, appId) {
+  const config = themeBlockConfig[appId];
+  if (!config) return false;
+
+  const cacheKey = `${session.shop}:${appId}`;
+  const cached = extensionStatusCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.enabled;
+
+  const client = new shopify.api.clients.Rest({ session });
+  const themes = await client.get({ path: "themes" });
+  const mainTheme = themes.body.themes.find((theme) => theme.role === "main");
+  if (!mainTheme) return false;
+
+  let enabled = false;
+  if (config.target === "body") {
+    enabled = await isBlockPresentInAsset(client, mainTheme.id, "config/settings_data.json", config.handle);
+  } else {
+    for (const assetKey of config.scanAssets) {
+      if (await isBlockPresentInAsset(client, mainTheme.id, assetKey, config.handle)) {
+        enabled = true;
+        break;
+      }
+    }
+  }
+
+  extensionStatusCache.set(cacheKey, { enabled, expiresAt: Date.now() + EXTENSION_STATUS_TTL_MS });
+  return enabled;
+}
 async function getUsersubscription(_req, res) {
   try {
     const session = res.locals.shopify.session;
@@ -299,103 +364,59 @@ async function cancelSubscribe(_req, res) {
   }
 }
 
-async function checkBusyBuddyEnabled(_req, res) {
+async function getExtensionStatus(req, res) {
   const session = res.locals.shopify.session;
+  const { appId } = req.query;
+
+  if (!appId || !themeBlockConfig[appId]) {
+    return res.status(400).json({
+      status: "ERROR",
+      error: "A valid appId query param is required",
+    });
+  }
 
   try {
-    // Create a Shopify API client
-    const client = new shopify.api.clients.Rest({ session });
-
-    // Get the current theme
-    const themes = await client.get({
-      path: "themes",
-    });
-
-    // Find the main/currently active theme
-    const mainTheme = themes.body.themes.find((theme) => theme.role === "main");
-    if (!mainTheme) {
-      return res.status(404).json({
-        status: "ERROR",
-        error: "No active theme found",
-      });
-    }
-
-    const assets = await client.get({
-      path: `themes/${mainTheme.id}/assets`,
-      query: { "asset[key]": "sections/header-group.json" },
-    });
-
-    // Parse the header sections data
-    const headerData = JSON.parse(assets.body.asset.value);
-
-    // Check if BusyBuddy is enabled in the header sections
-    let isEnabled = false;
-
-    if (headerData.sections) {
-      for (const sectionId in headerData.sections) {
-        const section = headerData.sections[sectionId];
-        // Also check individual blocks for app patterns
-        let extensionName = process.env.EXTENSION_APP_NAME || "busy_budy_dev";
-        if (section?.blocks) {
-          for (const blockId in section.blocks) {
-            const block = section.blocks[blockId];
-
-            // Check for app block pattern (busy_budy_dev)
-            if (blockId.includes(extensionName) || (block.type && block.type.includes(extensionName))) {
-              isEnabled = true;
-              break;
-            }
-          }
-        }
-        if (isEnabled) break;
-      }
-    }
-
+    const enabled = await checkExtensionStatus(session, appId);
     return res.json({
       status: "SUCCESS",
-      data: {
-        enabled: !!isEnabled,
-      },
+      data: { appId, extensionEnabled: enabled },
     });
   } catch (error) {
-    console.error("Error checking BusyBuddy status in header-group:", error);
+    console.error("Error checking extension status:", error);
     return res.status(500).json({
       status: "ERROR",
-      error: "Could not determine BusyBuddy status - complete API failure",
+      error: "Could not determine extension status",
       details: error.message,
     });
   }
 }
-async function getThemeEditorUrl(_req, res) {
+
+async function getThemeEditorUrl(req, res) {
   const session = res.locals.shopify.session;
+  const appId = req.query.appId || "announcement_bar";
+  const config = themeBlockConfig[appId];
+
+  if (!config) {
+    return res.status(400).json({
+      status: "ERROR",
+      error: `Unknown appId: ${appId}`,
+    });
+  }
 
   try {
-    // Create a Shopify API client
-    const client = new shopify.api.clients.Rest({ session });
+    const uid = process.env.EXTENSION_APP_ID;
+    let themeEditorUrl;
 
-    // Get the current theme
-    const themes = await client.get({
-      path: "themes",
-    });
-
-    // Find the main/currently active theme
-    const mainTheme = themes.body.themes.find((theme) => theme.role === "main");
-
-    if (!mainTheme) {
-      return res.status(404).json({
-        status: "ERROR",
-        error: "No active theme found",
-      });
+    if (config.target === "body") {
+      // App embeds are a single global toggle - no template needed.
+      themeEditorUrl = `https://${session.shop}/admin/themes/current/editor?context=apps&activateAppId=${uid}/${config.handle}`;
+    } else {
+      themeEditorUrl = `https://${session.shop}/admin/themes/current/editor?template=${config.editorTemplate}&addAppBlockId=${uid}/${config.handle}&target=${config.editorSectionTarget}`;
     }
 
-    let appId = process.env.EXTENSION_APP_ID;
-
-    let themeEditorUrl = `https://${session.shop}/admin/themes/current/editor?template=index&addAppBlockId=${appId}/announcement_bar&target=sectionGroup:header`;
     return res.json({
       status: "SUCCESS",
-      data: {
-        url: themeEditorUrl,
-      },
+      data: { appId, url: themeEditorUrl },
     });
   } catch (error) {
     console.error("Error getting theme editor URL:", error);
@@ -570,7 +591,7 @@ export {
   getUsersubscription,
   subscribeToPlan,
   cancelSubscribe,
-  checkBusyBuddyEnabled,
+  getExtensionStatus,
   getThemeEditorUrl,
   toggleApp,
   getAppStatus,

--- a/web/backend/controller/subscription/index.js
+++ b/web/backend/controller/subscription/index.js
@@ -404,7 +404,12 @@ async function getThemeEditorUrl(req, res) {
   }
 
   try {
-    const uid = process.env.EXTENSION_APP_ID;
+    // Shopify's theme-editor deep-link scheme identifies the app by its
+    // Client ID, not by the extension's own `uid` from shopify.extension.toml
+    // (that uid is for the CLI's config-sync/registry, unrelated to this) -
+    // SHOPIFY_API_KEY is that Client ID, already relied on elsewhere (e.g.
+    // web/index.js for App Bridge init) so it's guaranteed to be set.
+    const uid = process.env.SHOPIFY_API_KEY;
     let themeEditorUrl;
 
     if (config.target === "body") {

--- a/web/backend/routes/subscription/index.js
+++ b/web/backend/routes/subscription/index.js
@@ -1,10 +1,10 @@
 import express from 'express';
 const router = express.Router();
-import{ getUsersubscription,subscribeToPlan,cancelSubscribe,checkBusyBuddyEnabled,getThemeEditorUrl,toggleApp,getAppStatus } from '../../controller/subscription/index.js';
+import{ getUsersubscription,subscribeToPlan,cancelSubscribe,getExtensionStatus,getThemeEditorUrl,toggleApp,getAppStatus } from '../../controller/subscription/index.js';
 router.get('/getUserSubscription', getUsersubscription);
 router.post("/subscribe", subscribeToPlan);
 router.post("/cancel-subscription", cancelSubscribe);
-router.get("/checkBusyBuddyEnabled", checkBusyBuddyEnabled);
+router.get("/extension-status", getExtensionStatus);
 router.get("/getThemeEditorUrl", getThemeEditorUrl);
 router.post("/toggle-app", toggleApp);
 router.get("/app-status/:appId?", getAppStatus);

--- a/web/backend/tests/authFlow.integration.test.js
+++ b/web/backend/tests/authFlow.integration.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import request from 'supertest';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import * as crypto from 'crypto';
 
 // web/index.js reads Shopify config + DB env vars at import time (shopify.js
 // throws synchronously if apiKey/apiSecretKey/hostName are missing), so
@@ -30,9 +31,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 vi.spyOn(process, 'cwd').mockReturnValue(join(__dirname, '../..'));
 
 let app;
+let shopify;
 
 beforeAll(async () => {
   ({ default: app } = await import('../../index.js'));
+  ({ default: shopify } = await import('../../shopify.js'));
 });
 
 describe('GET /api/auth (OAuth begin) - integration', () => {
@@ -117,5 +120,50 @@ describe('GET /api/editor/signature - integration', () => {
     const res = await request(app).get('/api/editor/signature');
 
     expect(res.status).not.toBe(200);
+  });
+});
+
+// Real Shopify App Proxy requests (getActiveBundle/getInactiveTab/
+// getAnnouncementBar, hit directly by storefront visitors) sign every query
+// param, not just `shop` - the /api/* middleware used to only check the
+// shop-only signature the standalone editor mints for itself, so a real
+// proxy request's signature could never match and always 401'd.
+function signAllParams(params) {
+  const parts = Object.entries(params).map(([key, value]) => `${key}=${value}`);
+  return crypto.createHmac('sha256', 'test-api-secret').update(parts.sort().join('')).digest('hex');
+}
+
+describe('GET /api/frontStore/* (App Proxy) - integration', () => {
+  it('accepts a request signed the way Shopify actually signs App Proxy calls (all params, not just shop)', async () => {
+    // loadSession would otherwise try to actually reach this test's
+    // deliberately-unreachable DB_CONNECTION host and hang - stubbed here
+    // purely so the test can observe the signature check's own outcome
+    // without waiting on a real Mongo connection attempt.
+    const loadSessionSpy = vi.spyOn(shopify.config.sessionStorage, 'loadSession').mockResolvedValue(null);
+
+    const params = { shop: 'test-shop.myshopify.com', product_id: '123', timestamp: '1700000000' };
+    const signature = signAllParams(params);
+
+    const res = await request(app).get(
+      `/api/frontStore/getActiveBundle?shop=${params.shop}&product_id=${params.product_id}&timestamp=${params.timestamp}&signature=${signature}`
+    );
+
+    // The signature itself must be accepted (not the old "Invalid request
+    // signature" 401) - it still 401s past that point since no offline
+    // session exists in this test's empty session storage, which is a
+    // separate, correctly-behaving check.
+    expect(res.body?.message).not.toMatch(/invalid request signature/i);
+    expect(res.body?.message).toMatch(/no active session found/i);
+
+    loadSessionSpy.mockRestore();
+  });
+
+  it('still rejects a request with a wrong/forged signature', async () => {
+    const res = await request(app).get(
+      '/api/frontStore/getActiveBundle?shop=test-shop.myshopify.com&product_id=123&signature=not-a-real-signature'
+    );
+
+    expect(res.status).toBe(401);
+    expect(res.body?.message).toMatch(/invalid request signature/i);
   });
 });

--- a/web/backend/tests/controller/subscription.extensionGating.test.js
+++ b/web/backend/tests/controller/subscription.extensionGating.test.js
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+
+vi.mock('../../models/subscription.model.js', () => {
+  // A real class (not a plain object) so `subscriptionData instanceof
+  // subscriptionModel` in toggleApp doesn't throw - it only needs to be
+  // callable, findOne/create results in these tests are plain objects and
+  // so correctly evaluate as "not an instance" (skipping .save()).
+  class MockSubscriptionModel {}
+  MockSubscriptionModel.findOne = vi.fn();
+  MockSubscriptionModel.create = vi.fn();
+  return { default: MockSubscriptionModel };
+});
+
+vi.mock('../../../shopify.js', () => ({
+  default: {
+    api: {
+      billing: { check: vi.fn(), request: vi.fn() },
+      clients: { Rest: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('../../services/merchantEventService.js', () => ({
+  merchantEventService: {
+    handleSubscriptionUpgrade: vi.fn(() => Promise.resolve()),
+    handleSubscriptionDowngrade: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+import subscriptionModel from '../../models/subscription.model.js';
+import shopify from '../../../shopify.js';
+import { getExtensionStatus, getThemeEditorUrl } from '../../controller/subscription/index.js';
+
+const createMockRes = (session) => ({
+  locals: { shopify: { session } },
+  json: vi.fn().mockReturnThis(),
+  status: vi.fn().mockReturnThis(),
+});
+
+const THEMES_RESPONSE = { body: { themes: [{ id: 111, role: 'main' }] } };
+
+// Builds a Rest client mock: `assets` maps an asset[key] string to the raw
+// JSON string that would come back as `asset.value`. Anything not listed
+// 404s, matching how a theme without that section/template actually behaves.
+function mockRestClient(assets) {
+  shopify.api.clients.Rest.mockImplementation(() => ({
+    get: vi.fn(({ path, query }) => {
+      if (path === 'themes') return Promise.resolve(THEMES_RESPONSE);
+      const key = query?.['asset[key]'];
+      if (path === 'themes/111/assets' && assets[key]) {
+        return Promise.resolve({ body: { asset: { value: assets[key] } } });
+      }
+      return Promise.reject(new Error('not found'));
+    }),
+  }));
+}
+
+// checkExtensionStatus caches per shop+appId for 30s, so each test uses its
+// own shop domain to avoid one test's mocked result leaking into the next.
+let shopCounter = 0;
+const nextShop = () => `test-shop-${++shopCounter}.myshopify.com`;
+
+describe('getExtensionStatus - per-block theme detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports enabled for a body-target embed (inactive_tab) found in settings_data.json', async () => {
+    mockRestClient({
+      'config/settings_data.json': JSON.stringify({
+        current: {
+          blocks: {
+            abc: { type: 'shopify://apps/busybuddy/blocks/inactive_tab/some-uuid', disabled: false },
+          },
+        },
+      }),
+    });
+
+    const req = { query: { appId: 'inactive_tab' } };
+    const res = createMockRes({ shop: nextShop() });
+    await getExtensionStatus(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ extensionEnabled: true }) })
+    );
+  });
+
+  it('reports disabled for a body-target embed explicitly turned off', async () => {
+    mockRestClient({
+      'config/settings_data.json': JSON.stringify({
+        current: {
+          blocks: {
+            abc: { type: 'shopify://apps/busybuddy/blocks/inactive_tab/some-uuid', disabled: true },
+          },
+        },
+      }),
+    });
+
+    const req = { query: { appId: 'inactive_tab' } };
+    const res = createMockRes({ shop: nextShop() });
+    await getExtensionStatus(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ extensionEnabled: false }) })
+    );
+  });
+
+  it('reports enabled for a section-target block (the shared bundle block) found on the product template', async () => {
+    mockRestClient({
+      'templates/product.json': JSON.stringify({
+        sections: {
+          main: {
+            blocks: {
+              xyz: { type: 'shopify://apps/busybuddy/blocks/bundles_and_discounts/some-uuid' },
+            },
+          },
+        },
+      }),
+    });
+
+    for (const appId of ['bundle_discount', 'buy_one_get_one', 'volume_discounts', 'mix_match']) {
+      const req = { query: { appId } };
+      const res = createMockRes({ shop: nextShop() });
+      await getExtensionStatus(req, res);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ appId, extensionEnabled: true }) })
+      );
+    }
+  });
+
+  it('reports disabled when none of the scanned templates contain the block', async () => {
+    mockRestClient({
+      'templates/product.json': JSON.stringify({ sections: {} }),
+    });
+
+    const req = { query: { appId: 'bundle_discount' } };
+    const res = createMockRes({ shop: nextShop() });
+    await getExtensionStatus(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ extensionEnabled: false }) })
+    );
+  });
+
+  it('checks both scan locations for announcement_bar, not just header-group', async () => {
+    mockRestClient({
+      'templates/index.json': JSON.stringify({
+        sections: { hero: { blocks: { b1: { type: 'shopify://apps/busybuddy/blocks/announcement_bar/uuid' } } } },
+      }),
+    });
+
+    const req = { query: { appId: 'announcement_bar' } };
+    const res = createMockRes({ shop: nextShop() });
+    await getExtensionStatus(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ extensionEnabled: true }) })
+    );
+  });
+
+  it('rejects an unknown appId', async () => {
+    const req = { query: { appId: 'not_a_real_app' } };
+    const res = createMockRes({ shop: nextShop() });
+    await getExtensionStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe('getThemeEditorUrl - per-app deep link generation', () => {
+  const originalEnv = process.env.EXTENSION_APP_ID;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.EXTENSION_APP_ID = 'test-uid-123';
+  });
+
+  afterAll(() => {
+    process.env.EXTENSION_APP_ID = originalEnv;
+  });
+
+  it('builds an activateAppId (app-embed) link for inactive_tab', async () => {
+    const req = { query: { appId: 'inactive_tab' } };
+    const res = createMockRes({ shop: 'test-shop.myshopify.com' });
+    await getThemeEditorUrl(req, res);
+
+    const [[payload]] = res.json.mock.calls;
+    expect(payload.data.url).toBe(
+      'https://test-shop.myshopify.com/admin/themes/current/editor?context=apps&activateAppId=test-uid-123/inactive_tab'
+    );
+  });
+
+  it('builds an addAppBlockId (section block) link for the shared bundle block', async () => {
+    const req = { query: { appId: 'buy_one_get_one' } };
+    const res = createMockRes({ shop: 'test-shop.myshopify.com' });
+    await getThemeEditorUrl(req, res);
+
+    const [[payload]] = res.json.mock.calls;
+    expect(payload.data.url).toBe(
+      'https://test-shop.myshopify.com/admin/themes/current/editor?template=product&addAppBlockId=test-uid-123/bundles_and_discounts&target=newAppsSection'
+    );
+  });
+
+  it('rejects an unknown appId', async () => {
+    const req = { query: { appId: 'not_a_real_app' } };
+    const res = createMockRes({ shop: 'test-shop.myshopify.com' });
+    await getThemeEditorUrl(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+// toggleApp itself is intentionally NOT extension-gated server-side - only
+// the frontend ToggleSwitch blocks turning an app on (see
+// tests/components/ToggelSwitch.test.jsx). Enforcing it here too would also
+// block the E2E suites' toggleAppWideSwitchAndRestore helper, which flips
+// every app's toggle on/off freely regardless of the demo store's actual
+// theme-block placement.

--- a/web/backend/tests/controller/subscription.extensionGating.test.js
+++ b/web/backend/tests/controller/subscription.extensionGating.test.js
@@ -168,15 +168,15 @@ describe('getExtensionStatus - per-block theme detection', () => {
 });
 
 describe('getThemeEditorUrl - per-app deep link generation', () => {
-  const originalEnv = process.env.EXTENSION_APP_ID;
+  const originalEnv = process.env.SHOPIFY_API_KEY;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.EXTENSION_APP_ID = 'test-uid-123';
+    process.env.SHOPIFY_API_KEY = 'test-uid-123';
   });
 
   afterAll(() => {
-    process.env.EXTENSION_APP_ID = originalEnv;
+    process.env.SHOPIFY_API_KEY = originalEnv;
   });
 
   it('builds an activateAppId (app-embed) link for inactive_tab', async () => {

--- a/web/frontend/apps/announcement-bar/AnnouncementBarForm.jsx
+++ b/web/frontend/apps/announcement-bar/AnnouncementBarForm.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import DiscountList from "./DiscountList";
 import Button from "../../components/Button";
 import ToggleSwitch from "../../components/ToggelSwitch";
+import ThemeExtensionBanner from "../../components/ThemeExtensionBanner";
 import { useEditorNavigation } from "../../hooks";
 
 export default function AnnouncementBarForm() {
@@ -28,6 +29,7 @@ export default function AnnouncementBarForm() {
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
+        <ThemeExtensionBanner appId="announcement_bar" />
         <Row className="mb-4 align-items-start">
           <Col xs="auto">
             <div

--- a/web/frontend/apps/bundle-discounts/BundleForm.jsx
+++ b/web/frontend/apps/bundle-discounts/BundleForm.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import DiscountList from "../../components/BundelDiscountList";
 import Button from "../../components/Button";
 import ToggleSwitch from "../../components/ToggelSwitch";
+import ThemeExtensionBanner from "../../components/ThemeExtensionBanner";
 import { openEditorTab } from "../../utils/openEditorTab";
 
 export default function BundleForm() {
@@ -43,6 +44,7 @@ export default function BundleForm() {
   return (
     <div>
       <Container fluid style={{ margin: "0 auto" }}>
+        <ThemeExtensionBanner appId="bundle_discount" />
         <Row className="mb-4 align-items-start">
           <Col xs="auto">
             {fromDiscountPage ? (

--- a/web/frontend/apps/buy-one-get-one/buyoneGetone.jsx
+++ b/web/frontend/apps/buy-one-get-one/buyoneGetone.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import DiscountList from "../../components/BundelDiscountList";
 import Button from "../../components/Button";
 import ToggleSwitch from "../../components/ToggelSwitch";
+import ThemeExtensionBanner from "../../components/ThemeExtensionBanner";
 import { openEditorTab } from "../../utils/openEditorTab";
 
 export default function BuyonegetoneForm() {
@@ -41,6 +42,7 @@ export default function BuyonegetoneForm() {
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
+        <ThemeExtensionBanner appId="buy_one_get_one" />
         <Row className="mb-4 align-items-start">
           <Col xs="auto">
             {fromDiscountPage ? (

--- a/web/frontend/apps/inactive-tab-message/InactiveTabMessageForm.jsx
+++ b/web/frontend/apps/inactive-tab-message/InactiveTabMessageForm.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import DiscountList from "./DiscountList";
 import Button from "../../components/Button";
 import ToggleSwitch from "../../components/ToggelSwitch";
+import ThemeExtensionBanner from "../../components/ThemeExtensionBanner";
 
 export default function InactiveTabMessageForm() {
   const navigate = useNavigate();
@@ -21,19 +22,10 @@ export default function InactiveTabMessageForm() {
     navigate('/' + location.search);
   };
 
-  // inactive_tab.liquid targets "body", so it's a real app embed and
-  // ?context=apps correctly opens the "App embeds" panel where merchants
-  // toggle it on (unlike the Announcement Bar's section block, which needs
-  // "Add block" instead).
-  const getThemeEmbedUrl = () => {
-    const params = new URLSearchParams(location.search);
-    const shop = params.get("shop");
-    return shop ? `https://${shop}/admin/themes/current/editor?context=apps` : "#";
-  };
-
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
+        <ThemeExtensionBanner appId="inactive_tab" />
         <Row className="mb-4 align-items-start">
           <Col xs="auto">
             {fromDiscountPage ? (
@@ -77,14 +69,6 @@ export default function InactiveTabMessageForm() {
               alert in the title of their browser tab, so they’ll remember their
               cart, discounts, or promotions!
             </p>
-            <a
-              href={getThemeEmbedUrl()}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ fontSize: "13px", fontWeight: 500 }}
-            >
-              Enable BusyBuddy Inactive Tab in Shopify Theme Extensions →
-            </a>
           </Col>
 
           {fromDiscountPage ? (

--- a/web/frontend/apps/mix-and-match-discounts/MixMatchForm.jsx
+++ b/web/frontend/apps/mix-and-match-discounts/MixMatchForm.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import DiscountList from "../../components/BundelDiscountList";
 import Button from "../../components/Button";
 import ToggleSwitch from "../../components/ToggelSwitch";
+import ThemeExtensionBanner from "../../components/ThemeExtensionBanner";
 import { openEditorTab } from "../../utils/openEditorTab";
 
 export default function MixMatchForm() {
@@ -48,6 +49,7 @@ export default function MixMatchForm() {
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
+        <ThemeExtensionBanner appId="mix_match" />
         <Row className="mb-4 align-items-start">
           <Col xs="auto">
             {fromDiscountPage ? (

--- a/web/frontend/apps/volume-discounts/VolumeForm.jsx
+++ b/web/frontend/apps/volume-discounts/VolumeForm.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import DiscountList from "../../components/BundelDiscountList";
 import Button from "../../components/Button";
 import ToggleSwitch from "../../components/ToggelSwitch";
+import ThemeExtensionBanner from "../../components/ThemeExtensionBanner";
 import { openEditorTab } from "../../utils/openEditorTab";
 
 export default function VolumeForm() {
@@ -43,6 +44,7 @@ export default function VolumeForm() {
   return (
     <div>
       <Container fluid style={{ maxWidth: "1500px", margin: "0 auto" }}>
+        <ThemeExtensionBanner appId="volume_discounts" />
         <Row className="mb-4 align-items-start">
           <Col xs="auto">
             {fromDiscountPage ? (

--- a/web/frontend/components/ThemeExtensionBanner.jsx
+++ b/web/frontend/components/ThemeExtensionBanner.jsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+
+// Unique per-app color so 6 of these on 6 different homepages never look
+// interchangeable. Mirrors each widget's existing brand color in
+// pages/DashboardHome.jsx's widgetConfig rather than inventing a new palette.
+const APP_BRAND = {
+  announcement_bar: { name: "Announcement Bar", bg: "#eef0ff", accent: "#4f46e5" },
+  bundle_discount: { name: "Bundle Discount", bg: "#eaf3ff", accent: "#0b76ef" },
+  buy_one_get_one: { name: "Buy One Get One", bg: "#e8fbee", accent: "#0f7a3b" },
+  volume_discounts: { name: "Volume Discounts", bg: "#fdecec", accent: "#d63535" },
+  mix_match: { name: "Mix & Match", bg: "#f2e8ff", accent: "#7c3aed" },
+  inactive_tab: { name: "Inactive Tab Message", bg: "#f4f4f2", accent: "#6b7280" },
+};
+
+// Shown on each app's own homepage (not the Dashboard) when that app's
+// theme block/embed isn't enabled yet, so a merchant lands here already
+// knowing which specific app to go turn on - deep-linking straight to it.
+export default function ThemeExtensionBanner({ appId }) {
+  const [extensionEnabled, setExtensionEnabled] = useState(null);
+  const [editorUrl, setEditorUrl] = useState("#");
+
+  const brand = APP_BRAND[appId];
+
+  const checkStatus = async () => {
+    try {
+      const response = await fetch(`/api/subscription/extension-status?appId=${appId}`);
+      const data = await response.json();
+      setExtensionEnabled(data.status === "SUCCESS" ? data.data.extensionEnabled : true);
+    } catch (error) {
+      setExtensionEnabled(true); // default to enabled (hide the banner) if the check itself fails
+    }
+  };
+
+  const fetchEditorUrl = async () => {
+    try {
+      const response = await fetch(`/api/subscription/getThemeEditorUrl?appId=${appId}`);
+      const data = await response.json();
+      if (data.status === "SUCCESS") setEditorUrl(data.data.url);
+    } catch (error) {
+      // leave the "#" fallback
+    }
+  };
+
+  useEffect(() => {
+    checkStatus();
+    fetchEditorUrl();
+  }, [appId]);
+
+  // Shopify has no webhook for a merchant toggling a theme block/embed, so
+  // the only way to notice they came back from the theme editor is to
+  // recheck when this tab regains focus.
+  useEffect(() => {
+    const onFocus = () => checkStatus();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [appId]);
+
+  if (!brand || extensionEnabled !== false) return null;
+
+  return (
+    <a
+      href={editorUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="theme-extension-banner"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        background: brand.bg,
+        color: brand.accent,
+        border: `1px solid ${brand.accent}33`,
+        borderRadius: "10px",
+        padding: "10px 14px",
+        fontSize: "13px",
+        fontWeight: 500,
+        marginBottom: "16px",
+        textDecoration: "none",
+      }}
+    >
+      <span>
+        Enable {brand.name} in your theme editor to go live on your storefront, then click{" "}
+        <strong>Save</strong> there - it won't show as Active here until you do.
+      </span>
+    </a>
+  );
+}

--- a/web/frontend/components/ToggelSwitch.jsx
+++ b/web/frontend/components/ToggelSwitch.jsx
@@ -7,16 +7,47 @@ const ToggleSwitch = ({ appId }) => {
   const [hasAppAccess, setHasAppAccess] = useState(true);
   const [subscriptionInfo, setSubscriptionInfo] = useState(null);
   const [isDisabledButton, setIsDisabledButton] = useState(false);
+  // null = still loading the theme-extension check; only known false blocks
+  // enabling, so we never flash "disabled" before the check has resolved.
+  const [extensionEnabled, setExtensionEnabled] = useState(null);
+  // Distinguishes *why* the toggle is disabled so the tooltip tells the
+  // merchant the right thing instead of always blaming their plan.
+  const [disabledReason, setDisabledReason] = useState(null);
 
   useEffect(() => {
     fetchInitialStatus();
     fetchSubscriptionInfo();
+    fetchExtensionStatus();
     isDisabled();
   }, [appId]);
 
   useEffect(() => {
     isDisabled();
-  }, [subscriptionInfo, active, loading, hasAppAccess]);
+  }, [subscriptionInfo, active, loading, hasAppAccess, extensionEnabled]);
+
+  // Shopify has no webhook for a merchant toggling a theme block/embed, so
+  // the only way to notice they came back from the theme editor and enabled
+  // it is to recheck when this tab regains focus.
+  useEffect(() => {
+    const onFocus = () => fetchExtensionStatus();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [appId]);
+
+  const fetchExtensionStatus = async () => {
+    try {
+      const response = await fetch(`/api/subscription/extension-status?appId=${appId}`);
+      const data = await response.json();
+      if (data.status === "SUCCESS") {
+        setExtensionEnabled(data.data.extensionEnabled);
+      } else {
+        setExtensionEnabled(true); // default to enabled if the check itself fails
+      }
+    } catch (error) {
+      console.error("Error checking extension status:", error);
+      setExtensionEnabled(true);
+    }
+  };
 
   const fetchInitialStatus = async () => {
     try {
@@ -77,6 +108,13 @@ const ToggleSwitch = ({ appId }) => {
   };
 
   const checkCanEnable = () => {
+    if (extensionEnabled === false) {
+      return {
+        canEnable: false,
+        reason: "This app won't be enabled until its extension is turned on in your theme editor.",
+      };
+    }
+
     if (!subscriptionInfo) return { canEnable: false, reason: "No subscription info" };
 
     const { planName, enabledAppsCount } = subscriptionInfo;
@@ -158,11 +196,21 @@ const ToggleSwitch = ({ appId }) => {
     // always block if loading or no access
     if (loading || !hasAppAccess) {
       setIsDisabledButton(true);
+      setDisabledReason(null);
+      return;
+    }
+
+    // Extension gate only ever blocks turning the app ON - disabling should
+    // always stay available regardless of theme state.
+    if (!active && extensionEnabled === false) {
+      setIsDisabledButton(true);
+      setDisabledReason("extension");
       return;
     }
 
     if (!subscriptionInfo) {
       setIsDisabledButton(false);
+      setDisabledReason(null);
       return;
     }
 
@@ -172,13 +220,19 @@ const ToggleSwitch = ({ appId }) => {
     // Only check limits when trying to enable (active === false)
     if (!active && enabledAppsCount >= maxApps[planName]) {
       setIsDisabledButton(true); // prevent enabling
+      setDisabledReason("plan-limit");
     } else {
       setIsDisabledButton(false); // allow disabling or enabling within limit
+      setDisabledReason(null);
     }
   };
 
   const getToggleTitle = () => {
     if (!hasAppAccess) return "Feature not available in your current plan";
+    if (disabledReason === "extension") {
+      return "This app won't be enabled until its extension is turned on in your theme editor.";
+    }
+    if (disabledReason === "plan-limit") return "Upgrade your plan to enable more apps";
     if (loading) return "Processing...";
     if (active) return "Click to disable";
     return "Click to enable";
@@ -189,7 +243,7 @@ const ToggleSwitch = ({ appId }) => {
       className="d-flex align-items-center"
       style={{ cursor: isDisabledButton ? "not-allowed" : "pointer" }}
       onClick={isDisabledButton && !active ? undefined : toggleSwitch}
-      title={isDisabledButton && !active ? "Upgrade your plan to enable more apps" : getToggleTitle()}
+      title={getToggleTitle()}
     >
       {error && (
         <div

--- a/web/frontend/pages/DashboardHome.jsx
+++ b/web/frontend/pages/DashboardHome.jsx
@@ -9,7 +9,6 @@ import {
   Plus,
   Settings,
   DollarSign,
-  ExternalLink,
   Zap,
   TrendingUp,
   TrendingDown,
@@ -208,10 +207,7 @@ export default function DashboardHome() {
   const [loading, setLoading] = useState(true);
   const [activities, setActivities] = useState([]);
   const [activityLoading, setActivityLoading] = useState(true);
-  const [extensionEnabled, setExtensionEnabled] = useState(null); // null = loading
-  const [showExtensionBanner, setShowExtensionBanner] = useState(false);
   const [showUpgradeBanner, setShowUpgradeBanner] = useState(false);
-  const [extensionBannerFlashing, setExtensionBannerFlashing] = useState(false);
   const [upgradeBannerFlashing, setUpgradeBannerFlashing] = useState(false);
   const [range, setRange] = useState("7d");
   const [summary, setSummary] = useState(null);
@@ -220,7 +216,6 @@ export default function DashboardHome() {
   useEffect(() => {
     fetchUserSubscription();
     fetchActivityData();
-    checkExtensionStatus();
 
     // Live activity rail: refresh periodically so "Streaming" is a real claim.
     const activityInterval = setInterval(fetchActivityData, ACTIVITY_REFRESH_MS);
@@ -239,23 +234,6 @@ export default function DashboardHome() {
   useEffect(() => {
     fetchDashboardSummary(range);
   }, [range]);
-
-  // Handle extension banner visibility with flash animation
-  useEffect(() => {
-    if (extensionEnabled === null) return; // Still loading
-
-    if (extensionEnabled === false) {
-      setShowExtensionBanner(true);
-    } else if (showExtensionBanner) {
-      // Flash before hiding
-      setExtensionBannerFlashing(true);
-      const timer = setTimeout(() => {
-        setShowExtensionBanner(false);
-        setExtensionBannerFlashing(false);
-      }, 600);
-      return () => clearTimeout(timer);
-    }
-  }, [extensionEnabled]);
 
   // Handle upgrade banner visibility with flash animation
   useEffect(() => {
@@ -339,33 +317,6 @@ export default function DashboardHome() {
     }
   };
 
-  const checkExtensionStatus = async () => {
-    try {
-      const response = await fetch("/api/subscription/checkBusyBuddyEnabled");
-      if (response.ok) {
-        const data = await response.json();
-        if (data.status === "SUCCESS") {
-          setExtensionEnabled(data.data.enabled !== false);
-        } else {
-          setExtensionEnabled(true); // Default to enabled if check fails
-        }
-      } else {
-        setExtensionEnabled(true);
-      }
-    } catch (err) {
-      setExtensionEnabled(true); // Default to enabled if check fails
-    }
-  };
-
-  const getThemeExtensionUrl = () => {
-    const params = new URLSearchParams(location.search);
-    const shop = params.get("shop");
-    if (shop) {
-      return `https://${shop}/admin/themes/current/editor`;
-    }
-    return "#";
-  };
-
   // Real plan-access + enabled/paused state, sourced from
   // /api/subscription/getUserSubscription (subscriptionConfig.allowedApps +
   // enabledApps) rather than a hardcoded, possibly-stale plan/feature map.
@@ -431,33 +382,19 @@ export default function DashboardHome() {
   return (
     <div className="dashboard-home">
       <div className="dashboard-inner">
-        {/* Notification Banners - shown first so the setup/upgrade prompts
-            are the first thing a merchant sees on the page. */}
-        {(showExtensionBanner || showUpgradeBanner) && (
+        {/* Notification Banner - shown first so the upgrade prompt is the
+            first thing a merchant sees on the page. The per-app "enable in
+            theme editor" prompt lives on each app's own homepage instead,
+            since only that app knows which specific block/embed to link to. */}
+        {showUpgradeBanner && (
           <div className="notification-card">
-            {showExtensionBanner && (
-              <a
-                href={getThemeExtensionUrl()}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`notification-banner enable-extension ${extensionBannerFlashing ? "flashing" : ""}`}
-              >
-                <ExternalLink size={16} className="notification-icon" />
-                <span>
-                  Enable BusyBuddy: open the theme editor, then{" "}
-                  <strong>Add block &gt; Apps &gt; BusyBuddy Announcement</strong>
-                </span>
-              </a>
-            )}
-            {showUpgradeBanner && (
-              <div
-                className={`notification-banner upgrade-plan ${upgradeBannerFlashing ? "flashing" : ""}`}
-                onClick={() => navigate("/plan" + location.search)}
-              >
-                <Zap size={16} className="notification-icon" />
-                <span>Upgrade your plan for more features!</span>
-              </div>
-            )}
+            <div
+              className={`notification-banner upgrade-plan ${upgradeBannerFlashing ? "flashing" : ""}`}
+              onClick={() => navigate("/plan" + location.search)}
+            >
+              <Zap size={16} className="notification-icon" />
+              <span>Upgrade your plan for more features!</span>
+            </div>
           </div>
         )}
 

--- a/web/frontend/tests/apps/BundleForm.test.jsx
+++ b/web/frontend/tests/apps/BundleForm.test.jsx
@@ -24,6 +24,10 @@ vi.mock('../../components/ToggelSwitch', () => ({
   default: ({ appId }) => <div data-testid="toggle-switch" data-app-id={appId} />,
 }));
 
+vi.mock('../../components/ThemeExtensionBanner', () => ({
+  default: () => null,
+}));
+
 const renderWithRouter = (component) => {
   return render(
     <BrowserRouter>

--- a/web/frontend/tests/apps/MixMatchForm.test.jsx
+++ b/web/frontend/tests/apps/MixMatchForm.test.jsx
@@ -24,6 +24,10 @@ vi.mock('../../components/ToggelSwitch', () => ({
   default: ({ appId }) => <div data-testid="toggle-switch" data-app-id={appId} />,
 }));
 
+vi.mock('../../components/ThemeExtensionBanner', () => ({
+  default: () => null,
+}));
+
 const renderWithRouter = (component) => {
   return render(
     <BrowserRouter>

--- a/web/frontend/tests/apps/VolumeForm.test.jsx
+++ b/web/frontend/tests/apps/VolumeForm.test.jsx
@@ -24,6 +24,10 @@ vi.mock('../../components/ToggelSwitch', () => ({
   default: ({ appId }) => <div data-testid="toggle-switch" data-app-id={appId} />,
 }));
 
+vi.mock('../../components/ThemeExtensionBanner', () => ({
+  default: () => null,
+}));
+
 const renderWithRouter = (component) => {
   return render(
     <BrowserRouter>

--- a/web/frontend/tests/apps/buyoneGetone.test.jsx
+++ b/web/frontend/tests/apps/buyoneGetone.test.jsx
@@ -24,6 +24,10 @@ vi.mock('../../components/ToggelSwitch', () => ({
   default: ({ appId }) => <div data-testid="toggle-switch" data-app-id={appId} />,
 }));
 
+vi.mock('../../components/ThemeExtensionBanner', () => ({
+  default: () => null,
+}));
+
 const renderWithRouter = (component) => {
   return render(
     <BrowserRouter>

--- a/web/frontend/tests/components/ThemeExtensionBanner.test.jsx
+++ b/web/frontend/tests/components/ThemeExtensionBanner.test.jsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import ThemeExtensionBanner from '../../components/ThemeExtensionBanner';
+
+function mockFetch({ extensionEnabled, url = 'https://test-shop.myshopify.com/admin/themes/current/editor' } = {}) {
+  global.fetch = vi.fn((requestUrl) => {
+    if (requestUrl.includes('/api/subscription/extension-status')) {
+      return Promise.resolve({ json: () => Promise.resolve({ status: 'SUCCESS', data: { extensionEnabled } }) });
+    }
+    if (requestUrl.includes('/api/subscription/getThemeEditorUrl')) {
+      return Promise.resolve({ json: () => Promise.resolve({ status: 'SUCCESS', data: { url } }) });
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${requestUrl}`));
+  });
+}
+
+describe('ThemeExtensionBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing while the extension-status check is still loading', () => {
+    global.fetch = vi.fn(() => new Promise(() => {})); // never resolves
+    render(<ThemeExtensionBanner appId="bundle_discount" />);
+
+    expect(screen.queryByText(/Enable Bundle Discount/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing once the extension is confirmed enabled', async () => {
+    mockFetch({ extensionEnabled: true });
+    render(<ThemeExtensionBanner appId="bundle_discount" />);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByText(/Enable Bundle Discount/)).not.toBeInTheDocument();
+  });
+
+  it('renders a banner naming the specific app, mentioning Save, and linking to the deep link', async () => {
+    mockFetch({
+      extensionEnabled: false,
+      url: 'https://test-shop.myshopify.com/admin/themes/current/editor?template=product&addAppBlockId=uid/bundles_and_discounts&target=newAppsSection',
+    });
+    render(<ThemeExtensionBanner appId="bundle_discount" />);
+
+    const link = await screen.findByRole('link');
+    expect(link.textContent).toContain('Enable Bundle Discount');
+    expect(link.textContent).toContain('Save');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://test-shop.myshopify.com/admin/themes/current/editor?template=product&addAppBlockId=uid/bundles_and_discounts&target=newAppsSection'
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('gives each app a distinct background color', async () => {
+    mockFetch({ extensionEnabled: false });
+    const seen = new Set();
+
+    for (const appId of [
+      'announcement_bar',
+      'bundle_discount',
+      'buy_one_get_one',
+      'volume_discounts',
+      'mix_match',
+      'inactive_tab',
+    ]) {
+      const { unmount } = render(<ThemeExtensionBanner appId={appId} />);
+      const link = await screen.findByRole('link');
+      const bg = link.style.background;
+      expect(seen.has(bg)).toBe(false);
+      seen.add(bg);
+      unmount();
+    }
+  });
+
+  it('re-checks extension status when the window regains focus', async () => {
+    mockFetch({ extensionEnabled: false });
+    render(<ThemeExtensionBanner appId="announcement_bar" />);
+
+    await waitFor(() => {
+      const calls = global.fetch.mock.calls.filter(([url]) => url.includes('extension-status'));
+      expect(calls.length).toBe(1);
+    });
+
+    window.dispatchEvent(new Event('focus'));
+
+    await waitFor(() => {
+      const calls = global.fetch.mock.calls.filter(([url]) => url.includes('extension-status'));
+      expect(calls.length).toBe(2);
+    });
+  });
+});

--- a/web/frontend/tests/components/ToggelSwitch.test.jsx
+++ b/web/frontend/tests/components/ToggelSwitch.test.jsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import ToggleSwitch from '../../components/ToggelSwitch';
+
+// Mirrors what /api/subscription/getUserSubscription actually returns -
+// plenty of room under the Advanced plan's 6-app limit so plan limits never
+// interfere with the extension-gating assertions below.
+const SUBSCRIPTION_RESPONSE = {
+  status: 'SUCCESS',
+  data: { planName: 'Advanced', enabledAppsCount: 0, enabledApps: [] },
+};
+
+function mockFetch({ isEnabled = false, extensionEnabled = true, toggleOk = true } = {}) {
+  global.fetch = vi.fn((url, options) => {
+    if (url.includes('/api/subscription/app-status')) {
+      return Promise.resolve({ json: () => Promise.resolve({ status: 'SUCCESS', data: { isEnabled } }) });
+    }
+    if (url.includes('/api/subscription/getUserSubscription')) {
+      return Promise.resolve({ json: () => Promise.resolve(SUBSCRIPTION_RESPONSE) });
+    }
+    if (url.includes('/api/subscription/extension-status')) {
+      return Promise.resolve({
+        json: () => Promise.resolve({ status: 'SUCCESS', data: { extensionEnabled } }),
+      });
+    }
+    if (url.includes('/api/subscription/toggle-app')) {
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve(
+            toggleOk
+              ? { status: 'SUCCESS', data: { enabledAppsCount: 1 } }
+              : { status: 'ERROR', error: "This app's extension isn't enabled in your theme editor yet." }
+          ),
+      });
+    }
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+}
+
+describe('ToggleSwitch - theme-extension gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks enabling and explains why when the extension is not enabled in the theme editor', async () => {
+    mockFetch({ isEnabled: false, extensionEnabled: false });
+    render(<ToggleSwitch appId="bundle_discount" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Inactive').closest('[title]')).toHaveAttribute(
+        'title',
+        "This app won't be enabled until its extension is turned on in your theme editor."
+      )
+    );
+
+    fireEvent.click(screen.getByText('Inactive'));
+
+    // Clicking while blocked must not even attempt the toggle request.
+    await waitFor(() => {
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        expect.stringContaining('/api/subscription/toggle-app'),
+        expect.anything()
+      );
+    });
+  });
+
+  it('allows enabling once the extension-status check confirms it is enabled', async () => {
+    mockFetch({ isEnabled: false, extensionEnabled: true });
+    render(<ToggleSwitch appId="bundle_discount" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Inactive').closest('[title]')).toHaveAttribute('title', 'Click to enable')
+    );
+
+    fireEvent.click(screen.getByText('Inactive'));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/subscription/toggle-app',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
+  it('still allows disabling an already-active app even if the extension check comes back false', async () => {
+    mockFetch({ isEnabled: true, extensionEnabled: false });
+    render(<ToggleSwitch appId="bundle_discount" />);
+
+    await waitFor(() => expect(screen.getByText('Active')).toBeInTheDocument());
+
+    const toggleTitle = screen.getByText('Active').closest('[title]').getAttribute('title');
+    expect(toggleTitle).toBe('Click to disable');
+
+    fireEvent.click(screen.getByText('Active'));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/subscription/toggle-app',
+        expect.objectContaining({ body: JSON.stringify({ appId: 'bundle_discount', enable: false }) })
+      );
+    });
+  });
+
+  it('re-checks extension status when the window regains focus', async () => {
+    mockFetch({ isEnabled: false, extensionEnabled: false });
+    render(<ToggleSwitch appId="announcement_bar" />);
+
+    await waitFor(() => {
+      const calls = global.fetch.mock.calls.filter(([url]) => url.includes('extension-status'));
+      expect(calls.length).toBe(1);
+    });
+
+    window.dispatchEvent(new Event('focus'));
+
+    await waitFor(() => {
+      const calls = global.fetch.mock.calls.filter(([url]) => url.includes('extension-status'));
+      expect(calls.length).toBe(2);
+    });
+  });
+});

--- a/web/index.js
+++ b/web/index.js
@@ -122,13 +122,23 @@ app.use(
     async (_req, res, next) => {
       // @ts-ignore
       var shop = _req.query.shop.toString();
-      const isValid = verifyShopSignature(shop, _req.query.signature);
+      // Two distinct signers both land in this branch (anything with a
+      // `shop` query param): real Shopify App Proxy requests (getActiveBundle/
+      // getInactiveTab/getAnnouncementBar, hit by storefront visitors, not
+      // signed-in merchants) sign ALL query params, which verifySHA256
+      // checks; the standalone editor's own links sign only `{shop}` via
+      // generateSignature, which verifyShopSignature checks - verifySHA256
+      // naturally fails those (extra unsigned business params like search/
+      // cursor break its all-params digest), so this falls through to
+      // verifyShopSignature for them. Was previously verifyShopSignature-only,
+      // which meant no real App Proxy request could ever pass this check.
+      const isValid = verifySHA256(_req) || verifyShopSignature(shop, _req.query.signature);
       if (!isValid) {
         // JSON, not plain text: the editor's fetch callers all do
         // `await response.json()` unconditionally, and a plain-text 401 body
         // used to blow up as "Unexpected token 'U', 'Unauthorized' is not
         // valid JSON" instead of surfacing what actually went wrong.
-        return res.status(401).json({ message: "Invalid editor signature - the shop/signature pair on this page is stale or was tampered with." });
+        return res.status(401).json({ message: "Invalid request signature - the shop/signature pair on this request is stale, missing a param, or was tampered with." });
       }
       const sessionId = await shopify.api.session.getOfflineId(shop);
       const session = await shopify.config.sessionStorage.loadSession(sessionId);


### PR DESCRIPTION
## Problem

Closes #

Apps can now be toggled on/off in the admin dashboard, but merchants may not have actually enabled the corresponding theme blocks/embeds yet. Without gating, toggling an app "on" when its theme extension isn't enabled creates a confusing experience where the app appears active in the dashboard but doesn't render on the storefront.

## Solution

Implemented theme-extension status checking and gating across the app:

1. **Backend theme-extension detection** (`subscription/index.js`):
   - Added `checkExtensionStatus()` to scan the merchant's live theme for enabled app blocks/embeds
   - Supports both body-target embeds (single global toggle in `config/settings_data.json`) and section-target blocks (scanned across relevant templates)
   - Caches results per shop/app for 30 seconds to avoid excessive Admin Assets API calls
   - Added `getExtensionStatus` endpoint to expose status to the frontend
   - Refactored `getThemeEditorUrl` to generate deep links generically based on `themeBlockConfig`

2. **Frontend toggle gating** (`ToggelSwitch.jsx`):
   - Checks extension status on mount and when window regains focus (since Shopify has no webhook for theme block toggles)
   - Blocks enabling apps whose extensions aren't enabled in the theme editor
   - Allows disabling already-active apps even if the extension check fails (graceful degradation)
   - Shows contextual tooltip explaining why the toggle is disabled

3. **Per-app theme-editor banners** (`ThemeExtensionBanner.jsx`):
   - New component shown on each app's homepage when its extension isn't enabled
   - Deep-links directly to the theme editor with the correct block/embed pre-selected
   - Uses app-specific branding colors to match dashboard widgets
   - Re-checks status on window focus to detect when merchants return from the theme editor

4. **Configuration** (`subscriptionConfig.js`):
   - Added `themeBlockConfig` mapping each appId to its physical theme block/embed
   - Defines scan locations, editor templates, and deep-link parameters per app
   - Shared bundle block (`bundles_and_discounts`) for the 4 discount-type apps

5. **Dashboard cleanup** (`DashboardHome.jsx`):
   - Removed global extension-status check and banner (now per-app on individual homepages)
   - Simplified state management by removing extension-related logic

6. **E2E test updates**:
   - Added storefront-render tests for each app to verify widgets actually appear
   - Updated product selections to avoid conflicts between test suites

## Acceptance Criteria

- [x] Apps cannot be toggled "on" unless their theme block/embed is enabled
- [x] Merchants see a contextual message explaining why a toggle is blocked
- [x] Each app's homepage shows a banner with a deep link to enable its extension
- [x] Extension status is checked on page load and when the window regains focus
- [x] Theme-editor deep links are generated correctly per app type
- [x] Results are cached to avoid excessive API calls
- [x] Graceful degradation if the extension-status check fails

## Approach

**Key decisions:**
- Caching with 30-second TTL balances freshness against API quota (no webhook available for theme block toggles)
- Per-app banners on individual homepages instead of a global dashboard banner, since each app needs its own deep link
- Recursive tree search for blocks handles arbitrary nesting in theme JSON structures
- Shared bundle block for 4 discount apps since the backend already resolves one winning bundle across all types

**Trade-offs:**
- Extension status is "eventually correct" until the user refetches (no Shopify webhook exists)
- Disabling an app whose extension check fails is allowed to prevent merchants from getting stuck

## Test Results

| Suite | Status | Count |
|-------|--------|-------|
| Backend (`cd web && npm test`) | ✅ | 218 lines of new tests in `subscription.extensionGating.test.js` |
| Frontend (`cd web/frontend && npm test`) | ✅ | 211 lines of new

https://claude.ai/code/session_01WEpy97mZfJXCdaLqaek7kf