### PR TITLE
docs: correct dev-pipeline orchestrator owner references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,10 @@ Since this is a Shopify app that requires the Shopify development environment:
 ## OpenHands Cloud Automation (LEGACY — retired)
 
 > ⚠️ This entire section is retired. BusyBuddy_v2 now uses a GitHub Actions +
-> Claude Code pipeline orchestrated from `HeyItsChloe/agent-ops` — see
-> `.github/workflows/dev-pipeline.yml`. Trigger it by labeling an issue
+> Claude Code pipeline that calls the reusable workflow in
+> `HeyItsChloe/pipeline-orchestrator` (dev skills sourced from
+> `11thandOrange/agent-ops`) — see `.github/workflows/dev-pipeline.yml`.
+> Trigger it by labeling an issue
 > `approach-ready` (plan) or `approved` (implement), or commenting
 > `@dev-agent plan` / `@dev-agent implement`. Everything below describes the
 > old, retired pipeline and is kept for historical reference only.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ cd web/frontend && CI=true npm run build
 ## AI Agent Automation
 
 > ⚠️ **The OpenHands-based pipeline described below is retired.** BusyBuddy_v2
-> now uses a GitHub Actions + Claude Code pipeline orchestrated from
-> `HeyItsChloe/agent-ops` — see `.github/workflows/dev-pipeline.yml`. Label
+> now uses a GitHub Actions + Claude Code pipeline that calls the reusable
+> workflow in `HeyItsChloe/pipeline-orchestrator` (with dev skills sourced
+> from `11thandOrange/agent-ops`) — see `.github/workflows/dev-pipeline.yml`. Label
 > an issue `approach-ready` (plan) or `approved` (implement), or comment
 > `@dev-agent plan` / `@dev-agent implement`, to trigger it. The section
 > below is kept for historical reference only.


### PR DESCRIPTION
## Problem

Closes #323

`README.md` and `AGENTS.md` describe the dev pipeline as "orchestrated from `HeyItsChloe/agent-ops`", but `.github/workflows/dev-pipeline.yml:20` actually calls `HeyItsChloe/pipeline-orchestrator/.github/workflows/dev-pipeline-reusable.yml@main` — `agent-ops` is only the `skills_repo`. Surfaced by the Epic 1 pipeline audit (`11thandOrange/agent-ops#29`).

## Solution

Correct both docs to name **`HeyItsChloe/pipeline-orchestrator`** as the orchestrator, with dev skills sourced from `11thandOrange/agent-ops`.

## Acceptance Criteria

- [x] `README.md` and `AGENTS.md` name the correct orchestrator repo
- [x] No other BusyBuddy docs repeat the wrong owner (grep-checked)

## Approach

Docs-only: 2 files, +7/−4. No workflow, route, or code changes.

## Test Results

| Suite | Status | Count |
|-------|--------|-------|
| Backend (`cd web && npm test`) | N/A | docs-only |
| Frontend (`cd web/frontend && npm test`) | N/A | docs-only |
| Extension (`cd extensions/cart-transformer && npm test`) | N/A | docs-only |
| Build (`CI=true npm run build`) | N/A | docs-only |

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] ES modules only — no `require()`
- [x] `shopify app deploy` was NOT run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjPTqW1qxMFghxoyThd4Ac)_