### PR TITLE
docs: add FE/BE narrative + feature pages for the wiki generator

### DIFF
--- a/docs/backend-architecture.md
+++ b/docs/backend-architecture.md
@@ -1,0 +1,77 @@
+# Backend Architecture
+
+BusyBuddy's backend is an Express app that serves a Shopify embedded admin app plus the
+storefront-facing endpoints its theme extensions call. The entry point is `web/index.js`.
+
+## Express app structure
+
+`web/index.js` builds a single Express app and wires middleware in a deliberate order:
+
+1. **Error handling** — `unhandledRejection` is reported; `uncaughtException` is reported and
+   then exits the process.
+2. **Mongo connection** — `mongoose.connect(process.env.DB_CONNECTION)` (see below).
+3. **Request logging** — `morgan("tiny")`.
+4. **Webhook routes first** — Shopify's `shopify.processWebhooks(...)` and `/api/webhooks/*` are
+   registered *before* any global `express.json()`, because HMAC verification and
+   `processWebhooks` need the untouched raw request stream. A global body parser earlier would
+   drain the stream and break signature verification.
+5. **Global `express.json()`**, then the **public referral routes** at `/api/referrals` —
+   registered *before* Shopify auth so partners and visitors can reach them without a shop
+   session.
+6. **Shopify auth endpoints** (`auth.begin`, `auth.callback` → `shopData` → redirect) and the
+   **Google OAuth callback** at `/api/analytics/google/callback` (registered here, ahead of auth,
+   because Google redirects back without Shopify credentials; the controller is dynamically
+   imported so `googleapis` is not loaded at startup).
+7. **Authenticated `/api/*` gate** (see App-proxy auth below).
+8. **Main API router** mounted at `/api` (`web/backend/routes/index.js`).
+9. **Billing-confirmation catch** at `/` — on a signed `charge_id`+`shop` redirect it triggers a
+   subscription resync.
+10. **Static frontend** — serves `frontend/dist` (production) with the App Bridge HTML.
+
+## /api routing
+
+`web/backend/routes/index.js` mounts one router per feature under `/api`:
+
+| Mount | Router |
+| --- | --- |
+| `/api/products` | products |
+| `/api/bundles` | bundles (BOGO, volume, mix-and-match, bundle-discount all share this) |
+| `/api/frontStore` | public storefront endpoints (app-proxy) |
+| `/api/announcement-bars` | announcement bars |
+| `/api/subscription` | subscription / plan gating |
+| `/api/inactive-tab` | inactive tab message |
+| `/api/analytics` | analytics |
+| `/api/email-provider` | email provider integration |
+| `/api/analytics/google` | Google Analytics OAuth + data |
+| `/api/activity` | dashboard activity feed |
+| `/api/dashboard` | dashboard |
+| `/api/editor` | editor signature minting |
+
+Two route families are **not** mounted here and are instead registered directly in `web/index.js`:
+`/api/webhooks` (before body parsing / auth) and `/api/referrals` (before Shopify auth). See
+[Webhooks & Jobs](./webhooks-and-jobs.md).
+
+## App-proxy & session auth
+
+The `/api/*` gate in `web/index.js` uses `express-conditional-middleware`:
+
+- **Requests with a `shop` query param** take the app-proxy / editor branch. Two distinct signers
+  land here:
+  - **Shopify App Proxy** requests (storefront visitors hitting `getActiveBundle` /
+    `getInactiveTab` / `getAnnouncementBar`) sign *all* query params — verified by `verifySHA256`.
+  - The **standalone editor's** own links sign only `{shop}` via `generateSignature` — verified by
+    `verifyShopSignature` as a fallback when `verifySHA256` fails.
+  On a valid signature, the offline session for the shop is loaded from session storage and placed
+  on `res.locals.shopify`. Invalid signatures return `401` JSON.
+- **All other `/api/*` requests** fall through to `shopify.validateAuthenticatedSession()` — the
+  normal App Bridge embedded-app session check.
+
+The public storefront routes under `web/backend/routes/frontStore/` additionally run
+`requireSubscriptionAccess`, so a widget only responds while BusyBuddy is enabled for the shop.
+
+## MongoDB
+
+Persistence is MongoDB via Mongoose. The connection is opened once at startup from
+`process.env.DB_CONNECTION` with `strictQuery` enabled. Shopify offline sessions are stored via a
+custom session storage (`web/customeMongoSession.js`, referenced through `web/shopify.js`). The
+domain models live in `web/backend/models` — see [Data Models](./data-models.md).

--- a/docs/data-models.md
+++ b/docs/data-models.md
@@ -1,0 +1,78 @@
+# Data Models
+
+All persistence is MongoDB via Mongoose. The schemas live in `web/backend/models` (one file per
+model, `*.model.js`). Field lists below are the actual top-level schema fields.
+
+## shop (`shop.model.js`)
+The installed store record, created during the OAuth install callback (and lazily self-healed on
+read by `services/shopService.js`). Fields: `shopId`, `myshopify_domain`, `shopName`,
+`shopDomain`, `shopCountry`, `status`, `data`, `referral_code`, `referral_source`,
+`referral_campaign`, `installed_at`, `paid_at`.
+
+## Subscription (`subscription.model.js`)
+The plan / entitlement record keyed by `myshopify_domain`. Fields include `activeSubscriptions`,
+`currentPlan`, `billingHistory[]` (plan name, price, date, Shopify subscription id), `trialEndsAt`,
+`gracePeriodEndsAt`, `enabledApps[]`, `maxAppsAllowed`, `enabledAppsCount`, and an `appLimits`
+object with per-app booleans: `announcement_bar`, `inactive_tab`, `bundle_discount`,
+`buy_one_get_one`, `volume_discounts`, `mix_match`. This model is the source of truth for whether
+the app (and each widget) is active for a shop.
+
+## shopify_sessions (`shopify_sessions.model.js`)
+Shopify offline/online session storage. Fields: `id`, `shop`, `state`, `scope`, `accessToken`,
+`isOnline`.
+
+## bundle (`bundle.model.js`)
+The single model behind the whole discount-app family (bundle-discount, BOGO, volume, mix-and-match),
+distinguished by `type`. Core fields: `title`, `type`, `products[]`, `productsX[]`, `productsY[]`
+(BOGO buy/get sides), `quantityBreaks[]` and `tierDiscounts` (volume tiers), plus rich widget
+appearance settings (an embedded `widgetAppearanceSchema` with colours, timer, add-to-cart / skip
+button styling, emoji, margins).
+
+## announcementBar (`announcementBar.model.js`)
+The announcement-bar widget config, composed of several embedded sub-schemas: font settings, color
+settings, countdown-timer color / label / block settings, end-of-sale message, shop-now button, and
+save-box styling.
+
+## InactiveTab (`inactiveTab.model.js`)
+Inactive-tab message settings, unique per `myshopify_domain`. Fields: `message`, `startDate`,
+`endDate`, `imageUrl`, `faviconEmoji`, `timezone`, `isEnabled`.
+
+## EmailProvider (`emailProvider.model.js`)
+Per-shop ESP connection (`shopId`, `provider` enum `mailchimp|klaviyo|sendgrid|mailerlite|none`,
+API key, connection flags/dates) plus embedded `lists[]` and `templates[]` and a default list.
+
+## EmailLog (`emailLog.model.js`)
+A record of every outbound email: recipient, type, template, provider IDs (campaign/member/list/
+template), `status` enum (`pending|sent|delivered|failed|bounced|opened|clicked`), timestamps, and
+retry/error fields.
+
+## GoogleAnalytics (`googleAnalytics.model.js`)
+Per-shop Google (GA4) OAuth connection, unique per `shopDomain`. Fields: `googleEmail`,
+`accessToken`, `refreshToken`, `tokenExpiresAt`, `propertyId`, `propertyName`, `connectedAt`,
+`updatedAt`.
+
+## referral (`referral.model.js`)
+A referral partner. Fields: `code` (unique, public), `partner_token` (unique, sparse,
+`select: false` secret), `partner_name`, `payout_percent`, `source`, `campaign`, `is_active`,
+`metadata`, `created_at`, `updated_at`.
+
+## referralevent (`referralEvent.model.js`)
+An individual referral event. Fields: `referral_code`, `event_type` enum (`click|install|paid`),
+`shop_domain`, `myshopify_domain`, `plan_name`, `source`, `campaign`, `metadata`, `occurred_at`.
+
+## ActivityLog (`activityLog.model.js`)
+Dashboard activity-feed events. Fields: `shopId`, `type` enum
+(`purchase|view|click|redemption|created|updated|deleted|activated|deactivated`), `widget` enum
+(`bundle|bogo|volume|mix-match|announcement|upsell|inactive-tab`), `title`, `meta`, `amount`,
+`offerId`, `orderId`, `discountCode`, `createdAt`.
+
+## MerchantEvent (`merchantEvent.model.js`)
+Lifecycle events for a merchant (install, uninstall, plan change, etc.). Fields: `shopId`,
+`myshopify_domain`, `eventType` (enum), `eventData`, `previousState`, `newState`, `emailTriggered`,
+`emailId` (ref → EmailLog), `processed`, `processedAt`, `createdAt`.
+
+## MerchantReview (`merchantReview.model.js`)
+Tracks merchant app-store review state, unique per `myshopify_domain`. Fields include
+`merchantEmail`, `merchantName`, `hasLeftReview`, `rating`, `reviewText`, `reviewDate`, `source`
+enum (`shopify_app_store|in_app|external`), `reviewUrl`, `isVerified`, response fields,
+`emailSentOnReview`, `emailLogId` (ref → EmailLog), timestamps.

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -1,0 +1,57 @@
+# Frontend Architecture
+
+The merchant-facing admin UI is a Vite + React app under `web/frontend`, embedded inside Shopify
+admin. It is a Shopify app-template-node frontend using Polaris and App Bridge.
+
+## Entry & providers
+
+`index.jsx` mounts `App.jsx`, which wraps the tree in:
+
+- `PolarisProvider` (`components/providers/PolarisProvider.jsx`) — Shopify Polaris `AppProvider`
+  with a custom App Bridge-aware `Link` component for in-app navigation.
+- `BrowserRouter` (react-router-dom).
+- `QueryProvider` (`components/providers/QueryProvider.jsx`) — `react-query` client.
+- `NavMenu` from `@shopify/app-bridge-react` for the embedded-app nav.
+
+## Routing
+
+`Routes.jsx` uses **file-based routing**: `App.jsx` calls `import.meta.glob("./pages/**/...")` and
+`useRoutes` maps each file in `pages/` to a route (`/pages/index.jsx` → `/`, `[handle]` → `:handle`).
+On top of the file routes, `Routes.jsx` explicitly registers the **standalone editor routes** for
+each discount/widget app, e.g. `/announcement-bar/editor(/:id)`, `/bundle-discount/editor(/:id)`,
+`/buy-one-get-one/editor(/:id)`, `/volume-discounts/editor(/:id)`, `/mix-and-match/editor(/:id)`.
+
+## Pages, apps, and components
+
+- `pages/` — top-level dashboard pages: `DashboardHome.jsx` (the widget grid), `Plan.jsx`, and one
+  page per feature (`announcement-bar.jsx`, `bundles.jsx`, `bundle-discount.jsx`,
+  `buy-one-get-one.jsx`, `volume-discounts.jsx`, `mix-and-match.jsx`, `inactive-tab-message.jsx`).
+- `apps/` — the self-contained editor app per feature (`buy-one-get-one`, `volume-discounts`,
+  `mix-and-match-discounts`, `bundle-discounts`, `announcement-bar`, `inactive-tab-message`). Each
+  bundles its editor component, a `*Form`, and (for the discount apps) a reducer/actions pair for
+  local state. The discount apps also share `components/BundelDiscountList.jsx`.
+- `components/` — shared UI: providers, `Analytics/`, `Settings/AdvancedAnalyticsSettings.jsx`,
+  `Editor/`, `Modals/`, `Plans/`, `Header.jsx`, `OverviewTab.jsx`, buttons/toggles.
+- `hooks/` — `useEditorNavigation`, `useSimpleToast` (re-exported from `hooks/index.js`).
+
+State is local component state plus reducer/actions inside each app; server state is fetched with
+`react-query` and plain `fetch`/`authenticatedFetch` calls to `/api/*`.
+
+## App Bridge & Shopify session auth
+
+`index.html` loads Shopify App Bridge from the CDN
+(`https://cdn.shopify.com/shopifycloud/app-bridge.js`) and injects the API key via the
+`shopify-api-key` meta tag (`%VITE_SHOPIFY_API_KEY%`, substituted at build). App Bridge provides the
+session token that authenticates admin `/api/*` calls against the backend's
+`validateAuthenticatedSession()` gate.
+
+The **standalone editors** open in their own tab and are not inside the App Bridge session, so they
+authenticate with a signed `shop`+`signature` pair minted by `GET /api/editor/signature`
+(`generateSignature`) — the backend's app-proxy branch verifies it (see
+[Backend Architecture](./backend-architecture.md)).
+
+## Config & environment
+
+Vite config (`web/frontend/vite.config.js`) reads `SHOPIFY_API_KEY` into `VITE_SHOPIFY_API_KEY`,
+and proxies `/` and `/api` to the backend at `http://127.0.0.1:${BACKEND_PORT}` during dev. `HOST`,
+`FRONTEND_PORT`, `BACKEND_PORT`, and `SERVER_IP_ADDRESS` drive the dev server host/port and HMR.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,54 @@
+# Services
+
+The service layer lives in `web/backend/services`. Controllers call these modules so that the
+Shopify GraphQL calls, third-party ESP calls, and cross-model bookkeeping stay out of the route
+handlers.
+
+## shopService.js
+`getOrCreateShop(session)` — reads the `shop` document for a session, and lazily creates it if the
+install-time `shopData` middleware never ran or failed partway. This self-heals the case where an
+otherwise fully-installed shop would be treated as nonexistent by bare `Shop.findOne` calls.
+
+## subscription.js
+`subscriptionUpdate(session)` — resyncs a shop's subscription from Shopify's billing API
+(`getAppSubscription` in `web/billing.js`) into the `Subscription` model. Normalises Shopify's
+uppercase status enum (`ACTIVE`) to the lowercase `active` the rest of the codebase compares
+against. Invoked from the billing-confirmation redirect in `web/index.js`.
+
+## referral.js
+The referral-program engine backing the `/api/referrals` controllers. Exports include
+`createReferral`, `generateReferralUrl`, `getShopifyAppStoreUrl`, `getReferralByCode`,
+`getAllReferrals`, `trackReferralEvent`, `getReferralAnalytics`, `getReferralQuery`,
+`updateReferral`, `deactivateReferral`, `calculateMRR`, `calculateCommission`, `detectFraud`, and
+`getDashboardMetrics`. It reads/writes the `referral`, `referralevent`, `shop`, and `subscription`
+models and uses `configs/subscriptionConfig.js` for plan pricing.
+
+## activityLogService.js
+`activityLogService` (default export) — logs and retrieves dashboard activity events
+(`ActivityLog` model), reading bundle/announcement models to enrich entries. Feeds the
+`/api/activity` history card.
+
+## emailService.js
+The **shared email caller** — an adapter-per-provider abstraction. Exports `EmailService`,
+`EmailServiceError`, and the `EmailProviderAdapter` base class. Concrete adapters implement the same
+interface (`validateConnection`, `getLists`, `getTemplates`, `subscribeToList`,
+`sendTemplateEmail`) for Mailchimp, Klaviyo, SendGrid, and MailerLite, so callers never special-case
+the ESP. Used by the email-provider feature, the frontStore subscribe endpoint, and
+`merchantEmailService.js`.
+
+## merchantEmailService.js
+`emailService` singleton plus `EMAIL_TEMPLATES` and `MAILCHIMP_SEGMENTS`. Sends the
+merchant-lifecycle emails (welcome on install, uninstall survey, etc.) and records them in the
+`EmailLog` model.
+
+## merchantEventService.js
+`merchantEventService` singleton. Processes merchant lifecycle events (`MerchantEvent` /
+`MerchantReview` models) per an `EVENT_CONFIG` table that decides, per event type, whether to send
+an email, update ESP segments, and log to the DB. Bridges the webhook controllers to
+`merchantEmailService`.
+
+## mutations.js
+A library of Shopify Admin GraphQL query/mutation builders (products, bundles, orders,
+collections, publications) used by the bundle/product controllers — e.g. `GET_PRODUCTS`,
+`getCreateBundlesMutation`, `getBundlePriceUpdateMutation`, `CREATE_COLLECTIONV2`. Not a stateful
+service; a shared source of GraphQL strings.

--- a/docs/src/content/features/bundle-discounts.md
+++ b/docs/src/content/features/bundle-discounts.md
@@ -1,0 +1,48 @@
+---
+title: "Bundle Discounts"
+order: 6
+summary: "A Shopify discount app that lets merchants group products into a discounted bundle from the BusyBuddy dashboard."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+    - shopify-app-proxy
+runWith:
+  - "Open the BusyBuddy dashboard and choose the Bundle Discounts app."
+  - "Select the products in the bundle and the bundle price/discount in the editor, then save to publish."
+  - "Enable the app for the shop from the dashboard's app toggle before the storefront applies it."
+tradeoffs:
+  - "Bundle Discounts is one member of BusyBuddy's discount-app family (bogo, volume-discounts, mix-and-match); they persist through the shared /api/bundles route family and the single bundle model, distinguished by the document's `type` field."
+  - "Discount behavior is bounded by what Shopify's discount and cart-transform layer exposes."
+notes:
+  - kind: note
+    body: "Bundle Discounts sits inside BusyBuddy's plan-gated app-toggle system (subscription appLimits.bundle_discount): the offer only affects the storefront while the app is enabled for the shop."
+---
+
+## What it does
+
+Bundle Discounts is a Shopify discount app in the BusyBuddy suite. It lets a merchant group
+a fixed set of products into a bundle sold at a discounted price, and publish it to the
+storefront without touching theme code.
+
+## How it works
+
+The dashboard page is `web/frontend/pages/bundle-discount.jsx`, which renders the app under
+`web/frontend/apps/bundle-discounts/` (`StandardBundleEditor.jsx`, `BundleForm.jsx`, plus its
+reducers and actions). The standalone editor is mounted at `/bundle-discount/editor` (and
+`/bundle-discount/editor/:id`) in `web/frontend/Routes.jsx`.
+
+Bundles are saved through `web/backend/routes/bundles/`: `POST /api/bundles`
+(`createProductBundleV2`) creates a bundle, `GET /api/bundles` lists them, `GET /api/bundles/:id`
+reads one, and `PUT` / `DELETE /api/bundles/:id` update and remove it. The storefront reads the
+active bundle via the app-proxy route `GET /api/frontStore/getActiveBundle`.
+
+## Configuration & running
+
+Configure Bundle Discounts from the dashboard: pick the app, select the products and the bundle
+price, and save. Because it is part of the plan-gated app family, the bundle is only live while
+the app is toggled on for the shop.

--- a/docs/src/content/features/email-provider.md
+++ b/docs/src/content/features/email-provider.md
@@ -1,0 +1,55 @@
+---
+title: "Email Provider"
+order: 10
+summary: "The shared email-provider integration: connects a merchant's ESP (Mailchimp, Klaviyo, SendGrid, or MailerLite) and exposes one caller that other features use to subscribe storefront visitors and send templated email."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+runWith:
+  - "Connect an ESP with an API key via POST /api/email-provider/connect; read the current settings via GET /api/email-provider."
+  - "Pull the account's lists and templates with POST /api/email-provider/sync, then read them via GET /api/email-provider/lists and /templates."
+  - "Storefront email capture (e.g. announcement-bar email + inactive-tab) flows through the shared EmailService adapter to the connected provider."
+tradeoffs:
+  - "One provider is connected per shop at a time (the emailProvider model's `provider` enum is mailchimp/klaviyo/sendgrid/mailerlite/none); switching providers replaces the connection."
+  - "EmailService is the single adapter layer for all outbound email; each provider implements the same adapter interface, so callers do not special-case the ESP."
+notes:
+  - kind: note
+    body: "web/backend/services/emailService.js is the shared caller — an adapter-per-provider abstraction. merchantEmailService.js (lifecycle emails to merchants) and the frontStore subscribe endpoint both go through this layer."
+---
+
+## What it does
+
+Email Provider is BusyBuddy's shared email integration. A merchant connects one email service
+provider (ESP) — Mailchimp, Klaviyo, SendGrid, or MailerLite — and the rest of the app uses a
+single caller to subscribe storefront visitors to a list and to send templated email, without
+each feature knowing which ESP is configured.
+
+## How it works
+
+The frontend surface lives with the widgets that capture email (for example
+`web/frontend/apps/announcement-bar/components/EmailIntegration.jsx` and `EmailBarSettings.jsx`).
+The backend routes live under `web/backend/routes/emailProvider/` and are mounted at
+`/api/email-provider`:
+
+- `POST /connect`, `GET /`, `DELETE /` — connect, read, and disconnect the provider
+- `POST /sync` — pull lists and templates from the ESP
+- `GET /lists`, `GET /templates` — read the synced lists and templates
+- `PUT /default-list` — set the default subscribe list
+
+Connection state persists to the `EmailProvider` Mongoose model (provider enum, API key, lists,
+templates, default list). The shared caller is `web/backend/services/emailService.js`, an
+adapter-per-provider layer (`EmailProviderAdapter` base plus one adapter per ESP). Sends and
+subscribes — including the app-proxy `POST /api/frontStore/subscribe` endpoint and the
+merchant-lifecycle emails in `merchantEmailService.js` — route through this layer, and outbound
+sends are recorded in the `EmailLog` model.
+
+## Configuration & running
+
+A merchant connects their ESP with an API key, syncs lists and templates, and picks a default
+list. From then on, any BusyBuddy feature that captures or sends email calls the shared
+`EmailService`, which dispatches to whichever provider the shop connected.

--- a/docs/src/content/features/google-analytics.md
+++ b/docs/src/content/features/google-analytics.md
@@ -1,0 +1,52 @@
+---
+title: "Google Analytics"
+order: 9
+summary: "An OAuth integration that connects a merchant's Google Analytics (GA4) account so BusyBuddy can pull and surface analytics data in the dashboard."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+runWith:
+  - "Start the connection from the Advanced Analytics settings in the dashboard; the app calls POST /api/analytics/google/connect to begin OAuth."
+  - "Google redirects to GET /api/analytics/google/callback, which is registered before Shopify auth so Google can reach it without a shop session."
+  - "The dashboard reads connection state via GET /api/analytics/google/status and data via GET /api/analytics/google/data."
+tradeoffs:
+  - "The OAuth callback is wired directly in web/index.js (with a dynamic import of the controller) so googleapis is not loaded at server startup and Google's session-less redirect can be handled."
+  - "Tokens (access, refresh, expiry) are stored per shop in the GoogleAnalytics Mongoose model and refreshed as needed."
+notes:
+  - kind: note
+    body: "Google Analytics is a third-party integration reached through the googleapis SDK; it is not on the storefront request path — it only feeds the merchant-facing dashboard."
+---
+
+## What it does
+
+Google Analytics lets a merchant connect their GA4 account to BusyBuddy over OAuth, so the
+dashboard can display Google Analytics metrics alongside BusyBuddy's own analytics.
+
+## How it works
+
+The frontend surface is the analytics settings in the dashboard
+(`web/frontend/components/Analytics/` and `components/Settings/AdvancedAnalyticsSettings.jsx`).
+The backend routes live under `web/backend/routes/googleAnalytics/` and are mounted at
+`/api/analytics/google`:
+
+- `GET /status` — connection status
+- `POST /connect` — begin the OAuth flow
+- `GET /callback` — OAuth redirect handler
+- `POST /disconnect` — disconnect the account
+- `GET /data` — fetch analytics data
+
+The OAuth callback is additionally registered directly in `web/index.js` (ahead of the Shopify
+auth middleware, via a dynamic import of the controller) because Google redirects there without
+Shopify credentials. Credentials are persisted per shop in the `GoogleAnalytics` model
+(`googleEmail`, `accessToken`, `refreshToken`, `tokenExpiresAt`, `propertyId`).
+
+## Configuration & running
+
+A merchant starts the connection from the Advanced Analytics settings, completes Google's OAuth
+consent, and is redirected back to the callback. The dashboard then reads `status` and `data`
+to render the merchant's Google Analytics figures.

--- a/docs/src/content/features/inactive-tab.md
+++ b/docs/src/content/features/inactive-tab.md
@@ -1,0 +1,52 @@
+---
+title: "Inactive Tab Message"
+order: 7
+summary: "A storefront widget that changes the browser tab's title (and favicon) with a custom message when a visitor switches away, to win the visitor back."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+    - shopify-app-proxy
+runWith:
+  - "Configure the message, favicon emoji, and optional schedule from the Inactive Tab page in the BusyBuddy dashboard."
+  - "Settings are saved via POST /api/inactive-tab/settings and read back via GET /api/inactive-tab/settings."
+  - "The storefront fetches the active message via the app-proxy route GET /api/frontStore/getInactiveTab."
+tradeoffs:
+  - "The message is schedule-aware: getInactiveTab returns nothing outside the configured startDate/endDate window, so an expired or not-yet-started message never displays."
+  - "Like the rest of the suite, the widget only renders while BusyBuddy is enabled for the shop (see Subscription Management)."
+notes:
+  - kind: tip
+    body: "Image uploads for the message go through POST /api/inactive-tab/upload-image, which stores the file on Shopify via the Admin API and returns a hosted URL."
+---
+
+## What it does
+
+Inactive Tab Message is a storefront widget that swaps the browser tab's title — and
+optionally its favicon — for a custom message when a visitor tabs away from the store, nudging
+them to come back.
+
+## How it works
+
+The dashboard page is `web/frontend/pages/inactive-tab-message.jsx`, which renders the app under
+`web/frontend/apps/inactive-tab-message/` (`InactiveTabMessageForm`). Settings persist to the
+`InactiveTab` Mongoose model (message, favicon emoji, start/end date, timezone, isEnabled).
+
+The backend routes live under `web/backend/routes/inactivetabs/` and are mounted at
+`/api/inactive-tab`:
+
+- `POST /settings` and `GET /settings` — save and read the message settings
+- `POST /upload-image` — upload an image to Shopify (multer memory storage, 5MB, images only)
+
+The storefront reads the currently-active message through the app-proxy route
+`GET /api/frontStore/getInactiveTab`, which enforces the schedule window and the shop's
+subscription access.
+
+## Configuration & running
+
+Merchants set the message, favicon emoji, and optional schedule from the dashboard. The
+storefront fetches the active message from `getInactiveTab`; it displays only within the
+configured date window and only while BusyBuddy is enabled for the shop.

--- a/docs/src/content/features/mix-and-match.md
+++ b/docs/src/content/features/mix-and-match.md
@@ -1,0 +1,49 @@
+---
+title: "Mix and Match"
+order: 5
+summary: "A Shopify discount app that lets merchants build mix-and-match bundles — pick any N products from a set for a bundled price — from the BusyBuddy dashboard."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+    - shopify-app-proxy
+runWith:
+  - "Open the BusyBuddy dashboard and choose the Mix and Match app."
+  - "Choose the eligible products and the bundle pricing in the editor, then save to publish."
+  - "Enable the app for the shop from the dashboard's app toggle before the storefront applies it."
+tradeoffs:
+  - "Mix and Match is one member of BusyBuddy's discount-app family; unlike the others it has its own create/update endpoints (POST /api/bundles/mix-and-match and /api/bundles/mix-and-match/:id) rather than the generic bundle create route."
+  - "Discount behavior is bounded by what Shopify's discount and cart-transform layer exposes."
+notes:
+  - kind: note
+    body: "Mix and Match sits inside BusyBuddy's plan-gated app-toggle system (subscription appLimits.mix_match): the offer only affects the storefront while the app is enabled for the shop."
+---
+
+## What it does
+
+Mix and Match is a Shopify discount app in the BusyBuddy suite. It lets a merchant define
+a "pick any N from this set" bundle — customers assemble their own bundle from eligible
+products and receive the bundle price — and publish it to the storefront.
+
+## How it works
+
+The dashboard page is `web/frontend/pages/mix-and-match.jsx`, which renders the app under
+`web/frontend/apps/mix-and-match-discounts/` (`MixAndMatchEditor.jsx`, `MixMatchForm.jsx`,
+plus its reducers and actions). The standalone editor is mounted at `/mix-and-match/editor`
+(and `/mix-and-match/editor/:id`) in `web/frontend/Routes.jsx`.
+
+Mix-and-match offers use dedicated backend routes in `web/backend/routes/bundles/`:
+`POST /api/bundles/mix-and-match` (create) and `POST /api/bundles/mix-and-match/:id`
+(update), handled by `createMixAndMatchBundle` / `updateMixAndMatchBundle`. They are read
+back through the shared bundle list routes, and the storefront reads the active offer via
+the app-proxy route `GET /api/frontStore/getActiveBundle`.
+
+## Configuration & running
+
+Configure Mix and Match from the dashboard: pick the app, choose the eligible products and
+the bundle pricing, and save. Because it is part of the plan-gated app family, the offer is
+only live while the app is toggled on for the shop.

--- a/docs/src/content/features/referrals.md
+++ b/docs/src/content/features/referrals.md
@@ -1,0 +1,52 @@
+---
+title: "Referrals"
+order: 8
+summary: "A partner-referral program: admins mint referral codes, partners share tracked links to the Shopify App Store, and clicks/installs/paid conversions drive analytics, MRR, and commission reporting."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+runWith:
+  - "Admins create and manage referral partners via POST/PUT/DELETE /api/referrals/:code (x-api-key: REFERRAL_ADMIN_API_KEY)."
+  - "Partners share /api/referrals/:code/redirect, which records a click and redirects to the Shopify App Store."
+  - "Partners read their own analytics/MRR/commission via /api/referrals/:code/* using the x-referral-token header (partner_token)."
+tradeoffs:
+  - "Unlike the storefront widgets, the referral routes are registered in web/index.js BEFORE the Shopify auth middleware, so they are reachable without a shop session."
+  - "The referral code is public (it lives in shareable links) so it cannot be a credential: financial/analytics endpoints require the partner's separate partner_token secret; non-financial lookups stay open."
+notes:
+  - kind: important
+    body: "Two auth tiers guard this route family: adminAuth (x-api-key) for partner management, and partnerAuth (x-referral-token) for a partner's own financial data. Track and redirect are fully public."
+---
+
+## What it does
+
+Referrals is BusyBuddy's partner-referral program. Admins create referral partners, each with
+a shareable code; partners share a tracked link that redirects to the app's Shopify App Store
+listing; and the system records click / install / paid events to power analytics, MRR,
+commission, and fraud-detection reporting.
+
+## How it works
+
+There is no dashboard page — this is an API feature. The routes live in
+`web/backend/routes/referrals/index.js`, backed by `web/backend/controller/referrals/` and the
+`web/backend/services/referral.js` service, and persist to the `referral` and `referralevent`
+Mongoose models.
+
+- Admin (adminAuth, `x-api-key`): `POST /` create, `GET /` list, `PUT /:code`, `DELETE /:code`,
+  `GET /:code/fraud`, `GET /:code/query`
+- Partner (partnerAuth, `x-referral-token`): `GET /:code/analytics`, `/:code/mrr`,
+  `/:code/commission`, `/:code/dashboard`
+- Public: `GET /:code`, `GET /:code/url`, `POST /:code/track`, `GET /:code/redirect`
+
+Routes are mounted at `/api/referrals` and are registered in `web/index.js` ahead of Shopify
+session auth so partners and visitors can reach them without a shop session.
+
+## Configuration & running
+
+Admins mint and manage partners with the admin API key. Partners share
+`/api/referrals/:code/redirect` (records the click, then redirects to the App Store) and read
+their own performance data with their `partner_token` via the `x-referral-token` header.

--- a/docs/src/content/features/volume-discounts.md
+++ b/docs/src/content/features/volume-discounts.md
@@ -1,0 +1,48 @@
+---
+title: "Volume Discounts"
+order: 4
+summary: "A Shopify discount app that lets merchants configure quantity-break pricing (buy more, save more) from the BusyBuddy dashboard."
+status: stable
+implements:
+  workflows:
+    - ci
+  skills: []
+  dependencies: []
+  integrations:
+    - shopify-admin-api
+    - shopify-app-proxy
+runWith:
+  - "Open the BusyBuddy dashboard and choose the Volume Discounts app."
+  - "Add quantity tiers and their discounts in the editor, then save to publish the offer."
+  - "Enable the app for the shop from the dashboard's app toggle before the storefront applies it."
+tradeoffs:
+  - "Volume Discounts is one member of BusyBuddy's discount-app family (bundles, bundle-discount, bogo, mix-and-match); they persist through the shared /api/bundles route family and the bundle model's quantityBreaks/tierDiscounts fields rather than a bespoke store."
+  - "Discount behavior is bounded by what Shopify's discount and cart-transform layer exposes."
+notes:
+  - kind: note
+    body: "Volume Discounts sits inside BusyBuddy's plan-gated app-toggle system: the offer only affects the storefront while the app is enabled for the shop (see Subscription Management)."
+---
+
+## What it does
+
+Volume Discounts is a Shopify discount app in the BusyBuddy suite. It lets a merchant
+set up quantity-break pricing — for example, buy 3 and save 10%, buy 5 and save 20% —
+and publish it to the storefront without touching theme code.
+
+## How it works
+
+The dashboard page is `web/frontend/pages/volume-discounts.jsx`, which renders the app
+under `web/frontend/apps/volume-discounts/` (`VolumeDiscountEditor.jsx`, `VolumeForm.jsx`,
+plus its reducers and actions). The standalone editor is mounted at
+`/volume-discounts/editor` (and `/volume-discounts/editor/:id`) in `web/frontend/Routes.jsx`.
+
+Offers are saved through the shared bundle backend under `web/backend/routes/bundles/`:
+`POST /api/bundles` creates an offer, `PUT /api/bundles/:id` updates it, and the tiers
+are stored in the bundle model's `quantityBreaks` / `tierDiscounts` fields. The storefront
+reads the active offer via the app-proxy route `GET /api/frontStore/getActiveBundle`.
+
+## Configuration & running
+
+Configure Volume Discounts from the dashboard: pick the app, define the quantity tiers and
+their discounts in the editor, and save. Because it is part of the plan-gated app family,
+the offer is only live while the app is toggled on for the shop.

--- a/docs/webhooks-and-jobs.md
+++ b/docs/webhooks-and-jobs.md
@@ -1,0 +1,55 @@
+# Webhooks & Jobs
+
+## Webhook routing
+
+Webhook handling is deliberately separated from the authenticated `/api` surface. Two things run
+in `web/index.js` ahead of the global `express.json()` and the Shopify auth gate:
+
+1. **Shopify's own privacy/compliance webhooks** — `shopify.processWebhooks({ webhookHandlers: PrivacyWebhookHandlers })`
+   mounted at `shopify.config.webhooks.path` (see `web/privacy.js`).
+2. **BusyBuddy's webhook router** — mounted at `/api/webhooks` with a scoped `express.json()` that
+   captures `req.rawBody` for HMAC verification (`verifyShopifyWebhook` middleware), then the
+   router in `web/backend/routes/webhooks/index.js`.
+
+These must stay before the global body parser: HMAC verification and `processWebhooks` both need the
+untouched raw request stream, which a global `express.json()` would drain first.
+
+## Webhook endpoints
+
+`web/backend/routes/webhooks/index.js` (controller: `web/backend/controller/webhooks/`):
+
+**Shopify / storefront events**
+- `POST /app-installed` → `handleAppInstall`
+- `POST /app-uninstalled` → `handleAppUninstall`
+- `POST /orders-paid` → `handleOrderPaid`
+
+**Internal subscription events**
+- `POST /subscription-upgraded` → `handleSubscriptionUpgrade`
+- `POST /subscription-downgraded` → `handleSubscriptionDowngrade`
+
+**Merchant review**
+- `POST /review-submitted` → `handleMerchantReview`
+
+**Admin / read endpoints**
+- `GET /events` → `getMerchantEvents`
+- `GET /emails` → `getEmailLogs`
+- `POST /emails/:emailLogId/retry` → `retryFailedEmail`
+- `GET /merchants-analytics` → `getMerchantsAnalytics`
+- `GET /reviews` → `getMerchantReviews`
+
+## Event processing (the "jobs" layer)
+
+There is no cron/scheduler in the backend. Instead, work is driven synchronously off webhooks
+through the service layer:
+
+- Lifecycle webhooks (install, uninstall, plan change, review) create `MerchantEvent` records and
+  are processed by `services/merchantEventService.js`, whose `EVENT_CONFIG` table decides per event
+  type whether to **send an email** (via `merchantEmailService.js` → the shared `EmailService`),
+  **update ESP segments**, and **log to the DB**.
+- Outbound emails are written to the `EmailLog` model; failed sends can be re-driven via
+  `POST /api/webhooks/emails/:emailLogId/retry`.
+- The billing-confirmation redirect in `web/index.js` calls `services/subscription.js`'s
+  `subscriptionUpdate` to resync a shop's plan after checkout.
+
+> Note (inferred): "jobs" here means webhook-triggered background work in the service layer — no
+> standalone job scheduler or queue was found in `web/backend`.

--- a/wiki.config.yaml
+++ b/wiki.config.yaml
@@ -72,12 +72,31 @@ extractors:
     sources:
       - glob: "CHANGELOG.md"
         navSection: "Changelog"
+      # Narrative architecture docs authored against this repo's real tree
+      # (web/backend and web/frontend). Grounded in the actual code, not
+      # derived - read verbatim by the markdown extractor.
+      - glob: "docs/backend-architecture.md"
+        navSection: "Backend"
+      - glob: "docs/data-models.md"
+        navSection: "Backend"
+      - glob: "docs/services.md"
+        navSection: "Backend"
+      - glob: "docs/webhooks-and-jobs.md"
+        navSection: "Backend"
+      - glob: "docs/frontend-architecture.md"
+        navSection: "Frontend"
 
   appList:
     enabled: true
     sourceFile: "web/frontend/pages/DashboardHome.jsx"
     widgetConfigExport: "widgetConfig"
-    planFeaturesExport: "planFeatures"
+    # planFeaturesExport dropped: DashboardHome.jsx exports only widgetConfig -
+    # there is no `planFeatures` export in this file (the only `planFeatures`
+    # in the repo is a local const inside web/backend/configs/subscriptionUtils.js,
+    # not this source file). Pointing the extractor at a missing export made plan
+    # tags silently empty; removing it is the lower-risk fix (vs. adding a
+    # frontend export the app doesn't otherwise use). Per-app entitlement lives in
+    # the Subscription model's appLimits (see docs/data-models.md).
 
   # Repo-local skills (SKILL.md with name/description/applies_to frontmatter).
   # These are the same files the dev-ticket pipeline reads from skills/ in this
@@ -87,6 +106,17 @@ extractors:
     enabled: true
     roots:
       - "skills"
+
+  # Package manifests present in this repo's tree. Enabled so the
+  # Dependencies & Integrations page also lists real npm dependencies
+  # (previously only the authored integrations below were shown).
+  dependencies:
+    enabled: true
+    manifests:
+      - "package.json"
+      - "web/package.json"
+      - "docs/package.json"
+      - "extensions/bogo-shopify-app/package.json"
 
   # Third parties that live in no package.json - authored here (approach A)
   # and rendered on the Dependencies & Integrations page. Every field is a


### PR DESCRIPTION
## Problem

Part of #49 · Part of #51 (Epic 10)

The wiki generator produced BusyBuddy *facts* (endpoints, workflows, tests) but almost no *narrative* — architecture, data models, services, frontend structure — and most storefront apps had no feature page.

## Solution

Grounded in the actual code:
- **7 feature pages** `docs/src/content/features/`: `volume-discounts`, `mix-and-match`, `bundle-discounts`, `inactive-tab`, `referrals`, `google-analytics`, `email-provider` (announcement + BOGO already existed).
- **5 narrative docs** wired into `wiki.config.yaml` `markdown.sources`: `docs/backend-architecture.md`, `docs/data-models.md` (Mongoose models), `docs/services.md`, `docs/webhooks-and-jobs.md` (→ Backend nav), `docs/frontend-architecture.md` (→ Frontend nav).
- **Config fixes:** enabled the `dependencies` extractor (4 manifests); dropped `planFeaturesExport` (it pointed at a non-existent export and was silently emptying plan tags — per-app entitlement actually lives in the Subscription model's `appLimits`).

## Acceptance Criteria

- [x] FE + BE narrative markdown added and ingested by the generator (#49)
- [x] Missing feature/app docs added (#51)

## Approach

Notable accuracy calls: all discount apps share the single bundle model + `/api/bundles` (distinguished by type); "jobs" = webhook-triggered service-layer processing (no standalone cron), noted as inferred. YAML validated.

## Notes / merge order

Touches `wiki.config.yaml`, which #325 (OpenHands removal) also edits — different sections (this adds `markdown.sources`/`dependencies`; #325 removes the `openhands-cloud` block). Merge #325 first; resolve any adjacent-hunk conflict by keeping both.

## Test Results

| Suite | Status | Count |
|-------|--------|-------|
| Backend / Frontend / Extension / Build | N/A | docs + wiki config only |

## Checklist

- [x] No hardcoded secrets, shop URLs, or `localhost`
- [x] `shopify app deploy` was NOT run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjPTqW1qxMFghxoyThd4Ac)_