### PR TITLE
Fix case-sensitive subscription status checks blanking active shops

### DIFF
--- a/web/backend/configs/subscriptionUtils.js
+++ b/web/backend/configs/subscriptionUtils.js
@@ -20,8 +20,12 @@ export async function checkSubscriptionAccess(shopDomain, featureName) {
     let hasActiveSubscription = false;
 
     if (subscriptionData && subscriptionData.activeSubscriptions.length > 0) {
+      // Shopify's GraphQL API returns status as an uppercase enum ("ACTIVE"),
+      // but subscriptions synced locally via subscribeToPlan use lowercase
+      // "active" - compare case-insensitively so a real paid shop's status
+      // (however it last got synced) is never mistaken for "no subscription".
       const activeSub = subscriptionData.activeSubscriptions.find(
-        (sub) => sub.status === "active"
+        (sub) => sub.status?.toLowerCase() === "active"
       );
 
       if (activeSub) {

--- a/web/backend/controller/subscription/index.js
+++ b/web/backend/controller/subscription/index.js
@@ -82,7 +82,9 @@ async function getUsersubscription(_req, res) {
     let enabledApps = [];
 
     if (subscriptionData && subscriptionData.activeSubscriptions.length > 0) {
-      const activeSub = subscriptionData.activeSubscriptions.find((sub) => sub.status === "active");
+      // Shopify's API returns status as an uppercase enum ("ACTIVE") - compare
+      // case-insensitively so a real paid shop's synced record still matches.
+      const activeSub = subscriptionData.activeSubscriptions.find((sub) => sub.status?.toLowerCase() === "active");
 
       if (activeSub) {
         planName = activeSub.name;
@@ -121,7 +123,7 @@ async function subscribeToPlan(_req, res) {
       myshopify_domain: session.shop,
     });
 
-    const currentActiveSub = currentSubscription?.activeSubscriptions.find((sub) => sub.status === "active");
+    const currentActiveSub = currentSubscription?.activeSubscriptions.find((sub) => sub.status?.toLowerCase() === "active");
     const currentPlan = currentActiveSub?.name || "Free";
 
     // Get configuration for the new plan
@@ -141,7 +143,7 @@ async function subscribeToPlan(_req, res) {
 
       // Update database to Free plan - mark current as cancelled and add Free
       const updatedSubscriptions = currentSubscription.activeSubscriptions.map((sub) => {
-        if (sub.status === "active") {
+        if (sub.status?.toLowerCase() === "active") {
           return { ...sub, status: "cancelled", cancelledAt: new Date() };
         }
         return sub;
@@ -251,7 +253,7 @@ async function subscribeToPlan(_req, res) {
         // Already subscribed to this exact plan, just sync our database
         const updatedSubscriptions =
           currentSubscription?.activeSubscriptions.map((sub) => {
-            if (sub.status === "active") {
+            if (sub.status?.toLowerCase() === "active") {
               return { ...sub, status: "cancelled", cancelledAt: new Date() };
             }
             return sub;
@@ -325,7 +327,7 @@ async function cancelSubscribe(_req, res) {
     });
     if (currentSubscription) {
       const updatedSubscriptions = currentSubscription.activeSubscriptions.map((sub) => {
-        if (sub.name === planName && sub.status === "active") {
+        if (sub.name === planName && sub.status?.toLowerCase() === "active") {
           return { ...sub, status: "cancelled", cancelledAt: new Date() };
         }
         return sub;
@@ -461,7 +463,7 @@ async function toggleApp(req, res) {
       subscriptionData = await subscriptionModel.create(subscriptionData);
     }
 
-    const activeSub = subscriptionData.activeSubscriptions?.find((sub) => sub.status === "active");
+    const activeSub = subscriptionData.activeSubscriptions?.find((sub) => sub.status?.toLowerCase() === "active");
 
     // If no active subscription, assume free plan
     if (!activeSub) {

--- a/web/backend/models/subscription.model.js
+++ b/web/backend/models/subscription.model.js
@@ -73,10 +73,10 @@ const SubscriptionSchema = mongoose.Schema(
 );
 // Method to check if app can be enabled
 SubscriptionSchema.methods.canEnableApp = function (appId) {
-  const planConfig =
-    subscriptionConfig[
-      this.activeSubscriptions.find((s) => s.status === "active").name
-    ];
+  // Shopify's API returns status as an uppercase enum ("ACTIVE") - compare
+  // case-insensitively so a real paid shop's synced record still matches.
+  const activeSub = this.activeSubscriptions.find((s) => s.status?.toLowerCase() === "active");
+  const planConfig = subscriptionConfig[activeSub ? activeSub.name : "Free"];
 
   // Check if app is allowed in current plan
   if (!planConfig.allowedApps.includes(appId)) {

--- a/web/backend/services/merchantEventService.js
+++ b/web/backend/services/merchantEventService.js
@@ -116,7 +116,7 @@ class MerchantEventService {
       return null;
     }
 
-    const activeSub = subscription?.activeSubscriptions?.find((s) => s.status === "active");
+    const activeSub = subscription?.activeSubscriptions?.find((s) => s.status?.toLowerCase() === "active");
 
     return {
       shopId: shop.shopId,

--- a/web/backend/services/referral.js
+++ b/web/backend/services/referral.js
@@ -116,7 +116,7 @@ export async function getReferralAnalytics(code) {
         myshopify_domain: shop.myshopify_domain,
       });
       const activeSub = subscription?.activeSubscriptions?.find(
-        (sub) => sub.status === "active"
+        (sub) => sub.status?.toLowerCase() === "active"
       );
       return {
         shop_domain: shop.shopDomain,
@@ -254,7 +254,7 @@ export async function calculateMRR(code) {
 
     if (subscription) {
       const activeSub = subscription.activeSubscriptions?.find(
-        (sub) => sub.status === "active"
+        (sub) => sub.status?.toLowerCase() === "active"
       );
 
       if (activeSub && activeSub.name !== "Free") {

--- a/web/backend/services/subscription.js
+++ b/web/backend/services/subscription.js
@@ -6,10 +6,19 @@ import sbModel from "../models/subscription.model.js";
 const subscriptionUpdate = async (session) => {
   try {
     const allSubscription = await getAppSubscription(session)
+    // Shopify's GraphQL API returns status as an uppercase enum ("ACTIVE"),
+    // but every comparison against this field elsewhere in the codebase
+    // checks lowercase "active" - normalize on write so a resync (e.g. the
+    // billing-confirmation redirect) can't silently make a real paid shop's
+    // subscription stop matching those checks.
+    const normalizedSubscriptions = (allSubscription || []).map((sub) => ({
+      ...sub,
+      status: typeof sub.status === "string" ? sub.status.toLowerCase() : sub.status,
+    }));
     await sbModel.updateOne({ myshopify_domain: session.shop }, {
       $set: {
         myshopify_domain: session.shop,
-        activeSubscriptions: allSubscription
+        activeSubscriptions: normalizedSubscriptions
       }
     }, { upsert: true });
     console.log("subscription data updated for shop::::", session.shop);

--- a/web/backend/tests/controller/subscriptionUtils.appToggle.test.js
+++ b/web/backend/tests/controller/subscriptionUtils.appToggle.test.js
@@ -70,6 +70,26 @@ describe('checkSubscriptionAccess - app-level enable/disable gating', () => {
     expect(result.reason).toBe('Feature not available in Free plan');
   });
 
+  it('grants access when Shopify synced the subscription with its own uppercase status enum (ACTIVE, not active)', async () => {
+    // Regression: Shopify's GraphQL API returns AppSubscription.status as an
+    // uppercase enum ("ACTIVE") and subscriptionUpdate() (fired from the real
+    // billing-confirmation redirect) used to store that value verbatim. Every
+    // check here was hardcoded to lowercase "active", so a real paying
+    // shop's subscription silently stopped counting as active the moment it
+    // synced from Shopify's own data, blanking every gated endpoint
+    // (getActiveBundle included) regardless of plan or toggle state.
+    subscriptionModel.findOne.mockResolvedValue({
+      activeSubscriptions: [{ name: 'Advanced', status: 'ACTIVE' }],
+      enabledAppsCount: 1,
+      enabledApps: [{ appId: 'bundle_discount', appName: 'Bundle Discount', enabled: true }],
+    });
+
+    const result = await checkSubscriptionAccess('test-shop.myshopify.com', 'Bundle Discount');
+
+    expect(result.shouldReturnBlank).toBe(false);
+    expect(result.hasAccess).toBe(true);
+  });
+
   it('returns shouldReturnBlank: true when no subscription document exists at all', async () => {
     subscriptionModel.findOne.mockResolvedValue(null);
 

--- a/web/backend/tests/services/subscriptionUpdate.statusNormalization.test.js
+++ b/web/backend/tests/services/subscriptionUpdate.statusNormalization.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../billing.js', () => ({
+  getAppSubscription: vi.fn(),
+}));
+
+vi.mock('../../models/subscription.model.js', () => ({
+  default: { updateOne: vi.fn() },
+}));
+
+import { getAppSubscription } from '../../../billing.js';
+import sbModel from '../../models/subscription.model.js';
+import { subscriptionUpdate } from '../../services/subscription.js';
+
+// Regression: Shopify's GraphQL API returns AppSubscription.status as an
+// uppercase enum ("ACTIVE"), but every read site that later checks
+// activeSubscriptions[].status compares against lowercase "active".
+// subscriptionUpdate used to persist Shopify's raw casing verbatim, which
+// silently broke checkSubscriptionAccess (and everything else gated on
+// "is this shop's subscription active") the moment a real paid shop's
+// subscription synced from Shopify's own billing-confirmation redirect.
+describe('subscriptionUpdate - status casing normalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lowercases Shopify\'s uppercase status enum before storing', async () => {
+    getAppSubscription.mockResolvedValue([
+      { name: 'Advanced', status: 'ACTIVE', id: 'gid://shopify/AppSubscription/1' },
+    ]);
+
+    await subscriptionUpdate({ shop: 'test-shop.myshopify.com' });
+
+    expect(sbModel.updateOne).toHaveBeenCalledWith(
+      { myshopify_domain: 'test-shop.myshopify.com' },
+      {
+        $set: {
+          myshopify_domain: 'test-shop.myshopify.com',
+          activeSubscriptions: [
+            { name: 'Advanced', status: 'active', id: 'gid://shopify/AppSubscription/1' },
+          ],
+        },
+      },
+      { upsert: true }
+    );
+  });
+
+  it('does not throw and stores an empty array when Shopify returns no subscriptions', async () => {
+    getAppSubscription.mockResolvedValue([]);
+
+    await subscriptionUpdate({ shop: 'test-shop.myshopify.com' });
+
+    expect(sbModel.updateOne).toHaveBeenCalledWith(
+      { myshopify_domain: 'test-shop.myshopify.com' },
+      { $set: { myshopify_domain: 'test-shop.myshopify.com', activeSubscriptions: [] } },
+      { upsert: true }
+    );
+  });
+});

--- a/web/privacy.js
+++ b/web/privacy.js
@@ -221,14 +221,14 @@ export default {
         if (!currentSubscription) return;
 
         const activeSub = currentSubscription.activeSubscriptions.find(
-          (sub) => sub.status === "active" && sub.name === planName
+          (sub) => sub.status?.toLowerCase() === "active" && sub.name === planName
         );
         // Already reconciled (e.g. the merchant cancelled through our own
         // flow first) - nothing to do.
         if (!activeSub) return;
 
         const updatedSubscriptions = currentSubscription.activeSubscriptions.map((sub) => {
-          if (sub.status === "active" && sub.name === planName) {
+          if (sub.status?.toLowerCase() === "active" && sub.name === planName) {
             return { ...sub, status: "cancelled", cancelledAt: new Date() };
           }
           return sub;


### PR DESCRIPTION
## Problem

Closes #

The Bundle Discount widget rendered blank on a real Advanced-plan shop even though the theme extension, script, and bundle data were all confirmed correct. `getActiveBundle` was returning `{status: true, bundles: []}` — the `status: true` key only appears in one branch of that controller, the one that fires *after* a matching bundle was already found, when `checkSubscriptionAccess` decides to blank the response anyway.

## Solution

Shopify's GraphQL API returns `AppSubscription.status` as an uppercase enum (`"ACTIVE"`), but every comparison against `activeSubscriptions[].status` in this codebase was hardcoded to lowercase `"active"`. `subscriptionUpdate()` — called from the real billing-confirmation redirect in `web/index.js` — persisted Shopify's raw casing verbatim. So the moment a real paid shop's subscription synced from Shopify's own data, `hasActiveSubscription` silently evaluated `false` everywhere, and `checkSubscriptionAccess` blanked every gated storefront endpoint (`getActiveBundle`, and by the same mechanism `getInactiveTab`/`getAnnouncementBar`) regardless of the shop's actual plan or app-toggle state.

## Approach

- Made every `sub.status === "active"` comparison case-insensitive (`sub.status?.toLowerCase() === "active"`) across `subscriptionUtils.js`, `subscription/index.js` (5 sites), `subscription.model.js`, `referral.js` (2 sites), `merchantEventService.js`, and `privacy.js` (2 sites).
- Also normalized casing on write in `subscriptionUpdate()` as a safety net, so a resync (e.g. a future billing-confirmation redirect) self-heals any already-affected record instead of needing a manual DB fix.
- Added a null-safety guard in `subscription.model.js`'s `canEnableApp` (previously called `.name` on a `.find()` result with no undefined check).

## Acceptance Criteria

- [x] A shop with a Shopify-synced `status: "ACTIVE"` subscription is treated as having an active subscription by `checkSubscriptionAccess`
- [x] All existing subscription-gating behavior (free plan limits, disabled apps, missing subscription doc) is unchanged
- [x] `subscriptionUpdate` stores normalized lowercase status on future syncs

## Test Results

| Suite | Status | Count |
|-------|--------|-------|
| Backend (`cd web && npm test`) | ✅ | 198/198 |
| Frontend (`cd web/frontend && npm test`) | N/A (backend-only change) | — |
| Extension (`cd extensions/cart-transformer && npm test`) | N/A | — |
| Build (`CI=true npm run build`) | N/A | — |

## Checklist

- [x] Tests pass locally before every commit
- [x] No `console.log` in production paths
- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] New routes registered in `web/backend/routes/index.js` (n/a - no new routes)
- [x] Polaris components used for all admin UI (n/a - backend only)
- [x] ES modules only — no `require()`
- [x] `shopify app deploy` was NOT run


---
_Generated by [Claude Code](https://claude.ai/code/session_01WEpy97mZfJXCdaLqaek7kf)_