### PR TITLE
Fix CI extension deploy: write shopify.app.toml from a secret first

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,17 +42,31 @@ jobs:
         # what actually failed the one time this was run manually: it
         # deployed to an unrelated test app instead of production.
         #
+        # `shopify app deploy` requires an actual shopify.app.toml file to
+        # exist on disk - --client-id only overrides the client_id *inside*
+        # whatever toml it finds, it's not a substitute for having one at
+        # all. shopify.app.toml is gitignored (per-developer local state),
+        # so a fresh checkout here has none - write one from a secret
+        # first, so CI deploys the exact same config a human would deploy
+        # from, rather than guessing at one.
+        #
         # Required repo secrets (Settings > Secrets and variables > Actions):
         #   SHOPIFY_CLI_PARTNERS_TOKEN - a Partners API token so this runs
         #     non-interactively (see Shopify's CLI CI docs for how to mint one)
         #   SHOPIFY_PROD_APP_CLIENT_ID - the real production app's Client ID
         #     (Partner Dashboard > the correct "BusyBuddy" app > Client
         #     credentials) - NOT any "tester"/dev app's id.
+        #   SHOPIFY_APP_TOML - the full contents of a working
+        #     shopify.app.toml for that same production app (generate one
+        #     locally via `shopify app config link --client-id=<id>`, then
+        #     paste the resulting file's contents in as this secret).
         env:
           SHOPIFY_CLI_PARTNERS_TOKEN: ${{ secrets.SHOPIFY_CLI_PARTNERS_TOKEN }}
+          SHOPIFY_APP_TOML: ${{ secrets.SHOPIFY_APP_TOML }}
         run: |
           set -euo pipefail
           cd /home/bitnami/BusyBuddy_v2
+          printf '%s\n' "$SHOPIFY_APP_TOML" > shopify.app.toml
           npm install
           npm run deploy -- --force --no-color --client-id="${{ secrets.SHOPIFY_PROD_APP_CLIENT_ID }}"
 


### PR DESCRIPTION
## Problem

Follow-up to #313, merged before this fix landed. The new "Deploy theme app extension" CI step failed on its first real run:

```
Couldn't find an app toml file at /home/bitnami/BusyBuddy_v2, is this an app directory?
```

(see https://github.com/11thandOrange/BusyBuddy_v2/actions/runs/31130138695/job/92716937549)

## Solution

`shopify app deploy`'s `--client-id` flag only overrides the `client_id` value *inside* an existing `shopify.app.toml` - it's not a substitute for having one at all. `shopify.app.toml` is gitignored (per-developer local state), so a fresh CI checkout has none, and the deploy step failed before ever reaching Shopify.

Now writes the toml from a new `SHOPIFY_APP_TOML` secret before running deploy, so CI deploys the exact same config a human would deploy locally rather than guessing one.

## Required secrets (in addition to the two already needed from #313)

- `SHOPIFY_APP_TOML` - full contents of a working `shopify.app.toml` for the real production app. Generate locally via `shopify app config link --client-id=<the-real-client-id>`, then paste the resulting file's contents in as this secret's value.

## Test Results

YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`). No application code changed - this is a CI-workflow-only fix, so the existing test suites (backend/frontend/extension) are unaffected and were already green on the parent commit from #313.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEpy97mZfJXCdaLqaek7kf)_